### PR TITLE
fix: make delete buttons always visible on mobile

### DIFF
--- a/src/components/shopping/ShoppingItem.tsx
+++ b/src/components/shopping/ShoppingItem.tsx
@@ -127,7 +127,7 @@ export function ShoppingItem({ item, listType, onCheck, onDelete, onRename, drag
 
       <button
         onClick={() => onDelete(item.id)}
-        className="opacity-0 group-hover:opacity-100 p-1.5 rounded-lg text-stone-300 hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-950/40 transition-all"
+        className="opacity-100 sm:opacity-0 sm:group-hover:opacity-100 p-1.5 rounded-lg text-stone-300 hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-950/40 transition-all"
         aria-label="삭제"
       >
         <Trash2 size={14} />

--- a/src/components/shopping/ShoppingListCard.tsx
+++ b/src/components/shopping/ShoppingListCard.tsx
@@ -140,7 +140,7 @@ export function ShoppingListCard({ list, onDelete, onRename }: Props) {
           {!editing && (
             <button
               onClick={handleDeleteClick}
-              className="opacity-0 group-hover:opacity-100 p-2 rounded-xl text-stone-300 hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-950/40 transition-all flex-shrink-0"
+              className="opacity-100 sm:opacity-0 sm:group-hover:opacity-100 p-2 rounded-xl text-stone-300 hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-950/40 transition-all flex-shrink-0"
               aria-label="삭제"
             >
               <Trash2 size={16} />


### PR DESCRIPTION
## Summary
- Shopping list card delete button: `opacity-0 group-hover:opacity-100` → `opacity-100 sm:opacity-0 sm:group-hover:opacity-100`
- Shopping item delete button: same fix applied

Mobile browsers have no hover state, so `group-hover:opacity-100` never triggers. Delete buttons were effectively invisible on mobile.

## Visual Check
- [ ] 장바구니 목록 페이지 — 각 카드 우측에 삭제 버튼이 항상 표시되는지 확인 (모바일)
- [ ] 장바구니 상세 페이지 — 각 아이템 우측에 삭제 버튼이 항상 표시되는지 확인 (모바일)
- [ ] 데스크탑에서는 hover 시에만 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)