### PR TITLE
fix: resolve lint warnings in CalendarTab and CalendarFilter test

### DIFF
--- a/src/__tests__/components/CalendarFilter.test.tsx
+++ b/src/__tests__/components/CalendarFilter.test.tsx
@@ -62,7 +62,6 @@ describe('CalendarFilter', () => {
 
   it('"+" 버튼 클릭 시 onAdd가 호출된다', () => {
     render(<CalendarFilter {...defaultProps} />)
-    const addBtn = screen.getByRole('button', { name: '' })
     // Plus icon button has no text, but it's the last button
     const buttons = screen.getAllByRole('button')
     fireEvent.click(buttons[buttons.length - 1])

--- a/src/components/tabs/CalendarTab.tsx
+++ b/src/components/tabs/CalendarTab.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { ChevronLeft, ChevronRight, Plus } from 'lucide-react'
 import { useAuth } from '@/hooks/useAuth'
@@ -50,12 +50,12 @@ export function CalendarTab() {
     if (!authLoading && !user) router.replace('/login')
   }, [user, authLoading, router])
 
-  const loadEvents = () => {
+  const loadEvents = useCallback(() => {
     if (!familyId) return
     getEventsByMonth(familyId, year, month)
       .then(setEvents)
       .catch((e) => console.error('[CalendarTab] loadEvents failed:', e))
-  }
+  }, [familyId, year, month])
 
   useEffect(() => {
     if (!familyId) return
@@ -68,7 +68,7 @@ export function CalendarTab() {
     channelRef.current = channel
 
     return () => { supabase.removeChannel(channel) }
-  }, [familyId, year, month])
+  }, [familyId, year, month, loadEvents])
 
   const broadcast = () => {
     channelRef.current?.send({ type: 'broadcast', event: 'refresh', payload: {} })
@@ -306,7 +306,7 @@ function EventFormModalWithReminders({
     getReminders(event.id)
       .then((r) => setReminderMinutes(r.map((x) => x.remind_minutes_before)))
       .catch(() => setReminderMinutes([]))
-  }, [event?.id])
+  }, [event])
 
   if (reminderMinutes === null) return null
 


### PR DESCRIPTION
## Summary
- `loadEvents`를 `useCallback`으로 메모이제이션하고 `useEffect` 의존성 배열에 추가 (CalendarTab L71)
- `useEffect` 의존성을 `[event?.id]` → `[event]`로 수정 (CalendarTab L309)
- 테스트에서 사용되지 않는 `addBtn` 변수 제거 (CalendarFilter.test.tsx L65)

## Test plan
- [ ] CI lint/type check/test 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)