### PR TITLE
Add multilingual README (Korean, Japanese, English)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,3 +16,4 @@
 6. Whenever code is written or modified, unit tests must also be written or modified
 7. Use GitHub Actions CI — tests must pass before merging
 8. Items requiring manual visual verification by the user must be listed as checkboxes in the PR (exclude automated test items)
+9. After a PR is merged, delete the feature branch immediately

--- a/README.ja.md
+++ b/README.ja.md
@@ -88,11 +88,3 @@ NEXT_PUBLIC_SUPABASE_URL=your_supabase_url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
 ```
 
----
-
-## 開発ルール
-
-- すべての作業は `feature/*` ブランチ → PR → main マージ
-- main ブランチへの直接 push 禁止
-- コード作成・修正時は必ずユニットテストも作成
-- GitHub Actions CI 通過後にマージ

--- a/README.ko.md
+++ b/README.ko.md
@@ -88,11 +88,3 @@ NEXT_PUBLIC_SUPABASE_URL=your_supabase_url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
 ```
 
----
-
-## 개발 규칙
-
-- 모든 작업은 `feature/*` 브랜치 → PR → main 머지
-- main 브랜치 다이렉트 push 금지
-- 코드 작성/수정 시 반드시 유닛 테스트 함께 작성
-- GitHub Actions CI 통과 후 머지

--- a/README.md
+++ b/README.md
@@ -88,11 +88,3 @@ NEXT_PUBLIC_SUPABASE_URL=your_supabase_url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
 ```
 
----
-
-## Development Rules
-
-- All work is done on `feature/*` branches → PR → merge to main
-- Direct push to `main` is prohibited
-- All code changes must be accompanied by unit tests
-- GitHub Actions CI must pass before merging


### PR DESCRIPTION
## Summary
- README.md (English) — replaces default Next.js README
- README.ko.md (Korean)
- README.ja.md (Japanese)
- Language switcher links at the top of each file

## Manual Checks
- [ ] README.md — language switcher links work correctly on GitHub
- [ ] README.ko.md — language switcher links work correctly on GitHub
- [ ] README.ja.md — language switcher links work correctly on GitHub
- [ ] Korean content displays correctly (no broken characters)
- [ ] Japanese content displays correctly (no broken characters)

🤖 Generated with [Claude Code](https://claude.com/claude-code)