### PR TITLE
refactor: remove BroadcastChannel, simplify sync to Supabase Realtime only

### DIFF
--- a/src/app/shopping/[id]/page.tsx
+++ b/src/app/shopping/[id]/page.tsx
@@ -39,8 +39,6 @@ export default function ShoppingDetailPage() {
   const [items, setItems] = useState<ShoppingItemType[]>([])
   const [loading, setLoading] = useState(true)
   const channelRef = useRef<ReturnType<typeof supabase.channel> | null>(null)
-  const channelReadyRef = useRef(false)
-  const bcRef = useRef<BroadcastChannel | null>(null)
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
@@ -65,33 +63,19 @@ export default function ShoppingDetailPage() {
     }
     init()
 
-    // 같은 브라우저 내 탭 간 즉시 동기화
-    const bc = new BroadcastChannel(`koko-items-${id}`)
-    bc.onmessage = refreshItems
-    bcRef.current = bc
-
-    // 다른 기기 간 동기화
     const channel = supabase
       .channel(`list_items_${id}`)
       .on('broadcast', { event: 'refresh' }, refreshItems)
       .subscribe((status) => {
-        channelReadyRef.current = status === 'SUBSCRIBED'
         if (status === 'SUBSCRIBED') refreshItems()
       })
 
     channelRef.current = channel
-    return () => {
-      bc.close()
-      channelReadyRef.current = false
-      supabase.removeChannel(channel)
-    }
+    return () => { supabase.removeChannel(channel) }
   }, [id])
 
   const broadcast = () => {
-    bcRef.current?.postMessage('refresh')
-    if (channelRef.current && channelReadyRef.current) {
-      channelRef.current.send({ type: 'broadcast', event: 'refresh', payload: {} })
-    }
+    channelRef.current?.send({ type: 'broadcast', event: 'refresh', payload: {} })
   }
 
   const handleAdd = async (name: string) => {

--- a/src/components/tabs/ShoppingTab.tsx
+++ b/src/components/tabs/ShoppingTab.tsx
@@ -39,8 +39,6 @@ export function ShoppingTab() {
   const [fetchError, setFetchError] = useState(false)
   const [showModal, setShowModal] = useState(false)
   const channelRef = useRef<ReturnType<typeof supabase.channel> | null>(null)
-  const channelReadyRef = useRef(false)
-  const bcRef = useRef<BroadcastChannel | null>(null)
 
   const loading = authLoading || familyLoading
 
@@ -61,32 +59,20 @@ export function ShoppingTab() {
         })
     refresh()
 
-    const bc = new BroadcastChannel(`koko-lists-${familyId}`)
-    bc.onmessage = refresh
-    bcRef.current = bc
-
     const channel = supabase
       .channel(`family_lists_${familyId}`)
       .on('broadcast', { event: 'refresh' }, refresh)
       .subscribe((status) => {
-        channelReadyRef.current = status === 'SUBSCRIBED'
         if (status === 'SUBSCRIBED') refresh()
       })
 
     channelRef.current = channel
 
-    return () => {
-      bc.close()
-      channelReadyRef.current = false
-      supabase.removeChannel(channel)
-    }
+    return () => { supabase.removeChannel(channel) }
   }, [familyId])
 
   const broadcast = () => {
-    bcRef.current?.postMessage('refresh')
-    if (channelRef.current && channelReadyRef.current) {
-      channelRef.current.send({ type: 'broadcast', event: 'refresh', payload: {} })
-    }
+    channelRef.current?.send({ type: 'broadcast', event: 'refresh', payload: {} })
   }
 
   const handleCreate = async (name: string, type: ListType) => {


### PR DESCRIPTION
## Summary

- `ShoppingTab`, `ShoppingDetailPage` 양쪽에서 BroadcastChannel 제거
- `channelReadyRef` 가드 제거 → broadcast가 SUBSCRIBED 전에도 즉시 전송 (Supabase가 REST 폴백 처리)
- 다른 기기 간 실시간 동기화는 Supabase Realtime으로 완전 동일하게 유지됨

## Why

BroadcastChannel은 같은 브라우저에서 창을 2개 열었을 때만 효과가 있어 실제 사용 시나리오와 맞지 않아 제거. 코드 단순화 및 불필요한 리소스 사용 제거.

## Test plan

- [ ] 두 기기에서 동시 접속 후 한 기기에서 장바구니 목록 추가/삭제 시 다른 기기에 즉시 반영되는지 확인
- [ ] 두 기기에서 동시 접속 후 한 기기에서 아이템 추가/체크/삭제 시 다른 기기에 즉시 반영되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)