### PR TITLE
docs: add Commands and Architecture sections to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,7 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
 # Koko - Family Hub App
 
 ## Project Stack
@@ -22,3 +26,41 @@
 3. Use GitHub Actions CI — tests must pass before merging
 4. Items requiring manual visual verification by the user must be listed as checkboxes in the PR (exclude automated test items)
 5. Before adding or modifying features, read PATTERNS.md first
+
+## Commands
+
+```bash
+npm run dev          # dev server (localhost:3000)
+npm run build        # production build
+npm run lint         # ESLint
+npm run test         # run all tests
+npm run test -- --testPathPattern=<path>  # run single test file
+npm run test:watch   # watch mode
+```
+
+## Architecture
+
+### Layer Pipeline
+
+```
+DB migration → src/types/database.ts → src/lib/ → src/hooks/ (shared only) → app/page → components/
+```
+
+Each layer depends only on the layer below it. Real-time subscription is managed only at the page layer.
+
+### Tab Structure (CSS Keep-Alive)
+
+`/calendar` is the single entry point; `/shopping` and `/settings` redirect here.
+`TabsShell` keeps all three tabs permanently mounted and toggles visibility with `display: contents` / `display: none` — prevents re-fetch and spinner on tab switch.
+
+### Real-time Sync
+
+Uses Supabase Realtime **Broadcast** channel (not `postgres_changes`).
+After any mutation, manually call `channel.send()` to broadcast a refresh event to other devices.
+Only send after the channel is `SUBSCRIBED` — track readiness with `channelReadyRef`.
+
+### Auth Flow
+
+Email allowlist is stored in the `allowed_emails` DB table (not env vars — avoids Vercel redeployment on member changes).
+OAuth: Supabase auto-exchanges the code → `onAuthStateChange('SIGNED_IN')` → check allowlist → allow or sign out.
+Do **not** call `exchangeCodeForSession` manually; it conflicts with Supabase's automatic exchange.


### PR DESCRIPTION
  ## Summary

  - `/init` 컨벤션에 따라 필수 헤더(`# CLAUDE.md` + 안내 문구) 추가
  - **Commands** 섹션 추가: dev, build, lint, test, 단일 테스트 실행, watch 모드 명령어
  - **Architecture** 섹션 추가:
    - 레이어 파이프라인 (DB migration → lib → hooks → page → components)
    - CSS Keep-Alive 탭 패턴 (`TabsShell` + `display: none`)
    - 실시간 동기화 전략 (Supabase Realtime Broadcast + `channelReadyRef`)
    - Auth 흐름 (DB 기반 이메일 허용 목록, `exchangeCodeForSession` 대신 `onAuthStateChange`)

  ## 변경 이유

  미래의 Claude Code 인스턴스가 빌드/테스트 명령어를 알 수 없고, 탭 keep-alive 패턴·Broadcast 전용 실시간 동기화·OAuth 처리 방식 등 비자명적인 아키텍처 결정을 파악하려면 여러 소스 파일을 직접
  읽어야 했습니다. 이 변경으로 즉시 생산적으로 작업할 수 있게 됩니다.