### PR TITLE
fix: allow calendar creator to select their own calendar after insert

### DIFF
--- a/supabase/migrations/20260404030000_fix_calendars_select_rls.sql
+++ b/supabase/migrations/20260404030000_fix_calendars_select_rls.sql
@@ -1,0 +1,23 @@
+-- ================================================================
+-- calendars SELECT 정책 보완
+--
+-- 문제: createCalendar에서 INSERT 후 .select().single()로 새 행을 조회할 때
+--       SELECT 정책이 `id in (get_my_calendar_ids())`만 허용함.
+--       하지만 이 시점에 calendar_members에 아직 레코드가 없으므로
+--       방금 만든 캘린더가 SELECT에서 보이지 않아 PGRST116 에러 발생.
+--
+-- 해결: 생성자(created_by = auth.uid())는 항상 자신의 캘린더를 볼 수 있도록 정책 확장.
+--       이는 의미적으로도 올바름 — 캘린더를 만든 사람은 항상 볼 수 있어야 함.
+-- ================================================================
+
+drop policy if exists "calendar members can view calendars" on calendars;
+
+create policy "calendar members can view calendars"
+  on calendars for select
+  using (
+    -- 생성자는 멤버 등록 여부와 무관하게 항상 자신의 캘린더를 볼 수 있음
+    created_by = auth.uid()
+    or
+    -- 멤버로 등록된 캘린더도 조회 가능
+    id in (select get_my_calendar_ids())
+  );


### PR DESCRIPTION
## Summary
- `calendars` SELECT 정책에 `created_by = auth.uid()` 조건 추가

## Root Cause
이전 PR(#50)에서 `calendar_members` INSERT bootstrap을 해결했으나, `createCalendar`의 `.insert(...).select().single()` 단계에서 추가 문제 발견.

INSERT 직후 `.select()`로 새 행을 조회할 때 SELECT 정책이 `id in (get_my_calendar_ids())`만 허용하는데, 이 시점에 `calendar_members`에 아직 레코드가 없어 0 rows → PGRST116 에러 발생.

생성자(`created_by = auth.uid()`)는 멤버 등록 여부와 무관하게 항상 자신의 캘린더를 볼 수 있어야 하므로 정책에 조건 추가.

## Test plan
- [ ] 새 캘린더 생성 → 저장 → 캘린더 목록에 정상 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)