### PR TITLE
feat: Google OAuth login and family invite code system

### DIFF
--- a/src/app/api/family/join/route.ts
+++ b/src/app/api/family/join/route.ts
@@ -1,0 +1,56 @@
+import { createClient } from '@supabase/supabase-js'
+import { NextRequest, NextResponse } from 'next/server'
+import type { Database } from '@/types/database'
+
+const supabaseAdmin = createClient<Database>(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+)
+
+export async function POST(req: NextRequest) {
+  const { userId, inviteCode } = await req.json()
+
+  if (!userId || !inviteCode) {
+    return NextResponse.json({ error: 'userId and inviteCode are required' }, { status: 400 })
+  }
+
+  // 초대 코드로 family 조회
+  const { data: family } = await supabaseAdmin
+    .from('families')
+    .select('id')
+    .ilike('invite_code', inviteCode)
+    .maybeSingle()
+
+  if (!family) {
+    return NextResponse.json({ error: 'Invalid invite code' }, { status: 404 })
+  }
+
+  // 이미 이 family 구성원인지 확인
+  const { data: existing } = await supabaseAdmin
+    .from('family_members')
+    .select('family_id')
+    .eq('user_id', userId)
+    .maybeSingle()
+
+  if (existing?.family_id === family.id) {
+    return NextResponse.json({ familyId: family.id })
+  }
+
+  // 기존 family에서 나가고 새 family에 합류
+  if (existing) {
+    await supabaseAdmin.from('family_members').delete().eq('user_id', userId)
+  }
+
+  const { error } = await supabaseAdmin.from('family_members').insert({
+    family_id: family.id,
+    user_id: userId,
+    display_name: 'Member',
+    role: 'member',
+  })
+
+  if (error) {
+    return NextResponse.json({ error: 'Failed to join family' }, { status: 500 })
+  }
+
+  return NextResponse.json({ familyId: family.id })
+}

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { supabase } from '@/lib/supabase'
+
+export default function AuthCallbackPage() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  useEffect(() => {
+    const code = searchParams.get('code')
+    if (!code) {
+      router.replace('/login')
+      return
+    }
+
+    supabase.auth.exchangeCodeForSession(code).then(({ error }) => {
+      if (error) {
+        console.error('[auth/callback] error:', error)
+        router.replace('/login')
+      } else {
+        const next = searchParams.get('next') ?? '/shopping'
+        router.replace(next)
+      }
+    })
+  }, [])
+
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <div className="w-8 h-8 rounded-full border-2 border-orange-300 border-t-orange-500 animate-spin" />
+    </div>
+  )
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { supabase } from '@/lib/supabase'
+import { useAuth } from '@/hooks/useAuth'
+
+export default function LoginPage() {
+  const { user, loading } = useAuth()
+  const router = useRouter()
+
+  useEffect(() => {
+    if (!loading && user) {
+      router.replace('/shopping')
+    }
+  }, [user, loading, router])
+
+  const handleGoogleLogin = async () => {
+    await supabase.auth.signInWithOAuth({
+      provider: 'google',
+      options: {
+        redirectTo: `${window.location.origin}/auth/callback`,
+      },
+    })
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="w-8 h-8 rounded-full border-2 border-orange-300 border-t-orange-500 animate-spin" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen px-6 bg-white dark:bg-stone-950">
+      <div className="w-full max-w-sm flex flex-col items-center gap-8">
+        <div className="text-center">
+          <div className="text-6xl mb-4">🏠</div>
+          <h1 className="text-3xl font-bold text-stone-800 dark:text-stone-100">Koko</h1>
+          <p className="text-stone-400 dark:text-stone-500 mt-2 text-sm">가족과 함께하는 패밀리 허브</p>
+        </div>
+
+        <button
+          onClick={handleGoogleLogin}
+          className="w-full flex items-center justify-center gap-3 px-6 py-3.5 rounded-2xl border border-stone-200 dark:border-stone-700 bg-white dark:bg-stone-900 text-stone-700 dark:text-stone-200 font-semibold text-sm hover:bg-stone-50 dark:hover:bg-stone-800 transition-colors shadow-sm"
+        >
+          <svg width="20" height="20" viewBox="0 0 24 24">
+            <path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
+            <path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
+            <path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
+            <path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
+          </svg>
+          Google로 로그인
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,140 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { LogOut, Copy, Check, Users } from 'lucide-react'
+import { useAuth } from '@/hooks/useAuth'
+import { useFamily } from '@/hooks/useFamily'
+import { supabase } from '@/lib/supabase'
+
+export default function SettingsPage() {
+  const { user, loading: authLoading } = useAuth()
+  const { familyId, loading: familyLoading } = useFamily(user)
+  const router = useRouter()
+  const [inviteCode, setInviteCode] = useState<string | null>(null)
+  const [copied, setCopied] = useState(false)
+  const [joinCode, setJoinCode] = useState('')
+  const [joining, setJoining] = useState(false)
+  const [joinError, setJoinError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!authLoading && !user) {
+      router.replace('/login')
+    }
+  }, [user, authLoading, router])
+
+  useEffect(() => {
+    if (!familyId) return
+    supabase
+      .from('families')
+      .select('invite_code')
+      .eq('id', familyId)
+      .single()
+      .then(({ data }) => setInviteCode(data?.invite_code ?? null))
+  }, [familyId])
+
+  const handleCopy = () => {
+    if (!inviteCode) return
+    navigator.clipboard.writeText(inviteCode)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  const handleJoin = async () => {
+    if (!joinCode.trim() || !user) return
+    setJoining(true)
+    setJoinError(null)
+
+    const res = await fetch('/api/family/join', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: user.id, inviteCode: joinCode.trim() }),
+    })
+
+    if (!res.ok) {
+      const { error } = await res.json()
+      setJoinError(error === 'Invalid invite code' ? '올바르지 않은 초대 코드예요' : '오류가 발생했어요')
+    } else {
+      router.replace('/shopping')
+    }
+    setJoining(false)
+  }
+
+  const handleLogout = async () => {
+    await supabase.auth.signOut()
+    router.replace('/login')
+  }
+
+  if (authLoading || familyLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="w-8 h-8 rounded-full border-2 border-orange-300 border-t-orange-500 animate-spin" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="max-w-lg mx-auto px-4 py-8 min-h-screen">
+      <h1 className="text-2xl font-bold text-stone-800 dark:text-stone-100 mb-6">설정</h1>
+
+      {/* 계정 정보 */}
+      <div className="rounded-2xl bg-white dark:bg-stone-900 border border-stone-100 dark:border-stone-800 p-4 mb-4">
+        <p className="text-xs font-semibold text-stone-400 dark:text-stone-500 uppercase tracking-wide mb-2">계정</p>
+        <p className="text-sm text-stone-700 dark:text-stone-300">{user?.email}</p>
+      </div>
+
+      {/* 초대 코드 */}
+      <div className="rounded-2xl bg-white dark:bg-stone-900 border border-stone-100 dark:border-stone-800 p-4 mb-4">
+        <p className="text-xs font-semibold text-stone-400 dark:text-stone-500 uppercase tracking-wide mb-3">우리 가족 초대 코드</p>
+        <div className="flex items-center gap-3">
+          <span className="flex-1 text-2xl font-bold tracking-widest text-stone-800 dark:text-stone-100 font-mono">
+            {inviteCode ?? '------'}
+          </span>
+          <button
+            onClick={handleCopy}
+            className="flex items-center gap-1.5 px-3 py-2 rounded-xl bg-orange-50 dark:bg-orange-950/40 text-orange-500 text-sm font-semibold transition-colors hover:bg-orange-100"
+          >
+            {copied ? <Check size={14} /> : <Copy size={14} />}
+            {copied ? '복사됨' : '복사'}
+          </button>
+        </div>
+        <p className="text-xs text-stone-400 dark:text-stone-500 mt-2">이 코드를 가족에게 공유하세요</p>
+      </div>
+
+      {/* 가족 합류 */}
+      <div className="rounded-2xl bg-white dark:bg-stone-900 border border-stone-100 dark:border-stone-800 p-4 mb-4">
+        <p className="text-xs font-semibold text-stone-400 dark:text-stone-500 uppercase tracking-wide mb-3">
+          <Users size={12} className="inline mr-1" />
+          가족 합류
+        </p>
+        <div className="flex gap-2">
+          <input
+            value={joinCode}
+            onChange={(e) => setJoinCode(e.target.value.toUpperCase())}
+            placeholder="초대 코드 입력"
+            maxLength={6}
+            className="flex-1 px-3 py-2 rounded-xl border border-stone-200 dark:border-stone-700 bg-stone-50 dark:bg-stone-800 text-stone-800 dark:text-stone-100 font-mono tracking-widest text-sm focus:outline-none focus:ring-2 focus:ring-orange-300"
+          />
+          <button
+            onClick={handleJoin}
+            disabled={joining || joinCode.length < 6}
+            className="px-4 py-2 rounded-xl bg-orange-400 hover:bg-orange-500 disabled:opacity-50 text-white font-semibold text-sm transition-colors"
+          >
+            {joining ? '합류 중...' : '합류'}
+          </button>
+        </div>
+        {joinError && <p className="text-xs text-red-400 mt-2">{joinError}</p>}
+        <p className="text-xs text-stone-400 dark:text-stone-500 mt-2">합류하면 기존 내 가족 데이터는 초기화됩니다</p>
+      </div>
+
+      {/* 로그아웃 */}
+      <button
+        onClick={handleLogout}
+        className="w-full flex items-center justify-center gap-2 px-4 py-3 rounded-2xl border border-red-100 dark:border-red-900/40 text-red-400 hover:bg-red-50 dark:hover:bg-red-950/30 font-semibold text-sm transition-colors"
+      >
+        <LogOut size={16} />
+        로그아웃
+      </button>
+    </div>
+  )
+}

--- a/src/app/shopping/[id]/page.tsx
+++ b/src/app/shopping/[id]/page.tsx
@@ -19,6 +19,11 @@ export default function ShoppingDetailPage() {
   const { id } = useParams<{ id: string }>()
   const router = useRouter()
   const { user, loading: authLoading } = useAuth()
+
+  useEffect(() => {
+    if (!authLoading && !user) router.replace('/login')
+  }, [user, authLoading, router])
+
   const [list, setList] = useState<ShoppingList | null>(null)
   const [items, setItems] = useState<ShoppingItemType[]>([])
   const [loading, setLoading] = useState(true)

--- a/src/app/shopping/page.tsx
+++ b/src/app/shopping/page.tsx
@@ -1,18 +1,25 @@
 'use client'
 
 import { useEffect, useRef, useState } from 'react'
+import { useRouter } from 'next/navigation'
 import { Plus } from 'lucide-react'
 import { useAuth } from '@/hooks/useAuth'
 import { useFamily } from '@/hooks/useFamily'
 import { getShoppingLists, createShoppingList, deleteShoppingList } from '@/lib/shopping'
 import { ShoppingListCard } from '@/components/shopping/ShoppingListCard'
 import { CreateListModal } from '@/components/shopping/CreateListModal'
+import { BottomNav } from '@/components/BottomNav'
 import { supabase } from '@/lib/supabase'
 import type { ShoppingList, ListType } from '@/lib/shopping'
 
 export default function ShoppingPage() {
   const { user, loading: authLoading } = useAuth()
   const { familyId, loading: familyLoading } = useFamily(user)
+  const router = useRouter()
+
+  useEffect(() => {
+    if (!authLoading && !user) router.replace('/login')
+  }, [user, authLoading, router])
   const [lists, setLists] = useState<ShoppingList[]>([])
   const [showModal, setShowModal] = useState(false)
   const channelRef = useRef<ReturnType<typeof supabase.channel> | null>(null)
@@ -91,7 +98,7 @@ export default function ShoppingPage() {
   }
 
   return (
-    <div className="max-w-lg mx-auto px-4 py-8 min-h-screen">
+    <div className="max-w-lg mx-auto px-4 py-8 pb-24 min-h-screen">
       <div className="flex items-center justify-between mb-6">
         <div>
           <h1 className="text-2xl font-bold text-stone-800 dark:text-stone-100">🛒 장바구니</h1>
@@ -125,6 +132,7 @@ export default function ShoppingPage() {
       {showModal && (
         <CreateListModal onClose={() => setShowModal(false)} onCreate={handleCreate} />
       )}
+      <BottomNav />
     </div>
   )
 }

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { ShoppingCart, Settings } from 'lucide-react'
+
+const navItems = [
+  { href: '/shopping', icon: ShoppingCart, label: '장바구니' },
+  { href: '/settings', icon: Settings, label: '설정' },
+]
+
+export function BottomNav() {
+  const pathname = usePathname()
+
+  return (
+    <nav className="fixed bottom-0 left-0 right-0 z-50 bg-white dark:bg-stone-950 border-t border-stone-100 dark:border-stone-800 pb-safe">
+      <div className="max-w-lg mx-auto flex">
+        {navItems.map(({ href, icon: Icon, label }) => {
+          const active = pathname.startsWith(href)
+          return (
+            <Link
+              key={href}
+              href={href}
+              className={`flex-1 flex flex-col items-center gap-1 py-3 text-xs font-medium transition-colors ${
+                active
+                  ? 'text-orange-500'
+                  : 'text-stone-400 dark:text-stone-500 hover:text-stone-600 dark:hover:text-stone-300'
+              }`}
+            >
+              <Icon size={22} strokeWidth={active ? 2.5 : 1.8} />
+              {label}
+            </Link>
+          )
+        })}
+      </div>
+    </nav>
+  )
+}

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -12,14 +12,7 @@ export function useAuth() {
     const initAuth = async () => {
       try {
         const { data: { session } } = await supabase.auth.getSession()
-        if (session?.user) {
-          setUser(session.user)
-          return
-        }
-        // 세션 없으면 익명 로그인
-        const { data, error } = await supabase.auth.signInAnonymously()
-        if (error) console.error('[useAuth] signInAnonymously error:', error)
-        else setUser(data.user)
+        setUser(session?.user ?? null)
       } catch (e) {
         console.error('[useAuth] unexpected error:', e)
       } finally {

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -132,6 +132,7 @@ export type Database = {
         Row: {
           created_at: string
           id: string
+          invite_code: string | null
           name: string
         }
         Insert: {

--- a/supabase/migrations/20260329110000_add_family_invite_code.sql
+++ b/supabase/migrations/20260329110000_add_family_invite_code.sql
@@ -1,0 +1,14 @@
+-- 가족 초대 코드 추가 (6자리 영숫자)
+alter table families
+  add column if not exists invite_code text unique
+  default upper(substr(md5(gen_random_uuid()::text), 1, 6));
+
+-- 초대 코드로 family_id 조회하는 함수 (RLS 우회)
+create or replace function get_family_id_by_invite_code(p_code text)
+returns uuid
+language sql
+security definer
+stable
+as $$
+  select id from families where upper(invite_code) = upper(p_code)
+$$;


### PR DESCRIPTION
## Summary
- Google OAuth 로그인 구현 (`/login` 페이지, `/auth/callback`)
- 가족 초대 코드 시스템: 설정 페이지에서 코드 확인 및 입력으로 가족 합류
- 하단 네비게이션 바 (`BottomNav`) 추가 (장바구니, 설정)
- 익명 로그인 제거 → Google OAuth로 전환
- `families.invite_code` 컬럼 추가 (마이그레이션 포함)

## Changed Files
- `src/app/login/page.tsx` — Google 로그인 버튼 UI
- `src/app/auth/callback/page.tsx` — OAuth 코드 교환 후 리다이렉트
- `src/app/settings/page.tsx` — 초대 코드 표시/복사, 코드 입력으로 가족 합류, 로그아웃
- `src/app/api/family/join/route.ts` — 초대 코드로 가족 합류 API
- `src/components/BottomNav.tsx` — 하단 고정 네비게이션
- `src/hooks/useAuth.ts` — 익명 로그인 제거, getSession만 사용
- `supabase/migrations/20260329110000_add_family_invite_code.sql` — invite_code 컬럼

## Manual Test Checklist
- [x] Google 로그인 버튼 클릭 → Google 계정 선택 화면으로 이동
- [x] 로그인 완료 후 `/shopping` 페이지로 리다이렉트
- [ ] 설정 페이지에서 초대 코드 표시 확인
- [ ] 초대 코드 복사 버튼 동작 확인
- [ ] 다른 계정으로 로그인 후 초대 코드 입력 → 같은 가족으로 합류 확인
- [x] 로그아웃 후 `/login`으로 리다이렉트 확인
- [ ] BottomNav 장바구니/설정 탭 전환 확인
- [x] 로그인 안 한 상태에서 `/shopping` 접근 시 `/login`으로 리다이렉트 확인

## DB Migration
Supabase SQL Editor에서 아래 파일 실행 필요 (이미 완료):
`supabase/migrations/20260329110000_add_family_invite_code.sql`

🤖 Generated with [Claude Code](https://claude.com/claude-code)