### PR TITLE
fix: wrap useSearchParams in Suspense boundary for build compatibility

### DIFF
--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -1,10 +1,10 @@
 'use client'
 
-import { useEffect } from 'react'
+import { Suspense, useEffect } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { supabase } from '@/lib/supabase'
 
-export default function AuthCallbackPage() {
+function AuthCallbackInner() {
   const router = useRouter()
   const searchParams = useSearchParams()
 
@@ -30,5 +30,17 @@ export default function AuthCallbackPage() {
     <div className="flex items-center justify-center min-h-screen">
       <div className="w-8 h-8 rounded-full border-2 border-orange-300 border-t-orange-500 animate-spin" />
     </div>
+  )
+}
+
+export default function AuthCallbackPage() {
+  return (
+    <Suspense fallback={
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="w-8 h-8 rounded-full border-2 border-orange-300 border-t-orange-500 animate-spin" />
+      </div>
+    }>
+      <AuthCallbackInner />
+    </Suspense>
   )
 }

--- a/src/app/join/page.tsx
+++ b/src/app/join/page.tsx
@@ -1,12 +1,12 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { Suspense, useEffect, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { Users } from 'lucide-react'
 import { useAuth } from '@/hooks/useAuth'
 import { useFamily } from '@/hooks/useFamily'
 
-export default function JoinPage() {
+function JoinInner() {
   const searchParams = useSearchParams()
   const router = useRouter()
   const { user, loading: authLoading } = useAuth()
@@ -88,5 +88,17 @@ export default function JoinPage() {
         </div>
       </div>
     </div>
+  )
+}
+
+export default function JoinPage() {
+  return (
+    <Suspense fallback={
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="w-8 h-8 rounded-full border-2 border-orange-300 border-t-orange-500 animate-spin" />
+      </div>
+    }>
+      <JoinInner />
+    </Suspense>
   )
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,11 +1,11 @@
 'use client'
 
-import { useEffect } from 'react'
+import { Suspense, useEffect } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { supabase } from '@/lib/supabase'
 import { useAuth } from '@/hooks/useAuth'
 
-export default function LoginPage() {
+function LoginInner() {
   const { user, loading } = useAuth()
   const router = useRouter()
   const searchParams = useSearchParams()
@@ -57,5 +57,17 @@ export default function LoginPage() {
         </button>
       </div>
     </div>
+  )
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense fallback={
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="w-8 h-8 rounded-full border-2 border-orange-300 border-t-orange-500 animate-spin" />
+      </div>
+    }>
+      <LoginInner />
+    </Suspense>
   )
 }


### PR DESCRIPTION
## Summary
Vercel 배포 시 `useSearchParams()` 관련 빌드 에러 수정.
Next.js는 `useSearchParams()`를 사용하는 컴포넌트를 Suspense로 감싸야 프리렌더링이 가능함.

## Changed Files
- `src/app/auth/callback/page.tsx`
- `src/app/login/page.tsx`
- `src/app/join/page.tsx`

세 파일 모두 내부 로직을 Inner 컴포넌트로 분리하고 Suspense로 래핑.

🤖 Generated with [Claude Code](https://claude.com/claude-code)