### PR TITLE
polish: remove cart emoji from shopping list detail header

### DIFF
--- a/src/app/shopping/[id]/page.tsx
+++ b/src/app/shopping/[id]/page.tsx
@@ -169,7 +169,7 @@ export default function ShoppingDetailPage() {
         </button>
         <div>
           <h1 className="text-xl font-bold text-stone-800 dark:text-stone-100">
-            🛒 {list?.name ?? '장바구니'}
+            {list?.name ?? '장바구니'}
           </h1>
           <p className="text-xs text-stone-400 dark:text-stone-500 mt-0.5">
             {uncheckedItems.length > 0


### PR DESCRIPTION
## Summary
- 장바구니 상세 화면 헤더에서 카트 이모지(🛒) 제거
- 변경 전: `🛒 니토리` → 변경 후: `니토리`

🤖 Generated with [Claude Code](https://claude.com/claude-code)