### PR TITLE
perf: lift useAuth/useFamily to TabsShell to eliminate duplicate API calls on first load

### DIFF
--- a/src/__tests__/components/CalendarTab.test.tsx
+++ b/src/__tests__/components/CalendarTab.test.tsx
@@ -1,13 +1,8 @@
 import { render, act } from '@testing-library/react'
+import type { User } from '@supabase/supabase-js'
 import { CalendarTab } from '@/components/tabs/CalendarTab'
 
 // ── 의존성 모킹 ──────────────────────────────────────────────
-jest.mock('@/hooks/useAuth', () => ({
-  useAuth: () => ({ user: { id: 'user-1' }, loading: false }),
-}))
-jest.mock('@/hooks/useFamily', () => ({
-  useFamily: () => ({ familyId: 'fam-1', loading: false }),
-}))
 jest.mock('@/hooks/useCalendars', () => ({
   useCalendars: () => ({ calendars: [], loading: false, reload: jest.fn() }),
 }))
@@ -71,7 +66,14 @@ jest.mock('@/components/calendar/CalendarListSheet', () => ({
 
 describe('CalendarTab — touch-action 스크롤 차단', () => {
   it('모달이 없을 때 컨테이너에 touch-action: none이 적용된다', async () => {
-    const { container } = render(<CalendarTab preferences={null} />)
+    const { container } = render(
+      <CalendarTab
+        preferences={null}
+        user={{ id: 'user-1' } as User}
+        familyId="fam-1"
+        isInitializing={false}
+      />
+    )
     await act(async () => {})
 
     const wrapper = container.firstChild as HTMLElement

--- a/src/components/TabsShell.tsx
+++ b/src/components/TabsShell.tsx
@@ -1,33 +1,54 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
 import { CalendarTab } from '@/components/tabs/CalendarTab'
 import { ShoppingTab } from '@/components/tabs/ShoppingTab'
 import { SettingsTab } from '@/components/tabs/SettingsTab'
 import { BottomNav } from '@/components/BottomNav'
 import { useAuth } from '@/hooks/useAuth'
+import { useFamily } from '@/hooks/useFamily'
 import { useUserPreferences } from '@/hooks/useUserPreferences'
 
 type Tab = 'calendar' | 'shopping' | 'settings'
 
 export function TabsShell() {
   const [activeTab, setActiveTab] = useState<Tab>('calendar')
-  const { user } = useAuth()
+  const router = useRouter()
+  const { user, loading: authLoading } = useAuth()
+  const { familyId, loading: familyLoading } = useFamily(user)
   const { preferences, updatePreferences } = useUserPreferences(user)
+  const isInitializing = authLoading || familyLoading
+
+  useEffect(() => {
+    if (!authLoading && !user) router.replace('/login')
+  }, [user, authLoading, router])
 
   return (
     <>
       <div style={{ display: activeTab === 'calendar' ? 'contents' : 'none' }}>
-        <CalendarTab preferences={preferences} />
+        <CalendarTab
+          preferences={preferences}
+          user={user}
+          familyId={familyId}
+          isInitializing={isInitializing}
+        />
       </div>
       <div style={{ display: activeTab === 'shopping' ? 'contents' : 'none' }}>
-        <ShoppingTab />
+        <ShoppingTab
+          user={user}
+          familyId={familyId}
+          isInitializing={isInitializing}
+        />
       </div>
       <div style={{ display: activeTab === 'settings' ? 'contents' : 'none' }}>
         <SettingsTab
           onNavigateToTab={setActiveTab}
           preferences={preferences}
           updatePreferences={updatePreferences}
+          user={user}
+          familyId={familyId}
+          isInitializing={isInitializing}
         />
       </div>
       <BottomNav activeTab={activeTab} onTabChange={(tab) => setActiveTab(tab as Tab)} />

--- a/src/components/tabs/CalendarTab.tsx
+++ b/src/components/tabs/CalendarTab.tsx
@@ -2,13 +2,11 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useSwipe } from '@/hooks/useSwipe'
-import { useRouter } from 'next/navigation'
 import { ChevronLeft, ChevronRight, Plus } from 'lucide-react'
-import { useAuth } from '@/hooks/useAuth'
-import { useFamily } from '@/hooks/useFamily'
 import { useCalendars } from '@/hooks/useCalendars'
 import { useHolidays } from '@/hooks/useHolidays'
 import type { UserPreferences } from '@/lib/preferences'
+import type { AuthState } from '@/types/tabs'
 import {
   getEventsByMonth,
   createCalendar,
@@ -36,15 +34,12 @@ import { CalendarFormModal } from '@/components/calendar/CalendarFormModal'
 import { supabase } from '@/lib/supabase'
 import type { Calendar } from '@/lib/calendar'
 
-interface Props {
+interface Props extends AuthState {
   preferences: UserPreferences | null
 }
 
-export function CalendarTab({ preferences }: Props) {
-  const { user, loading: authLoading } = useAuth()
-  const { familyId, loading: familyLoading } = useFamily(user)
+export function CalendarTab({ preferences, user, familyId, isInitializing }: Props) {
   const { calendars, loading: calLoading, reload: reloadCalendars } = useCalendars(familyId)
-  const router = useRouter()
 
   const today = new Date()
   const [year, setYear] = useState(today.getFullYear())
@@ -70,10 +65,6 @@ export function CalendarTab({ preferences }: Props) {
   const [slideDir, setSlideDir] = useState<'left' | 'right' | null>(null)
 
   const isModalOpen = selectedDate !== null || selectedEvent !== null || editingEvent !== null || calendarForm !== null
-
-  useEffect(() => {
-    if (!authLoading && !user) router.replace('/login')
-  }, [user, authLoading, router])
 
   useEffect(() => {
     if (!familyId) return
@@ -230,7 +221,7 @@ export function CalendarTab({ preferences }: Props) {
     setSelectedEvent(null)
   }
 
-  const loading = authLoading || familyLoading || calLoading
+  const loading = isInitializing || calLoading
 
   if (loading) {
     return (

--- a/src/components/tabs/SettingsTab.tsx
+++ b/src/components/tabs/SettingsTab.tsx
@@ -3,11 +3,10 @@
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { LogOut, Share2, Check, Users, Pencil, X } from 'lucide-react'
-import { useAuth } from '@/hooks/useAuth'
-import { useFamily } from '@/hooks/useFamily'
 import { supabase } from '@/lib/supabase'
 import { getMyFamilyMember, updateMyDisplayName } from '@/lib/family'
 import type { UserPreferences } from '@/lib/preferences'
+import type { AuthState } from '@/types/tabs'
 
 const SUPPORTED_HOLIDAY_COUNTRIES = [
   { code: 'KR', label: '🇰🇷 한국' },
@@ -15,15 +14,13 @@ const SUPPORTED_HOLIDAY_COUNTRIES = [
   { code: 'US', label: '🇺🇸 미국' },
 ]
 
-interface Props {
+interface Props extends AuthState {
   onNavigateToTab: (tab: 'calendar' | 'shopping' | 'settings') => void
   preferences: UserPreferences | null
   updatePreferences: (updates: Partial<Omit<UserPreferences, 'user_id' | 'created_at' | 'updated_at'>>) => Promise<void>
 }
 
-export function SettingsTab({ onNavigateToTab, preferences, updatePreferences }: Props) {
-  const { user, loading: authLoading } = useAuth()
-  const { familyId, loading: familyLoading } = useFamily(user)
+export function SettingsTab({ onNavigateToTab, preferences, updatePreferences, user, familyId, isInitializing }: Props) {
   const router = useRouter()
 
   const [inviteCode, setInviteCode] = useState<string | null>(null)
@@ -40,12 +37,6 @@ export function SettingsTab({ onNavigateToTab, preferences, updatePreferences }:
   const [editingName, setEditingName] = useState(false)
   const [nameInput, setNameInput] = useState('')
   const [savingName, setSavingName] = useState(false)
-
-  useEffect(() => {
-    if (!authLoading && !user) {
-      router.replace('/login')
-    }
-  }, [user, authLoading, router])
 
   useEffect(() => {
     if (!familyId) return
@@ -129,7 +120,7 @@ export function SettingsTab({ onNavigateToTab, preferences, updatePreferences }:
     router.replace('/login')
   }
 
-  if (authLoading || familyLoading) {
+  if (isInitializing) {
     return (
       <div className="flex items-center justify-center min-h-screen">
         <div className="w-8 h-8 rounded-full border-2 border-orange-300 border-t-orange-500 animate-spin" />

--- a/src/components/tabs/ShoppingTab.tsx
+++ b/src/components/tabs/ShoppingTab.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { useEffect, useRef, useState } from 'react'
-import { useRouter } from 'next/navigation'
 import { Plus, ShoppingCart, AlertTriangle } from 'lucide-react'
 import {
   DndContext,
@@ -12,8 +11,7 @@ import {
   type DragEndEvent,
 } from '@dnd-kit/core'
 import { SortableContext, arrayMove, rectSortingStrategy } from '@dnd-kit/sortable'
-import { useAuth } from '@/hooks/useAuth'
-import { useFamily } from '@/hooks/useFamily'
+import type { AuthState } from '@/types/tabs'
 import {
   getShoppingListsWithPreviews,
   createShoppingList,
@@ -26,21 +24,15 @@ import { CreateListModal } from '@/components/shopping/CreateListModal'
 import { supabase } from '@/lib/supabase'
 import type { ShoppingListWithPreview, ListType } from '@/lib/shopping'
 
-export function ShoppingTab() {
-  const { user, loading: authLoading } = useAuth()
-  const { familyId, loading: familyLoading } = useFamily(user)
-  const router = useRouter()
+type Props = AuthState
 
-  useEffect(() => {
-    if (!authLoading && !user) router.replace('/login')
-  }, [user, authLoading, router])
-
+export function ShoppingTab({ user, familyId, isInitializing }: Props) {
   const [lists, setLists] = useState<ShoppingListWithPreview[]>([])
   const [fetchError, setFetchError] = useState(false)
   const [showModal, setShowModal] = useState(false)
   const channelRef = useRef<ReturnType<typeof supabase.channel> | null>(null)
 
-  const loading = authLoading || familyLoading
+  const loading = isInitializing
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),

--- a/src/types/tabs.ts
+++ b/src/types/tabs.ts
@@ -1,0 +1,7 @@
+import type { User } from '@supabase/supabase-js'
+
+export interface AuthState {
+  user: User | null
+  familyId: string | null
+  isInitializing: boolean
+}


### PR DESCRIPTION
## Summary

- `useAuth` 호출을 4회 → 1회로, `POST /api/family` 호출을 3회 → 1회로 줄여 첫 로드 시 중복 API 요청 제거
- auth redirect 로직을 각 탭에서 TabsShell로 통합
- `authLoading || familyLoading` 반복 계산을 `isInitializing` 단일 prop으로 정리
- 공유 타입 `AuthState`를 `src/types/tabs.ts`로 추출해 Props 중복 제거

## Test plan

- [x] 앱 첫 접속 시 로딩 속도가 개선되었는지 확인
- [x] 캘린더 → 장바구니 → 설정 탭 전환이 정상 동작하는지 확인
- [x] 로그아웃 후 `/login`으로 리다이렉트되는지 확인
- [x] 미로그인 상태에서 직접 접근 시 `/login`으로 리다이렉트되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)