### PR TITLE
feat: inline editing for shopping list and item names

### DIFF
--- a/src/__tests__/shopping/ShoppingItem.test.tsx
+++ b/src/__tests__/shopping/ShoppingItem.test.tsx
@@ -18,14 +18,14 @@ describe('ShoppingItem', () => {
   it('아이템 이름을 표시한다', () => {
     const onCheck = jest.fn()
     const onDelete = jest.fn()
-    render(<ShoppingItem item={mockItem} listType="strikethrough" onCheck={onCheck} onDelete={onDelete} />)
+    render(<ShoppingItem item={mockItem} listType="strikethrough" onCheck={onCheck} onDelete={onDelete} onRename={jest.fn()} />)
     expect(screen.getByText('우유')).toBeInTheDocument()
   })
 
   it('체크 버튼 클릭 시 onCheck가 호출된다', () => {
     const onCheck = jest.fn()
     const onDelete = jest.fn()
-    render(<ShoppingItem item={mockItem} listType="strikethrough" onCheck={onCheck} onDelete={onDelete} />)
+    render(<ShoppingItem item={mockItem} listType="strikethrough" onCheck={onCheck} onDelete={onDelete} onRename={jest.fn()} />)
     fireEvent.click(screen.getByLabelText('체크'))
     expect(onCheck).toHaveBeenCalledWith('item-1', true)
   })
@@ -34,15 +34,42 @@ describe('ShoppingItem', () => {
     const onCheck = jest.fn()
     const onDelete = jest.fn()
     const checkedItem = { ...mockItem, is_checked: true }
-    render(<ShoppingItem item={checkedItem} listType="strikethrough" onCheck={onCheck} onDelete={onDelete} />)
+    render(<ShoppingItem item={checkedItem} listType="strikethrough" onCheck={onCheck} onDelete={onDelete} onRename={jest.fn()} />)
     expect(screen.getByText('우유')).toHaveClass('line-through')
   })
 
   it('삭제 버튼 클릭 시 onDelete가 호출된다', () => {
     const onCheck = jest.fn()
     const onDelete = jest.fn()
-    render(<ShoppingItem item={mockItem} listType="strikethrough" onCheck={onCheck} onDelete={onDelete} />)
+    render(<ShoppingItem item={mockItem} listType="strikethrough" onCheck={onCheck} onDelete={onDelete} onRename={jest.fn()} />)
     fireEvent.click(screen.getByLabelText('삭제'))
     expect(onDelete).toHaveBeenCalledWith('item-1')
+  })
+
+  it('이름 클릭 시 인라인 편집 입력창이 나타난다', () => {
+    render(<ShoppingItem item={mockItem} listType="strikethrough" onCheck={jest.fn()} onDelete={jest.fn()} onRename={jest.fn()} />)
+    fireEvent.click(screen.getByText('우유'))
+    expect(screen.getByLabelText('아이템 이름 수정')).toBeInTheDocument()
+  })
+
+  it('이름 수정 후 Enter 키로 onRename이 호출된다', () => {
+    const onRename = jest.fn()
+    render(<ShoppingItem item={mockItem} listType="strikethrough" onCheck={jest.fn()} onDelete={jest.fn()} onRename={onRename} />)
+    fireEvent.click(screen.getByText('우유'))
+    const input = screen.getByLabelText('아이템 이름 수정')
+    fireEvent.change(input, { target: { value: '두유' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(onRename).toHaveBeenCalledWith('item-1', '두유')
+  })
+
+  it('Escape 키 입력 시 편집이 취소된다', () => {
+    const onRename = jest.fn()
+    render(<ShoppingItem item={mockItem} listType="strikethrough" onCheck={jest.fn()} onDelete={jest.fn()} onRename={onRename} />)
+    fireEvent.click(screen.getByText('우유'))
+    const input = screen.getByLabelText('아이템 이름 수정')
+    fireEvent.change(input, { target: { value: '두유' } })
+    fireEvent.keyDown(input, { key: 'Escape' })
+    expect(onRename).not.toHaveBeenCalled()
+    expect(screen.getByText('우유')).toBeInTheDocument()
   })
 })

--- a/src/__tests__/shopping/ShoppingListCard.test.tsx
+++ b/src/__tests__/shopping/ShoppingListCard.test.tsx
@@ -18,7 +18,7 @@ const mockList: ShoppingList = {
 describe('ShoppingListCard', () => {
   it('삭제 버튼 클릭 시 확인 UI가 나타난다', () => {
     const onDelete = jest.fn()
-    render(<ShoppingListCard list={mockList} onDelete={onDelete} />)
+    render(<ShoppingListCard list={mockList} onDelete={onDelete} onRename={jest.fn()} />)
 
     fireEvent.click(screen.getByLabelText('삭제'))
 
@@ -29,7 +29,7 @@ describe('ShoppingListCard', () => {
 
   it('확인 클릭 시 onDelete가 호출된다', () => {
     const onDelete = jest.fn()
-    render(<ShoppingListCard list={mockList} onDelete={onDelete} />)
+    render(<ShoppingListCard list={mockList} onDelete={onDelete} onRename={jest.fn()} />)
 
     fireEvent.click(screen.getByLabelText('삭제'))
     fireEvent.click(screen.getByLabelText('삭제 확인'))
@@ -39,7 +39,7 @@ describe('ShoppingListCard', () => {
 
   it('취소 클릭 시 onDelete가 호출되지 않고 확인 UI가 사라진다', () => {
     const onDelete = jest.fn()
-    render(<ShoppingListCard list={mockList} onDelete={onDelete} />)
+    render(<ShoppingListCard list={mockList} onDelete={onDelete} onRename={jest.fn()} />)
 
     fireEvent.click(screen.getByLabelText('삭제'))
     fireEvent.click(screen.getByLabelText('취소'))
@@ -49,7 +49,34 @@ describe('ShoppingListCard', () => {
   })
 
   it('목록 이름이 렌더링된다', () => {
-    render(<ShoppingListCard list={mockList} onDelete={jest.fn()} />)
+    render(<ShoppingListCard list={mockList} onDelete={jest.fn()} onRename={jest.fn()} />)
+    expect(screen.getByText('이마트')).toBeInTheDocument()
+  })
+
+  it('이름 클릭 시 인라인 편집 입력창이 나타난다', () => {
+    render(<ShoppingListCard list={mockList} onDelete={jest.fn()} onRename={jest.fn()} />)
+    fireEvent.click(screen.getByText('이마트'))
+    expect(screen.getByLabelText('목록 이름 수정')).toBeInTheDocument()
+  })
+
+  it('이름 수정 후 Enter 키로 onRename이 호출된다', () => {
+    const onRename = jest.fn()
+    render(<ShoppingListCard list={mockList} onDelete={jest.fn()} onRename={onRename} />)
+    fireEvent.click(screen.getByText('이마트'))
+    const input = screen.getByLabelText('목록 이름 수정')
+    fireEvent.change(input, { target: { value: '코스트코' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(onRename).toHaveBeenCalledWith('list-1', '코스트코')
+  })
+
+  it('Escape 키 입력 시 편집이 취소된다', () => {
+    const onRename = jest.fn()
+    render(<ShoppingListCard list={mockList} onDelete={jest.fn()} onRename={onRename} />)
+    fireEvent.click(screen.getByText('이마트'))
+    const input = screen.getByLabelText('목록 이름 수정')
+    fireEvent.change(input, { target: { value: '코스트코' } })
+    fireEvent.keyDown(input, { key: 'Escape' })
+    expect(onRename).not.toHaveBeenCalled()
     expect(screen.getByText('이마트')).toBeInTheDocument()
   })
 })

--- a/src/app/shopping/[id]/page.tsx
+++ b/src/app/shopping/[id]/page.tsx
@@ -9,6 +9,7 @@ import {
   addShoppingItem,
   checkShoppingItem,
   deleteShoppingItem,
+  renameShoppingItem,
 } from '@/lib/shopping'
 import { ShoppingItem } from '@/components/shopping/ShoppingItem'
 import { AddItemInput } from '@/components/shopping/AddItemInput'
@@ -123,6 +124,12 @@ export default function ShoppingDetailPage() {
     broadcast()
   }
 
+  const handleRename = async (itemId: string, name: string) => {
+    setItems((prev) => prev.map((i) => i.id === itemId ? { ...i, name } : i))
+    await renameShoppingItem(itemId, name)
+    broadcast()
+  }
+
   const uncheckedItems = items.filter((i) => !i.is_checked)
   const checkedItems = items.filter((i) => i.is_checked)
 
@@ -174,6 +181,7 @@ export default function ShoppingDetailPage() {
             listType={list?.type as 'strikethrough' | 'delete' ?? 'strikethrough'}
             onCheck={handleCheck}
             onDelete={handleDelete}
+            onRename={handleRename}
           />
         ))}
 
@@ -191,6 +199,7 @@ export default function ShoppingDetailPage() {
                 listType="strikethrough"
                 onCheck={handleCheck}
                 onDelete={handleDelete}
+                onRename={handleRename}
               />
             ))}
           </>

--- a/src/app/shopping/page.tsx
+++ b/src/app/shopping/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation'
 import { Plus } from 'lucide-react'
 import { useAuth } from '@/hooks/useAuth'
 import { useFamily } from '@/hooks/useFamily'
-import { getShoppingLists, createShoppingList, deleteShoppingList } from '@/lib/shopping'
+import { getShoppingLists, createShoppingList, deleteShoppingList, renameShoppingList } from '@/lib/shopping'
 import { ShoppingListCard } from '@/components/shopping/ShoppingListCard'
 import { CreateListModal } from '@/components/shopping/CreateListModal'
 import { BottomNav } from '@/components/BottomNav'
@@ -89,6 +89,12 @@ export default function ShoppingPage() {
     broadcast()
   }
 
+  const handleRename = async (listId: string, name: string) => {
+    setLists((prev) => prev.map((l) => l.id === listId ? { ...l, name } : l))
+    await renameShoppingList(listId, name)
+    broadcast()
+  }
+
   if (loading) {
     return (
       <div className="flex items-center justify-center min-h-screen">
@@ -124,7 +130,7 @@ export default function ShoppingPage() {
       ) : (
         <div className="space-y-2">
           {lists.map((list) => (
-            <ShoppingListCard key={list.id} list={list} onDelete={handleDelete} />
+            <ShoppingListCard key={list.id} list={list} onDelete={handleDelete} onRename={handleRename} />
           ))}
         </div>
       )}

--- a/src/components/shopping/ShoppingItem.tsx
+++ b/src/components/shopping/ShoppingItem.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useRef, useState } from 'react'
 import { Trash2 } from 'lucide-react'
 import type { ShoppingItem as ShoppingItemType } from '@/lib/shopping'
 
@@ -8,11 +9,40 @@ interface Props {
   listType: 'strikethrough' | 'delete'
   onCheck: (itemId: string, checked: boolean) => void
   onDelete: (itemId: string) => void
+  onRename: (itemId: string, name: string) => void
 }
 
-export function ShoppingItem({ item, listType, onCheck, onDelete }: Props) {
+export function ShoppingItem({ item, listType, onCheck, onDelete, onRename }: Props) {
+  const [editing, setEditing] = useState(false)
+  const [editValue, setEditValue] = useState(item.name)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const handleNameClick = () => {
+    setEditValue(item.name)
+    setEditing(true)
+    setTimeout(() => inputRef.current?.select(), 0)
+  }
+
+  const commitEdit = () => {
+    const trimmed = editValue.trim()
+    if (trimmed && trimmed !== item.name) {
+      onRename(item.id, trimmed)
+    } else {
+      setEditValue(item.name)
+    }
+    setEditing(false)
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') commitEdit()
+    if (e.key === 'Escape') {
+      setEditValue(item.name)
+      setEditing(false)
+    }
+  }
+
   const handleCheck = () => {
-    onCheck(item.id, !item.is_checked)
+    if (!editing) onCheck(item.id, !item.is_checked)
   }
 
   return (
@@ -39,15 +69,28 @@ export function ShoppingItem({ item, listType, onCheck, onDelete }: Props) {
         )}
       </button>
 
-      <span
-        className={`flex-1 text-stone-800 dark:text-stone-100 transition-all ${
-          item.is_checked && listType === 'strikethrough'
-            ? 'line-through text-stone-400 dark:text-stone-500'
-            : ''
-        }`}
-      >
-        {item.name}
-      </span>
+      {editing ? (
+        <input
+          ref={inputRef}
+          value={editValue}
+          onChange={(e) => setEditValue(e.target.value)}
+          onBlur={commitEdit}
+          onKeyDown={handleKeyDown}
+          className="flex-1 text-stone-800 dark:text-stone-100 bg-transparent border-b border-orange-400 outline-none"
+          aria-label="아이템 이름 수정"
+        />
+      ) : (
+        <span
+          onClick={handleNameClick}
+          className={`flex-1 text-stone-800 dark:text-stone-100 transition-all cursor-text ${
+            item.is_checked && listType === 'strikethrough'
+              ? 'line-through text-stone-400 dark:text-stone-500'
+              : ''
+          }`}
+        >
+          {item.name}
+        </span>
+      )}
 
       <button
         onClick={() => onDelete(item.id)}

--- a/src/components/shopping/ShoppingListCard.tsx
+++ b/src/components/shopping/ShoppingListCard.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { ShoppingCart, Trash2, CheckSquare } from 'lucide-react'
 import type { ShoppingList } from '@/lib/shopping'
@@ -8,11 +8,40 @@ import type { ShoppingList } from '@/lib/shopping'
 interface Props {
   list: ShoppingList
   onDelete: (listId: string) => void
+  onRename: (listId: string, name: string) => void
 }
 
-export function ShoppingListCard({ list, onDelete }: Props) {
+export function ShoppingListCard({ list, onDelete, onRename }: Props) {
   const router = useRouter()
   const [confirming, setConfirming] = useState(false)
+  const [editing, setEditing] = useState(false)
+  const [editValue, setEditValue] = useState(list.name)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const handleNameClick = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    setEditValue(list.name)
+    setEditing(true)
+    setTimeout(() => inputRef.current?.select(), 0)
+  }
+
+  const commitEdit = () => {
+    const trimmed = editValue.trim()
+    if (trimmed && trimmed !== list.name) {
+      onRename(list.id, trimmed)
+    } else {
+      setEditValue(list.name)
+    }
+    setEditing(false)
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') commitEdit()
+    if (e.key === 'Escape') {
+      setEditValue(list.name)
+      setEditing(false)
+    }
+  }
 
   const handleDeleteClick = (e: React.MouseEvent) => {
     e.stopPropagation()
@@ -31,15 +60,33 @@ export function ShoppingListCard({ list, onDelete }: Props) {
 
   return (
     <div
-      onClick={() => !confirming && router.push(`/shopping/${list.id}`)}
+      onClick={() => !confirming && !editing && router.push(`/shopping/${list.id}`)}
       className="group flex items-center justify-between p-4 rounded-2xl bg-white dark:bg-stone-900 border border-stone-100 dark:border-stone-800 shadow-sm hover:shadow-md hover:border-orange-200 dark:hover:border-orange-900 active:scale-[0.98] transition-all cursor-pointer"
     >
-      <div className="flex items-center gap-3">
-        <div className="p-2 rounded-xl bg-orange-50 dark:bg-orange-950/40 text-orange-400">
+      <div className="flex items-center gap-3 flex-1 min-w-0">
+        <div className="p-2 rounded-xl bg-orange-50 dark:bg-orange-950/40 text-orange-400 flex-shrink-0">
           <ShoppingCart size={20} />
         </div>
-        <div>
-          <p className="font-semibold text-stone-800 dark:text-stone-100">{list.name}</p>
+        <div className="flex-1 min-w-0">
+          {editing ? (
+            <input
+              ref={inputRef}
+              value={editValue}
+              onChange={(e) => setEditValue(e.target.value)}
+              onBlur={commitEdit}
+              onKeyDown={handleKeyDown}
+              onClick={(e) => e.stopPropagation()}
+              className="w-full font-semibold text-stone-800 dark:text-stone-100 bg-transparent border-b border-orange-400 outline-none"
+              aria-label="목록 이름 수정"
+            />
+          ) : (
+            <p
+              className="font-semibold text-stone-800 dark:text-stone-100 truncate"
+              onClick={handleNameClick}
+            >
+              {list.name}
+            </p>
+          )}
           <p className="text-xs text-stone-400 dark:text-stone-500 mt-0.5 flex items-center gap-1">
             {list.type === 'strikethrough' ? (
               <>
@@ -57,7 +104,7 @@ export function ShoppingListCard({ list, onDelete }: Props) {
       </div>
 
       {confirming ? (
-        <div className="flex items-center gap-2" onClick={(e) => e.stopPropagation()}>
+        <div className="flex items-center gap-2 flex-shrink-0" onClick={(e) => e.stopPropagation()}>
           <span className="text-xs text-stone-500 dark:text-stone-400">삭제할까요?</span>
           <button
             onClick={handleConfirm}
@@ -75,13 +122,15 @@ export function ShoppingListCard({ list, onDelete }: Props) {
           </button>
         </div>
       ) : (
-        <button
-          onClick={handleDeleteClick}
-          className="opacity-0 group-hover:opacity-100 p-2 rounded-xl text-stone-300 hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-950/40 transition-all"
-          aria-label="삭제"
-        >
-          <Trash2 size={16} />
-        </button>
+        !editing && (
+          <button
+            onClick={handleDeleteClick}
+            className="opacity-0 group-hover:opacity-100 p-2 rounded-xl text-stone-300 hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-950/40 transition-all flex-shrink-0"
+            aria-label="삭제"
+          >
+            <Trash2 size={16} />
+          </button>
+        )
       )}
     </div>
   )

--- a/src/lib/shopping.ts
+++ b/src/lib/shopping.ts
@@ -85,3 +85,19 @@ export async function deleteShoppingItem(itemId: string): Promise<void> {
   const { error } = await supabase.from('shopping_items').delete().eq('id', itemId)
   if (error) throw error
 }
+
+export async function renameShoppingList(listId: string, name: string): Promise<void> {
+  const { error } = await supabase
+    .from('shopping_lists')
+    .update({ name })
+    .eq('id', listId)
+  if (error) throw error
+}
+
+export async function renameShoppingItem(itemId: string, name: string): Promise<void> {
+  const { error } = await supabase
+    .from('shopping_items')
+    .update({ name })
+    .eq('id', itemId)
+  if (error) throw error
+}


### PR DESCRIPTION
## Summary
- 장바구니 목록 이름을 클릭하면 바로 수정 입력창으로 전환 (아이폰 미리 알림 스타일)
- 장바구니 아이템 이름을 클릭하면 바로 수정 입력창으로 전환
- Enter 키로 저장, Esc 키로 취소, blur(포커스 이탈)로 저장
- 별도 수정 버튼 없이 텍스트 클릭만으로 편집 시작
- Optimistic update로 즉각적인 UI 피드백

## Manual Verification
- [ ] 장바구니 목록 이름을 클릭하면 인라인 입력창이 나타나는지 확인
- [ ] 이름 수정 후 Enter를 누르면 저장되는지 확인
- [ ] 이름 수정 후 다른 곳을 클릭(blur)하면 저장되는지 확인
- [ ] Esc 키를 누르면 원래 이름으로 돌아가는지 확인
- [ ] 아이템 이름 클릭 시 동일하게 동작하는지 확인
- [ ] 빈 문자열로 저장하면 원래 이름이 유지되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)