### PR TITLE
fix: resolve calendar group save failure due to RLS bootstrap deadlock

### DIFF
--- a/src/__tests__/lib/calendar.test.ts
+++ b/src/__tests__/lib/calendar.test.ts
@@ -64,30 +64,42 @@ describe('getCalendars', () => {
 // ── createCalendar ────────────────────────────────────────
 
 describe('createCalendar', () => {
-  it('생성된 캘린더를 반환한다', async () => {
+  it('생성된 캘린더를 반환한다 (owner 먼저, members 따로)', async () => {
     const mockCal = { id: 'cal-1', name: '가족', color: '#f97316' }
-    // calendars insert → single 반환, calendar_members insert 는 별도 체인
     mockFrom
-      .mockReturnValueOnce(makeChain({ data: mockCal, error: null }))  // calendars
-      .mockReturnValueOnce(makeChain({ data: null, error: null }))      // calendar_members
+      .mockReturnValueOnce(makeChain({ data: mockCal, error: null }))  // calendars insert
+      .mockReturnValueOnce(makeChain({ data: null, error: null }))      // calendar_members: owner
+      .mockReturnValueOnce(makeChain({ data: null, error: null }))      // calendar_members: members
     const result = await createCalendar('fam-1', 'user-1', '가족', '#f97316', ['user-2'])
     expect(result).toEqual(mockCal)
     expect(mockFrom).toHaveBeenCalledWith('calendars')
     expect(mockFrom).toHaveBeenCalledWith('calendar_members')
+    // owner + members = calendar_members 2회 호출
+    expect(mockFrom.mock.calls.filter(([t]) => t === 'calendar_members')).toHaveLength(2)
   })
 
-  it('memberUserIds 없이도 동작한다 (owner만 등록)', async () => {
+  it('memberUserIds 없이도 동작한다 (owner만 등록, members insert 생략)', async () => {
+    const mockCal = { id: 'cal-1', name: '가족', color: '#f97316' }
+    mockFrom
+      .mockReturnValueOnce(makeChain({ data: mockCal, error: null }))  // calendars insert
+      .mockReturnValueOnce(makeChain({ data: null, error: null }))      // calendar_members: owner only
+    const result = await createCalendar('fam-1', 'user-1', '가족', '#f97316')
+    expect(result).toEqual(mockCal)
+    // owner만 = calendar_members 1회 호출
+    expect(mockFrom.mock.calls.filter(([t]) => t === 'calendar_members')).toHaveLength(1)
+  })
+
+  it('calendars insert error가 있으면 throw한다', async () => {
+    mockFrom.mockReturnValueOnce(makeChain({ data: null, error: { message: 'insert error' } }))
+    await expect(createCalendar('fam-1', 'user-1', '가족', '#f97316')).rejects.toEqual({ message: 'insert error' })
+  })
+
+  it('owner insert error가 있으면 throw한다', async () => {
     const mockCal = { id: 'cal-1', name: '가족', color: '#f97316' }
     mockFrom
       .mockReturnValueOnce(makeChain({ data: mockCal, error: null }))
-      .mockReturnValueOnce(makeChain({ data: null, error: null }))
-    const result = await createCalendar('fam-1', 'user-1', '가족', '#f97316')
-    expect(result).toEqual(mockCal)
-  })
-
-  it('error가 있으면 throw한다', async () => {
-    mockFrom.mockReturnValue(makeChain({ data: null, error: { message: 'insert error' } }))
-    await expect(createCalendar('fam-1', 'user-1', '가족', '#f97316')).rejects.toEqual({ message: 'insert error' })
+      .mockReturnValueOnce(makeChain({ data: null, error: { message: 'owner insert error' } }))
+    await expect(createCalendar('fam-1', 'user-1', '가족', '#f97316')).rejects.toEqual({ message: 'owner insert error' })
   })
 })
 

--- a/src/components/calendar/CalendarFormModal.tsx
+++ b/src/components/calendar/CalendarFormModal.tsx
@@ -29,6 +29,7 @@ export function CalendarFormModal({
   const [name, setName] = useState(initial?.name ?? '')
   const [color, setColor] = useState(initial?.color ?? CALENDAR_COLORS[0])
   const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
   const [confirmDelete, setConfirmDelete] = useState(false)
 
   // owner(currentUserId) 제외한 나머지 구성원만 선택 대상
@@ -54,9 +55,13 @@ export function CalendarFormModal({
   const handleSave = async () => {
     if (!name.trim()) return
     setSaving(true)
+    setSaveError(null)
     try {
       await onSave(name.trim(), color, Array.from(selectedIds))
       onClose()
+    } catch (e) {
+      console.error('[CalendarFormModal] save failed:', e)
+      setSaveError('저장에 실패했습니다. 다시 시도해주세요.')
     } finally {
       setSaving(false)
     }
@@ -169,6 +174,9 @@ export function CalendarFormModal({
 
         {/* 저장/삭제 버튼 — 항상 하단 고정 */}
         <div className="px-6 py-4 pb-safe shrink-0 border-t border-stone-100 dark:border-stone-800">
+          {saveError && (
+            <p className="text-xs text-red-500 mb-3 text-center">{saveError}</p>
+          )}
           <div className="flex gap-2">
             {initial && onDelete && (
               confirmDelete ? (

--- a/src/lib/calendar.ts
+++ b/src/lib/calendar.ts
@@ -67,15 +67,22 @@ export async function createCalendar(
     .single()
   if (error) throw error
 
-  // 생성자는 항상 owner, 선택된 멤버는 member로 등록
-  const members = [
-    { calendar_id: data.id, user_id: userId, role: 'owner' as const },
-    ...memberUserIds
-      .filter((id) => id !== userId)
-      .map((id) => ({ calendar_id: data.id, user_id: id, role: 'member' as const })),
-  ]
-  const { error: memberError } = await supabase.from('calendar_members').insert(members)
-  if (memberError) throw memberError
+  // Step 1: 생성자를 owner로 먼저 단독 insert
+  // (bootstrap RLS 정책 케이스 A — owner 레코드가 없는 상태에서 첫 레코드 등록)
+  const { error: ownerError } = await supabase
+    .from('calendar_members')
+    .insert({ calendar_id: data.id, user_id: userId, role: 'owner' })
+  if (ownerError) throw ownerError
+
+  // Step 2: 나머지 멤버 insert
+  // (owner 레코드가 존재하므로 RLS 케이스 B 통과)
+  const newMembers = memberUserIds
+    .filter((id) => id !== userId)
+    .map((id) => ({ calendar_id: data.id, user_id: id, role: 'member' as const }))
+  if (newMembers.length > 0) {
+    const { error: memberError } = await supabase.from('calendar_members').insert(newMembers)
+    if (memberError) throw memberError
+  }
 
   return data
 }

--- a/supabase/migrations/20260404020000_fix_calendar_members_rls_bootstrap.sql
+++ b/supabase/migrations/20260404020000_fix_calendar_members_rls_bootstrap.sql
@@ -1,0 +1,59 @@
+-- ================================================================
+-- calendar_members RLS 재설계
+--
+-- 문제: "calendar owner can manage members" 정책이 FOR ALL + USING만 정의됨.
+--       Postgres는 FOR ALL + USING(expr)을 INSERT의 WITH CHECK로도 사용한다.
+--       신규 캘린더 생성 시 calendar_members에 아직 레코드가 없으므로
+--       owner 자신조차 첫 레코드를 insert할 수 없는 bootstrap 불가 상태 발생.
+--
+-- 해결: PATTERNS.md 컨벤션 — "자식 테이블 WITH CHECK에서 JOIN 서브쿼리 금지,
+--       SECURITY DEFINER 헬퍼 함수 사용"에 따라 재설계
+--       1. get_my_owned_calendar_ids() SECURITY DEFINER 추가
+--       2. FOR ALL 정책 제거 → INSERT / UPDATE / DELETE 역할별 분리
+--       3. INSERT 정책에 bootstrap 케이스(창작자 → owner 등록) 명시
+-- ================================================================
+
+-- 기존 FOR ALL 정책 제거
+drop policy if exists "calendar owner can manage members" on calendar_members;
+
+-- ── SECURITY DEFINER 헬퍼 함수 ──────────────────────────────
+-- 현재 유저가 owner인 캘린더 ID 목록 반환
+-- (기존 get_my_calendar_ids()는 접근 가능한 캘린더 전체를 반환하므로 별도 분리)
+create or replace function get_my_owned_calendar_ids()
+returns setof uuid
+language sql
+security definer
+stable
+as $$
+  select calendar_id from calendar_members
+  where user_id = auth.uid() and role = 'owner'
+$$;
+
+-- ── 역할별 분리 정책 ─────────────────────────────────────────
+
+-- INSERT: 두 가지 경우 허용
+--   케이스 A (bootstrap): 캘린더 생성자가 자신을 owner로 최초 등록
+--   케이스 B (관리):      기존 owner가 다른 멤버를 추가
+create policy "calendar_members_insert"
+  on calendar_members for insert
+  with check (
+    (
+      -- 케이스 A: created_by = 본인인 캘린더에 자신을 owner로 등록
+      user_id = auth.uid()
+      and role = 'owner'
+      and calendar_id in (select id from calendars where created_by = auth.uid())
+    )
+    or
+    -- 케이스 B: 이미 owner인 캘린더에 멤버 추가
+    calendar_id in (select get_my_owned_calendar_ids())
+  );
+
+-- UPDATE: owner만 가능
+create policy "calendar_members_update"
+  on calendar_members for update
+  using (calendar_id in (select get_my_owned_calendar_ids()));
+
+-- DELETE: owner만 가능
+create policy "calendar_members_delete"
+  on calendar_members for delete
+  using (calendar_id in (select get_my_owned_calendar_ids()));


### PR DESCRIPTION
## Summary
- `calendar_members` RLS 정책 재설계: `FOR ALL + USING` → INSERT/UPDATE/DELETE 역할별 분리 + `get_my_owned_calendar_ids()` SECURITY DEFINER 헬퍼 함수 추가
- `createCalendar`에서 owner 먼저 insert → members 별도 insert (RLS 체인 보장)
- `CalendarFormModal`에 `catch` 블록 추가 → 에러 시 "저장에 실패했습니다" 메시지 표시

## Root Cause
신규 캘린더 생성 시 `calendar_members`에 아직 아무 레코드도 없는 상태에서 `FOR ALL + USING` 정책이 INSERT의 `WITH CHECK`로도 사용됨. 결과적으로 owner 자신조차 첫 레코드를 insert할 수 없는 chicken-and-egg 상태 발생. PATTERNS.md의 SECURITY DEFINER 패턴으로 근본 해결.

## Test plan
- [ ] 새 캘린더 생성 → 저장 버튼 클릭 → 정상 저장되는지 확인
- [ ] 기존 캘린더 편집 → 저장 버튼 클릭 → 정상 저장되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)