### PR TITLE
fix: prevent create button from being hidden behind bottom nav on mobile

### DIFF
--- a/src/components/shopping/CreateListModal.tsx
+++ b/src/components/shopping/CreateListModal.tsx
@@ -23,7 +23,7 @@ export function CreateListModal({ onClose, onCreate }: Props) {
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center">
+    <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center pb-16 sm:pb-0">
       <div className="absolute inset-0 bg-black/40 backdrop-blur-sm" onClick={onClose} />
       <div className="relative w-full sm:max-w-sm bg-white dark:bg-stone-900 rounded-t-3xl sm:rounded-2xl shadow-xl max-h-[90vh] flex flex-col">
         <div className="flex items-center justify-between px-6 pt-6 pb-4 shrink-0">


### PR DESCRIPTION
## 변경 내용

모달 컨테이너에 `pb-16 sm:pb-0` 추가

## 원인

`CreateListModal`이 `fixed inset-0 flex items-end`로 화면 바닥에 붙는 bottom sheet인데, `BottomNav`도 `fixed bottom-0`이라 두 요소가 동일한 `z-50`로 겹치면서 Nav가 만들기 버튼을 덮어버림.

## 수정 방법

모달 외부 컨테이너에 `pb-16 sm:pb-0` 추가. 모바일에서는 BottomNav 높이(~64px)만큼 위로 올라가고, sm 이상에서는 그대로 중앙 정렬.

## 체크리스트

- [x] 모바일(스마트폰)에서 새 장바구니 모달 열었을 때 만들기 버튼이 잘 보이는지 확인
- [x] 데스크탑/태블릿에서 모달이 정상적으로 중앙에 표시되는지 확인