### PR TITLE
feat: show time range and memo preview in DayEventsSheet

### DIFF
--- a/src/__tests__/components/DayEventsSheet.test.tsx
+++ b/src/__tests__/components/DayEventsSheet.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { DayEventsSheet } from '@/components/calendar/DayEventsSheet'
+import type { Calendar, CalendarEvent } from '@/lib/calendar'
+
+const calendars: Calendar[] = [
+  { id: 'cal-1', family_id: 'fam-1', created_by: 'user-1', name: 'JGBB', color: '#22c55e', created_at: '', updated_at: '' },
+]
+
+function makeEvent(overrides: Partial<CalendarEvent> = {}): CalendarEvent {
+  return {
+    id: 'evt-1',
+    family_id: 'fam-1',
+    calendar_id: 'cal-1',
+    created_by: 'user-1',
+    created_at: '',
+    updated_at: '',
+    title: '테스트 일정',
+    description: null,
+    start_at: '2026-04-13T09:00:00',
+    end_at: null,
+    is_all_day: false,
+    ...overrides,
+  }
+}
+
+const defaultProps = {
+  date: new Date('2026-04-13'),
+  calendars,
+  onClose: jest.fn(),
+  onSelectEvent: jest.fn(),
+  onAddEvent: jest.fn(),
+}
+
+describe('DayEventsSheet', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('종일 일정은 "종일"로 표시된다', () => {
+    render(<DayEventsSheet {...defaultProps} events={[makeEvent({ is_all_day: true })]} />)
+    expect(screen.getByText(/종일/)).toBeInTheDocument()
+  })
+
+  it('end_at이 없는 비종일 일정은 시작시간만 표시된다', () => {
+    render(<DayEventsSheet {...defaultProps} events={[makeEvent({ end_at: null })]} />)
+    expect(screen.getByText(/09:00/)).toBeInTheDocument()
+    expect(screen.queryByText(/~/)).not.toBeInTheDocument()
+  })
+
+  it('end_at이 있는 비종일 일정은 시작~종료 형식으로 표시된다', () => {
+    render(
+      <DayEventsSheet
+        {...defaultProps}
+        events={[makeEvent({ end_at: '2026-04-13T10:30:00' })]}
+      />
+    )
+    expect(screen.getByText(/09:00~10:30/)).toBeInTheDocument()
+  })
+
+  it('description이 있으면 미리보기가 렌더링된다', () => {
+    render(
+      <DayEventsSheet
+        {...defaultProps}
+        events={[makeEvent({ description: '회의 준비물 챙기기' })]}
+      />
+    )
+    expect(screen.getByText('회의 준비물 챙기기')).toBeInTheDocument()
+  })
+
+  it('description이 null이면 미리보기가 렌더링되지 않는다', () => {
+    render(<DayEventsSheet {...defaultProps} events={[makeEvent({ description: null })]} />)
+    // title만 있고 description 관련 요소 없음
+    expect(screen.getByText('테스트 일정')).toBeInTheDocument()
+    expect(screen.queryByText('회의')).not.toBeInTheDocument()
+  })
+
+  it('해당 날짜의 일정이 없으면 빈 상태 메시지를 표시한다', () => {
+    render(<DayEventsSheet {...defaultProps} events={[]} />)
+    expect(screen.getByText('이 날의 일정이 없어요')).toBeInTheDocument()
+  })
+
+  it('닫기 버튼 클릭 시 onClose가 호출된다', () => {
+    render(<DayEventsSheet {...defaultProps} events={[]} />)
+    const closeBtn = screen.getByRole('button', { name: '' })
+    // X 버튼은 lucide icon만 있음 — 마지막 버튼
+    const buttons = screen.getAllByRole('button')
+    fireEvent.click(buttons[buttons.length - 1])
+    expect(defaultProps.onClose).toHaveBeenCalled()
+  })
+
+  it('일정 클릭 시 onSelectEvent가 호출된다', () => {
+    const evt = makeEvent()
+    render(<DayEventsSheet {...defaultProps} events={[evt]} />)
+    fireEvent.click(screen.getByText('테스트 일정'))
+    expect(defaultProps.onSelectEvent).toHaveBeenCalledWith(evt)
+  })
+
+  it('일정 추가 버튼 클릭 시 onAddEvent가 호출된다', () => {
+    render(<DayEventsSheet {...defaultProps} events={[]} />)
+    fireEvent.click(screen.getByText('일정 추가'))
+    expect(defaultProps.onAddEvent).toHaveBeenCalled()
+  })
+})

--- a/src/components/calendar/DayEventsSheet.tsx
+++ b/src/components/calendar/DayEventsSheet.tsx
@@ -3,10 +3,15 @@
 import { Plus, X } from 'lucide-react'
 import type { Calendar, CalendarEvent } from '@/lib/calendar'
 
-function formatTime(isoString: string, isAllDay: boolean): string {
+function formatHHMM(isoString: string): string {
+  return new Date(isoString).toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit', hour12: false })
+}
+
+function formatTimeRange(startAt: string, endAt: string | null, isAllDay: boolean): string {
   if (isAllDay) return '종일'
-  const d = new Date(isoString)
-  return d.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit', hour12: false })
+  const start = formatHHMM(startAt)
+  if (!endAt) return start
+  return `${start}~${formatHHMM(endAt)}`
 }
 
 function formatDate(date: Date): string {
@@ -87,10 +92,15 @@ export function DayEventsSheet({ date, events, calendars, onClose, onSelectEvent
                       <p className="text-sm font-medium text-stone-800 dark:text-stone-100 truncate">
                         {evt.title}
                       </p>
-                      <p className="text-xs text-stone-400 mt-0.5">
-                        {formatTime(evt.start_at, evt.is_all_day)}
+                      <p className="text-xs text-stone-400 mt-0.5 tabular-nums">
+                        {formatTimeRange(evt.start_at, evt.end_at, evt.is_all_day)}
                         {cal && <span className="ml-2">{cal.name}</span>}
                       </p>
+                      {evt.description && (
+                        <p className="text-xs text-stone-500 dark:text-stone-400 mt-1 line-clamp-2 leading-relaxed">
+                          {evt.description}
+                        </p>
+                      )}
                     </div>
                   </button>
                 )


### PR DESCRIPTION
## Summary

- 날짜 클릭 시 나오는 일정 리스트에서 종일이 아닌 일정의 시간 표시를 `09:00` → `09:00~10:30` 형식으로 변경
- 일정에 메모(`description`)가 있는 경우 카드에서 최대 2줄 미리보기 표시
- 시간 숫자에 `tabular-nums` 적용으로 자릿수 정렬 일관성 확보
- 메모 미리보기 색상을 메타데이터(시간/캘린더명)와 시각적으로 구분

## Test plan

- [x] 종일이 아닌 일정에서 시작~종료 시간이 올바르게 표시되는지 확인
- [x] `end_at`이 없는 일정은 시작 시간만 표시되는지 확인
- [x] 메모가 있는 일정 카드에 미리보기 텍스트가 2줄 이내로 잘리는지 확인
- [x] 메모가 없는 일정 카드에 미리보기 영역이 표시되지 않는지 확인
- [x] 라이트/다크 모드 양쪽에서 색상 계층이 의도대로 보이는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)