### PR TITLE
fix: add BottomNav to settings page

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -6,6 +6,7 @@ import { LogOut, Share2, Check, Users } from 'lucide-react'
 import { useAuth } from '@/hooks/useAuth'
 import { useFamily } from '@/hooks/useFamily'
 import { supabase } from '@/lib/supabase'
+import { BottomNav } from '@/components/BottomNav'
 
 export default function SettingsPage() {
   const { user, loading: authLoading } = useAuth()
@@ -84,7 +85,7 @@ export default function SettingsPage() {
   }
 
   return (
-    <div className="max-w-lg mx-auto px-4 py-8 min-h-screen">
+    <div className="max-w-lg mx-auto px-4 py-8 pb-24 min-h-screen">
       <h1 className="text-2xl font-bold text-stone-800 dark:text-stone-100 mb-6">설정</h1>
 
       {/* 계정 정보 */}
@@ -145,6 +146,7 @@ export default function SettingsPage() {
         <LogOut size={16} />
         로그아웃
       </button>
+      <BottomNav />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
설정 페이지에 하단 네비게이션 바(`BottomNav`) 누락 버그 수정

## Manual Test Checklist
- [x] 설정 페이지 하단에 장바구니/설정 탭 표시 확인
- [x] 장바구니 탭 클릭 시 `/shopping`으로 이동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)