### PR TITLE
fix: replace visualViewport correction with focus(preventScroll) on modal open

### DIFF
--- a/src/components/calendar/EventFormModal.tsx
+++ b/src/components/calendar/EventFormModal.tsx
@@ -91,24 +91,13 @@ export function EventFormModal({ initial, initialDate, initialReminderMinutes = 
   )
   const [saving, setSaving] = useState(false)
 
-  const modalRef = useRef<HTMLDivElement>(null)
+  const titleInputRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
-    const vv = window.visualViewport
-    if (!vv) return
-
-    const handler = () => {
-      if (!modalRef.current) return
-      const offsetY = vv.offsetTop ?? 0
-      modalRef.current.style.transform = `translateY(${offsetY}px)`
-    }
-
-    vv.addEventListener('resize', handler)
-    vv.addEventListener('scroll', handler)
-    return () => {
-      vv.removeEventListener('resize', handler)
-      vv.removeEventListener('scroll', handler)
-    }
+    const timer = setTimeout(() => {
+      titleInputRef.current?.focus({ preventScroll: true })
+    }, 300)
+    return () => clearTimeout(timer)
   }, [])
 
   const triggerShake = () => {
@@ -216,7 +205,7 @@ export function EventFormModal({ initial, initialDate, initialReminderMinutes = 
   const dateBtnCls = 'relative overflow-hidden px-3 py-2.5 rounded-xl bg-stone-100 dark:bg-stone-800 text-sm font-medium text-stone-700 dark:text-stone-200 text-left'
 
   return (
-    <div ref={modalRef} className={`fixed inset-0 z-[70] bg-white dark:bg-stone-900 flex flex-col ${isClosing ? 'modal-slide-down' : 'modal-slide-up'}`}>
+    <div className={`fixed inset-0 z-[70] bg-white dark:bg-stone-900 flex flex-col ${isClosing ? 'modal-slide-down' : 'modal-slide-up'}`}>
       {/* 헤더 */}
       <div className="flex items-center justify-between px-5 py-4 border-b border-stone-100 dark:border-stone-800 shrink-0 pt-safe">
         <h2 className="text-base font-bold text-stone-800 dark:text-stone-100">
@@ -250,12 +239,12 @@ export function EventFormModal({ initial, initialDate, initialReminderMinutes = 
 
         {/* 제목 */}
         <input
+          ref={titleInputRef}
           type="text"
           value={title}
           onChange={(e) => setTitle(e.target.value)}
           placeholder="제목"
           className="w-full px-3 py-2.5 rounded-xl border border-stone-200 dark:border-stone-700 bg-stone-50 dark:bg-stone-800 text-stone-800 dark:text-stone-100 placeholder:text-stone-400 focus:outline-none focus:ring-2 focus:ring-orange-400 text-base"
-          autoFocus
         />
 
         {/* 종일 토글 */}


### PR DESCRIPTION
  ## Summary
  - 일정 추가 모달 오픈 시 키보드가 올라오면서 화면이 밀렸다가 돌아오는 어지러운 현상 수정

  ## Problem
  기존 `visualViewport` API 방식은 브라우저가 화면을 밀어 올린 **후** 보정을 적용해서,
  "밀렸다가 돌아오는" 두 단계가 눈에 보이는 문제가 있었음

  ## Solution
  모달 오픈 애니메이션 완료 후(300ms) `focus({ preventScroll: true })` 호출로 교체.
  브라우저가 스크롤 자체를 시도하지 않아 화면이 처음부터 밀리지 않음

  ## Manual Verification
  - [x] 새 일정 추가 시 모달이 열린 후 제목 필드에 커서가 잡히는지 확인
  - [x] 키보드가 올라올 때 화면이 밀리거나 튀는 현상 없는지 확인