### PR TITLE
fix: delete dialog z-index and item delete confirmation modal

### DIFF
--- a/src/__tests__/shopping/ShoppingItem.test.tsx
+++ b/src/__tests__/shopping/ShoppingItem.test.tsx
@@ -48,11 +48,29 @@ describe('ShoppingItem', () => {
     expect(screen.getByText('우유')).toHaveClass('line-through')
   })
 
-  it('삭제 버튼 클릭 시 onDelete가 호출된다', () => {
+  it('삭제 버튼 클릭 시 확인 다이얼로그가 나타난다', () => {
+    render(<ShoppingItem item={mockItem} listType="strikethrough" onCheck={jest.fn()} onDelete={jest.fn()} onRename={jest.fn()} />)
+    fireEvent.click(screen.getByLabelText('삭제'))
+    expect(screen.getByText('아이템 삭제')).toBeInTheDocument()
+    expect(screen.getByLabelText('삭제 확인')).toBeInTheDocument()
+    expect(screen.getByLabelText('취소')).toBeInTheDocument()
+  })
+
+  it('다이얼로그에서 삭제 확인 시 onDelete가 호출된다', () => {
     const onDelete = jest.fn()
     render(<ShoppingItem item={mockItem} listType="strikethrough" onCheck={jest.fn()} onDelete={onDelete} onRename={jest.fn()} />)
     fireEvent.click(screen.getByLabelText('삭제'))
+    fireEvent.click(screen.getByLabelText('삭제 확인'))
     expect(onDelete).toHaveBeenCalledWith('item-1')
+  })
+
+  it('다이얼로그에서 취소 시 onDelete가 호출되지 않는다', () => {
+    const onDelete = jest.fn()
+    render(<ShoppingItem item={mockItem} listType="strikethrough" onCheck={jest.fn()} onDelete={onDelete} onRename={jest.fn()} />)
+    fireEvent.click(screen.getByLabelText('삭제'))
+    fireEvent.click(screen.getByLabelText('취소'))
+    expect(onDelete).not.toHaveBeenCalled()
+    expect(screen.queryByText('아이템 삭제')).not.toBeInTheDocument()
   })
 
   it('이름 클릭 시 인라인 편집 입력창이 나타난다', () => {

--- a/src/components/shopping/ShoppingItem.tsx
+++ b/src/components/shopping/ShoppingItem.tsx
@@ -18,6 +18,7 @@ interface Props {
 export function ShoppingItem({ item, listType, onCheck, onDelete, onRename, draggable = false }: Props) {
   const [editing, setEditing] = useState(false)
   const [editValue, setEditValue] = useState(item.name)
+  const [confirming, setConfirming] = useState(false)
 
   const {
     attributes,
@@ -126,12 +127,40 @@ export function ShoppingItem({ item, listType, onCheck, onDelete, onRename, drag
       )}
 
       <button
-        onClick={() => onDelete(item.id)}
+        onClick={() => setConfirming(true)}
         className="opacity-100 sm:opacity-0 sm:group-hover:opacity-100 p-1.5 rounded-lg text-stone-300 hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-950/40 transition-all"
         aria-label="삭제"
       >
         <Trash2 size={14} />
       </button>
+
+      {confirming && (
+        <div className="fixed inset-0 z-[60] flex items-end sm:items-center justify-center p-4">
+          <div className="absolute inset-0 bg-black/40" onClick={() => setConfirming(false)} />
+          <div className="relative bg-white dark:bg-stone-900 rounded-2xl w-full sm:max-w-xs p-6 shadow-xl">
+            <p className="font-semibold text-stone-800 dark:text-stone-100 mb-1">아이템 삭제</p>
+            <p className="text-sm text-stone-500 dark:text-stone-400 mb-6">
+              &ldquo;{item.name}&rdquo;을(를) 삭제할까요?
+            </p>
+            <div className="flex gap-3">
+              <button
+                onClick={() => setConfirming(false)}
+                className="flex-1 py-2.5 rounded-xl bg-stone-100 dark:bg-stone-800 text-stone-700 dark:text-stone-300 font-semibold text-sm transition-colors hover:bg-stone-200 dark:hover:bg-stone-700"
+                aria-label="취소"
+              >
+                취소
+              </button>
+              <button
+                onClick={() => { setConfirming(false); onDelete(item.id) }}
+                className="flex-1 py-2.5 rounded-xl bg-red-500 hover:bg-red-600 text-white font-semibold text-sm transition-colors"
+                aria-label="삭제 확인"
+              >
+                삭제
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/shopping/ShoppingListCard.tsx
+++ b/src/components/shopping/ShoppingListCard.tsx
@@ -150,7 +150,7 @@ export function ShoppingListCard({ list, onDelete, onRename }: Props) {
       </div>
 
       {confirming && (
-        <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-4">
+        <div className="fixed inset-0 z-[60] flex items-end sm:items-center justify-center p-4">
           <div
             className="absolute inset-0 bg-black/40"
             onClick={handleCancel}


### PR DESCRIPTION
## Summary
- 장바구니 삭제 확인 모달이 BottomNav에 가려지는 문제 수정 (`z-50` → `z-[60]`)
- 아이템 삭제도 장바구니와 동일하게 확인 모달 추가
- ShoppingItem 테스트 3개 추가 (삭제 다이얼로그 플로우 커버)

## Test plan
- [x] 장바구니 목록에서 삭제 버튼 클릭 → 확인 모달이 BottomNav 위로 완전히 표시되는지 확인
- [x] 아이템 삭제 버튼 클릭 → "아이템 삭제" 확인 모달이 표시되는지 확인
- [x] 모달에서 취소 → 삭제 안 됨, 확인 → 삭제 됨 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)