### PR TITLE
feat: add app-wide color theme selector in settings

### DIFF
--- a/src/__tests__/components/BottomNav.test.tsx
+++ b/src/__tests__/components/BottomNav.test.tsx
@@ -20,28 +20,28 @@ describe('BottomNav', () => {
     mockUsePathname.mockReturnValue('/shopping')
     render(<BottomNav />)
     const shoppingLink = screen.getByText('장바구니').closest('a')
-    expect(shoppingLink).toHaveClass('text-orange-500')
+    expect(shoppingLink).toHaveClass('text-accent-500')
   })
 
   it('/shopping/list-1 경로에서도 장바구니 탭이 활성화된다', () => {
     mockUsePathname.mockReturnValue('/shopping/list-1')
     render(<BottomNav />)
     const shoppingLink = screen.getByText('장바구니').closest('a')
-    expect(shoppingLink).toHaveClass('text-orange-500')
+    expect(shoppingLink).toHaveClass('text-accent-500')
   })
 
   it('/settings 경로에서 설정 탭이 활성화된다', () => {
     mockUsePathname.mockReturnValue('/settings')
     render(<BottomNav />)
     const settingsLink = screen.getByText('설정').closest('a')
-    expect(settingsLink).toHaveClass('text-orange-500')
+    expect(settingsLink).toHaveClass('text-accent-500')
   })
 
   it('활성화되지 않은 탭은 기본 색상이다', () => {
     mockUsePathname.mockReturnValue('/shopping')
     render(<BottomNav />)
     const settingsLink = screen.getByText('설정').closest('a')
-    expect(settingsLink).not.toHaveClass('text-orange-500')
+    expect(settingsLink).not.toHaveClass('text-accent-500')
   })
 
   it('링크의 href가 올바르다', () => {

--- a/src/__tests__/hooks/useUserPreferences.test.ts
+++ b/src/__tests__/hooks/useUserPreferences.test.ts
@@ -33,6 +33,7 @@ describe('useUserPreferences', () => {
     const mockData = {
       user_id: 'user-1',
       holiday_countries: ['KR', 'JP'],
+      app_theme: 'tangerine',
       created_at: '',
       updated_at: '',
     }
@@ -65,6 +66,7 @@ describe('useUserPreferences', () => {
     const updated = {
       user_id: 'user-1',
       holiday_countries: ['KR'],
+      app_theme: 'tangerine',
       created_at: '',
       updated_at: '',
     }

--- a/src/__tests__/lib/preferences.test.ts
+++ b/src/__tests__/lib/preferences.test.ts
@@ -31,6 +31,7 @@ describe('getUserPreferences', () => {
     const mockData = {
       user_id: 'user-1',
       holiday_countries: ['KR', 'JP'],
+      app_theme: 'tangerine',
       created_at: '',
       updated_at: '',
     }
@@ -59,6 +60,7 @@ describe('upsertUserPreferences', () => {
     const mockData = {
       user_id: 'user-1',
       holiday_countries: ['KR'],
+      app_theme: 'tangerine',
       created_at: '',
       updated_at: '',
     }
@@ -66,6 +68,19 @@ describe('upsertUserPreferences', () => {
     const result = await upsertUserPreferences('user-1', { holiday_countries: ['KR'] })
     expect(result).toEqual(mockData)
     expect(mockFrom).toHaveBeenCalledWith('user_preferences')
+  })
+
+  it('app_theme을 저장하고 반환한다', async () => {
+    const mockData = {
+      user_id: 'user-1',
+      holiday_countries: [],
+      app_theme: 'ocean',
+      created_at: '',
+      updated_at: '',
+    }
+    mockFrom.mockReturnValue(makeChain({ data: mockData, error: null }))
+    const result = await upsertUserPreferences('user-1', { app_theme: 'ocean' })
+    expect(result.app_theme).toBe('ocean')
   })
 
   it('error가 있으면 throw한다', async () => {

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -61,7 +61,7 @@ function AuthCallbackInner() {
 
   return (
     <div className="flex items-center justify-center min-h-screen">
-      <div className="w-8 h-8 rounded-full border-2 border-orange-300 border-t-orange-500 animate-spin" />
+      <div className="w-8 h-8 rounded-full border-2 border-accent-300 border-t-accent-500 animate-spin" />
     </div>
   )
 }
@@ -70,7 +70,7 @@ export default function AuthCallbackPage() {
   return (
     <Suspense fallback={
       <div className="flex items-center justify-center min-h-screen">
-        <div className="w-8 h-8 rounded-full border-2 border-orange-300 border-t-orange-500 animate-spin" />
+        <div className="w-8 h-8 rounded-full border-2 border-accent-300 border-t-accent-500 animate-spin" />
       </div>
     }>
       <AuthCallbackInner />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,6 +5,17 @@
 :root {
   --background: #fafaf9;
   --foreground: #1c1917;
+
+  /* Default theme: tangerine (orange) */
+  --accent-50: #fff7ed;
+  --accent-100: #ffedd5;
+  --accent-200: #fed7aa;
+  --accent-300: #fdba74;
+  --accent-400: #fb923c;
+  --accent-500: #f97316;
+  --accent-600: #ea580c;
+  --accent-700: #c2410c;
+  --accent-950: #431407;
 }
 
 .dark {
@@ -12,11 +23,87 @@
   --foreground: #f5f4f2;
 }
 
+/* Theme: sage (teal) */
+[data-theme="sage"] {
+  --accent-50: #f0fdfa;
+  --accent-100: #ccfbf1;
+  --accent-200: #99f6e4;
+  --accent-300: #5eead4;
+  --accent-400: #2dd4bf;
+  --accent-500: #14b8a6;
+  --accent-600: #0d9488;
+  --accent-700: #0f766e;
+  --accent-950: #042f2e;
+}
+
+/* Theme: ocean (sky blue) */
+[data-theme="ocean"] {
+  --accent-50: #f0f9ff;
+  --accent-100: #e0f2fe;
+  --accent-200: #bae6fd;
+  --accent-300: #7dd3fc;
+  --accent-400: #38bdf8;
+  --accent-500: #0ea5e9;
+  --accent-600: #0284c7;
+  --accent-700: #0369a1;
+  --accent-950: #082f49;
+}
+
+/* Theme: rose (pink) */
+[data-theme="rose"] {
+  --accent-50: #fff1f2;
+  --accent-100: #ffe4e6;
+  --accent-200: #fecdd3;
+  --accent-300: #fda4af;
+  --accent-400: #fb7185;
+  --accent-500: #f43f5e;
+  --accent-600: #e11d48;
+  --accent-700: #be123c;
+  --accent-950: #4c0519;
+}
+
+/* Theme: violet (purple) */
+[data-theme="violet"] {
+  --accent-50: #f5f3ff;
+  --accent-100: #ede9fe;
+  --accent-200: #ddd6fe;
+  --accent-300: #c4b5fd;
+  --accent-400: #a78bfa;
+  --accent-500: #8b5cf6;
+  --accent-600: #7c3aed;
+  --accent-700: #6d28d9;
+  --accent-950: #2e1065;
+}
+
+/* Theme: denim (indigo) */
+[data-theme="denim"] {
+  --accent-50: #eef2ff;
+  --accent-100: #e0e7ff;
+  --accent-200: #c7d2fe;
+  --accent-300: #a5b4fc;
+  --accent-400: #818cf8;
+  --accent-500: #6366f1;
+  --accent-600: #4f46e5;
+  --accent-700: #4338ca;
+  --accent-950: #1e1b4b;
+}
+
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --font-sans: 'Pretendard JP', 'Pretendard Variable', -apple-system, BlinkMacSystemFont, sans-serif;
   --font-mono: ui-monospace, 'SF Mono', Menlo, monospace;
+
+  /* Accent color scale — theme-aware via CSS variables */
+  --color-accent-50: var(--accent-50);
+  --color-accent-100: var(--accent-100);
+  --color-accent-200: var(--accent-200);
+  --color-accent-300: var(--accent-300);
+  --color-accent-400: var(--accent-400);
+  --color-accent-500: var(--accent-500);
+  --color-accent-600: var(--accent-600);
+  --color-accent-700: var(--accent-700);
+  --color-accent-950: var(--accent-950);
 }
 
 body {

--- a/src/app/join/page.tsx
+++ b/src/app/join/page.tsx
@@ -47,7 +47,7 @@ function JoinInner() {
   if (authLoading || familyLoading) {
     return (
       <div className="flex items-center justify-center min-h-screen">
-        <div className="w-8 h-8 rounded-full border-2 border-orange-300 border-t-orange-500 animate-spin" />
+        <div className="w-8 h-8 rounded-full border-2 border-accent-300 border-t-accent-500 animate-spin" />
       </div>
     )
   }
@@ -56,8 +56,8 @@ function JoinInner() {
     <div className="max-w-lg mx-auto px-4 min-h-screen flex flex-col items-center justify-center">
       <div className="w-full">
         <div className="text-center mb-8">
-          <div className="inline-flex items-center justify-center w-16 h-16 rounded-2xl bg-orange-50 dark:bg-orange-950/40 mb-4">
-            <Users size={32} className="text-orange-400" />
+          <div className="inline-flex items-center justify-center w-16 h-16 rounded-2xl bg-accent-50 dark:bg-accent-950/40 mb-4">
+            <Users size={32} className="text-accent-400" />
           </div>
           <h1 className="text-2xl font-bold text-stone-800 dark:text-stone-100">가족에 합류하기</h1>
           <p className="text-sm text-stone-400 dark:text-stone-500 mt-2">초대 코드를 확인하고 합류하세요</p>
@@ -72,13 +72,13 @@ function JoinInner() {
             onChange={(e) => setJoinCode(e.target.value.toUpperCase())}
             placeholder="ABC123"
             maxLength={6}
-            className="w-full px-4 py-3 rounded-xl border border-stone-200 dark:border-stone-700 bg-stone-50 dark:bg-stone-800 text-stone-800 dark:text-stone-100 font-mono tracking-widest text-xl text-center focus:outline-none focus:ring-2 focus:ring-orange-300 mb-4"
+            className="w-full px-4 py-3 rounded-xl border border-stone-200 dark:border-stone-700 bg-stone-50 dark:bg-stone-800 text-stone-800 dark:text-stone-100 font-mono tracking-widest text-xl text-center focus:outline-none focus:ring-2 focus:ring-accent-300 mb-4"
           />
           {error && <p className="text-xs text-red-400 mb-3">{error}</p>}
           <button
             onClick={handleJoin}
             disabled={joining || joinCode.length < 6}
-            className="w-full py-3 rounded-xl bg-orange-400 hover:bg-orange-500 disabled:opacity-50 text-white font-bold text-base transition-colors shadow-sm"
+            className="w-full py-3 rounded-xl bg-accent-400 hover:bg-accent-500 disabled:opacity-50 text-white font-bold text-base transition-colors shadow-sm"
           >
             {joining ? '합류 중...' : '가족에 합류하기'}
           </button>
@@ -95,7 +95,7 @@ export default function JoinPage() {
   return (
     <Suspense fallback={
       <div className="flex items-center justify-center min-h-screen">
-        <div className="w-8 h-8 rounded-full border-2 border-orange-300 border-t-orange-500 animate-spin" />
+        <div className="w-8 h-8 rounded-full border-2 border-accent-300 border-t-accent-500 animate-spin" />
       </div>
     }>
       <JoinInner />

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -30,7 +30,7 @@ function LoginInner() {
   if (loading) {
     return (
       <div className="flex items-center justify-center min-h-screen">
-        <div className="w-8 h-8 rounded-full border-2 border-orange-300 border-t-orange-500 animate-spin" />
+        <div className="w-8 h-8 rounded-full border-2 border-accent-300 border-t-accent-500 animate-spin" />
       </div>
     )
   }
@@ -71,7 +71,7 @@ export default function LoginPage() {
   return (
     <Suspense fallback={
       <div className="flex items-center justify-center min-h-screen">
-        <div className="w-8 h-8 rounded-full border-2 border-orange-300 border-t-orange-500 animate-spin" />
+        <div className="w-8 h-8 rounded-full border-2 border-accent-300 border-t-accent-500 animate-spin" />
       </div>
     }>
       <LoginInner />

--- a/src/app/shopping/[id]/page.tsx
+++ b/src/app/shopping/[id]/page.tsx
@@ -152,7 +152,7 @@ export default function ShoppingDetailPage() {
   if (authLoading || loading) {
     return (
       <div className="flex items-center justify-center min-h-screen">
-        <div className="w-8 h-8 rounded-full border-2 border-orange-300 border-t-orange-500 animate-spin" />
+        <div className="w-8 h-8 rounded-full border-2 border-accent-300 border-t-accent-500 animate-spin" />
       </div>
     )
   }

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -29,7 +29,7 @@ export function BottomNav({ activeTab, onTabChange }: Props) {
             : pathname.startsWith(href)
           const className = `flex-1 flex flex-col items-center gap-1 py-3 text-xs font-medium transition-colors ${
             active
-              ? 'text-orange-500'
+              ? 'text-accent-500'
               : 'text-stone-400 dark:text-stone-500 hover:text-stone-600 dark:hover:text-stone-300'
           }`
           return tabMode ? (

--- a/src/components/TabsShell.tsx
+++ b/src/components/TabsShell.tsx
@@ -9,6 +9,7 @@ import { BottomNav } from '@/components/BottomNav'
 import { useAuth } from '@/hooks/useAuth'
 import { useFamily } from '@/hooks/useFamily'
 import { useUserPreferences } from '@/hooks/useUserPreferences'
+import { DEFAULT_THEME } from '@/lib/preferences'
 
 type Tab = 'calendar' | 'shopping' | 'settings'
 
@@ -23,6 +24,10 @@ export function TabsShell() {
   useEffect(() => {
     if (!authLoading && !user) router.replace('/login')
   }, [user, authLoading, router])
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', preferences?.app_theme ?? DEFAULT_THEME)
+  }, [preferences?.app_theme])
 
   return (
     <>

--- a/src/components/calendar/CalendarFormModal.tsx
+++ b/src/components/calendar/CalendarFormModal.tsx
@@ -106,7 +106,7 @@ export function CalendarFormModal({
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder="캘린더 이름"
-              className="w-full px-3 py-2.5 rounded-xl border border-stone-200 dark:border-stone-700 bg-stone-50 dark:bg-stone-800 text-stone-800 dark:text-stone-100 placeholder:text-stone-400 focus:outline-none focus:ring-2 focus:ring-orange-400 text-base"
+              className="w-full px-3 py-2.5 rounded-xl border border-stone-200 dark:border-stone-700 bg-stone-50 dark:bg-stone-800 text-stone-800 dark:text-stone-100 placeholder:text-stone-400 focus:outline-none focus:ring-2 focus:ring-accent-400 text-base"
               autoFocus
             />
           </div>
@@ -148,14 +148,14 @@ export function CalendarFormModal({
                       onClick={() => toggleMember(member.user_id)}
                       className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-xl border transition-colors ${
                         selected
-                          ? 'border-orange-300 bg-orange-50 dark:bg-orange-950/30 dark:border-orange-700'
+                          ? 'border-accent-300 bg-accent-50 dark:bg-accent-950/30 dark:border-accent-700'
                           : 'border-stone-200 dark:border-stone-700 bg-stone-50 dark:bg-stone-800'
                       }`}
                     >
                       <div
                         className={`w-5 h-5 rounded-full border-2 flex items-center justify-center shrink-0 transition-colors ${
                           selected
-                            ? 'border-orange-400 bg-orange-400'
+                            ? 'border-accent-400 bg-accent-400'
                             : 'border-stone-300 dark:border-stone-600'
                         }`}
                       >
@@ -199,7 +199,7 @@ export function CalendarFormModal({
             <button
               onClick={handleSave}
               disabled={!name.trim() || saving}
-              className="flex-1 py-2.5 rounded-xl bg-orange-400 hover:bg-orange-500 disabled:opacity-40 text-white font-semibold text-sm transition-colors"
+              className="flex-1 py-2.5 rounded-xl bg-accent-400 hover:bg-accent-500 disabled:opacity-40 text-white font-semibold text-sm transition-colors"
             >
               저장
             </button>

--- a/src/components/calendar/CalendarGrid.tsx
+++ b/src/components/calendar/CalendarGrid.tsx
@@ -110,7 +110,7 @@ export function CalendarGrid({ year, month, events, calendars, activeIds, holida
               onClick={() => onSelectDate(cell.date)}
               className={`relative flex flex-col items-start p-0.5 border-t transition-colors ${
                 isSelected
-                  ? 'bg-orange-50 dark:bg-orange-950/30'
+                  ? 'bg-accent-50 dark:bg-accent-950/30'
                   : 'hover:bg-stone-50 dark:hover:bg-stone-800/50'
               } border-stone-100 dark:border-stone-800`}
             >
@@ -118,9 +118,9 @@ export function CalendarGrid({ year, month, events, calendars, activeIds, holida
               <span
                 className={`text-xs font-medium w-6 h-6 flex items-center justify-center rounded-full mx-auto mb-0.5 ${
                   isToday
-                    ? 'bg-orange-400 text-white font-bold'
+                    ? 'bg-accent-400 text-white font-bold'
                     : isSelected
-                    ? 'underline underline-offset-2 decoration-orange-400 font-bold ' + (
+                    ? 'underline underline-offset-2 decoration-accent-400 font-bold ' + (
                         !cell.isCurrentMonth ? 'text-stone-300 dark:text-stone-600'
                         : isSun ? 'text-red-400'
                         : isSat ? 'text-blue-400'

--- a/src/components/calendar/EventFormModal.tsx
+++ b/src/components/calendar/EventFormModal.tsx
@@ -198,7 +198,7 @@ export function EventFormModal({ initial, initialDate, initialReminderMinutes = 
   const timeBtnCls = (active: boolean) =>
     `w-24 px-3 py-2.5 rounded-xl text-sm font-semibold text-center transition-colors shrink-0 ${
       active
-        ? 'bg-orange-400 text-white'
+        ? 'bg-accent-400 text-white'
         : 'bg-stone-100 dark:bg-stone-800 text-stone-700 dark:text-stone-200'
     }`
 
@@ -244,7 +244,7 @@ export function EventFormModal({ initial, initialDate, initialReminderMinutes = 
           value={title}
           onChange={(e) => setTitle(e.target.value)}
           placeholder="제목"
-          className="w-full px-3 py-2.5 rounded-xl border border-stone-200 dark:border-stone-700 bg-stone-50 dark:bg-stone-800 text-stone-800 dark:text-stone-100 placeholder:text-stone-400 focus:outline-none focus:ring-2 focus:ring-orange-400 text-base"
+          className="w-full px-3 py-2.5 rounded-xl border border-stone-200 dark:border-stone-700 bg-stone-50 dark:bg-stone-800 text-stone-800 dark:text-stone-100 placeholder:text-stone-400 focus:outline-none focus:ring-2 focus:ring-accent-400 text-base"
         />
 
         {/* 종일 토글 */}
@@ -252,7 +252,7 @@ export function EventFormModal({ initial, initialDate, initialReminderMinutes = 
           <span className="text-sm text-stone-600 dark:text-stone-300">종일</span>
           <button
             onClick={() => toggleAllDay(!isAllDay)}
-            className={`relative w-11 h-6 rounded-full transition-colors ${isAllDay ? 'bg-orange-400' : 'bg-stone-200 dark:bg-stone-700'}`}
+            className={`relative w-11 h-6 rounded-full transition-colors ${isAllDay ? 'bg-accent-400' : 'bg-stone-200 dark:bg-stone-700'}`}
           >
             <span
               className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full shadow transition-transform ${isAllDay ? 'translate-x-5' : 'translate-x-0'}`}
@@ -335,7 +335,7 @@ export function EventFormModal({ initial, initialDate, initialReminderMinutes = 
           onChange={(e) => setDescription(e.target.value)}
           placeholder="메모 (선택)"
           rows={2}
-          className="w-full px-3 py-2.5 rounded-xl border border-stone-200 dark:border-stone-700 bg-stone-50 dark:bg-stone-800 text-stone-800 dark:text-stone-100 placeholder:text-stone-400 focus:outline-none focus:ring-2 focus:ring-orange-400 text-base resize-none"
+          className="w-full px-3 py-2.5 rounded-xl border border-stone-200 dark:border-stone-700 bg-stone-50 dark:bg-stone-800 text-stone-800 dark:text-stone-100 placeholder:text-stone-400 focus:outline-none focus:ring-2 focus:ring-accent-400 text-base resize-none"
         />
 
         {/* 알림 */}
@@ -353,7 +353,7 @@ export function EventFormModal({ initial, initialDate, initialReminderMinutes = 
                   onClick={() => toggleReminder(opt.minutes)}
                   className={`px-2.5 py-1 rounded-full text-xs font-medium border transition-colors ${
                     active
-                      ? 'bg-orange-400 border-orange-400 text-white'
+                      ? 'bg-accent-400 border-accent-400 text-white'
                       : 'border-stone-200 dark:border-stone-700 text-stone-500 dark:text-stone-400'
                   }`}
                 >
@@ -373,7 +373,7 @@ export function EventFormModal({ initial, initialDate, initialReminderMinutes = 
         <button
           onClick={handleSave}
           disabled={!title.trim() || !startDate || saving}
-          className="w-full py-3 rounded-xl bg-orange-400 hover:bg-orange-500 disabled:opacity-40 text-white font-semibold text-sm transition-colors"
+          className="w-full py-3 rounded-xl bg-accent-400 hover:bg-accent-500 disabled:opacity-40 text-white font-semibold text-sm transition-colors"
         >
           저장
         </button>

--- a/src/components/calendar/TimeWheelPicker.tsx
+++ b/src/components/calendar/TimeWheelPicker.tsx
@@ -46,7 +46,7 @@ function WheelCol({ values, selected, onSelect }: ColProps) {
   return (
     <div className="relative flex-1">
       <div
-        className="pointer-events-none absolute inset-x-0 bg-orange-50 dark:bg-orange-950/30 rounded-xl z-10"
+        className="pointer-events-none absolute inset-x-0 bg-accent-50 dark:bg-accent-950/30 rounded-xl z-10"
         style={{ top: ITEM_H * 2, height: ITEM_H }}
       />
       <div

--- a/src/components/shopping/AddItemInput.tsx
+++ b/src/components/shopping/AddItemInput.tsx
@@ -27,12 +27,12 @@ export function AddItemInput({ onAdd }: Props) {
         value={value}
         onChange={(e) => setValue(e.target.value)}
         placeholder="아이템 추가..."
-        className="flex-1 px-4 py-2.5 rounded-xl border border-stone-200 dark:border-stone-700 bg-stone-50 dark:bg-stone-800 text-stone-900 dark:text-stone-100 placeholder-stone-400 focus:outline-none focus:ring-2 focus:ring-orange-300 dark:focus:ring-orange-500 transition text-sm"
+        className="flex-1 px-4 py-2.5 rounded-xl border border-stone-200 dark:border-stone-700 bg-stone-50 dark:bg-stone-800 text-stone-900 dark:text-stone-100 placeholder-stone-400 focus:outline-none focus:ring-2 focus:ring-accent-300 dark:focus:ring-accent-500 transition text-sm"
       />
       <button
         type="submit"
         disabled={!value.trim() || loading}
-        className="p-2.5 rounded-xl bg-orange-400 hover:bg-orange-500 disabled:bg-stone-200 dark:disabled:bg-stone-700 text-white disabled:text-stone-400 transition-colors flex-shrink-0"
+        className="p-2.5 rounded-xl bg-accent-400 hover:bg-accent-500 disabled:bg-stone-200 dark:disabled:bg-stone-700 text-white disabled:text-stone-400 transition-colors flex-shrink-0"
         aria-label="추가"
       >
         <Plus size={20} />

--- a/src/components/shopping/CreateListModal.tsx
+++ b/src/components/shopping/CreateListModal.tsx
@@ -47,7 +47,7 @@ export function CreateListModal({ onClose, onCreate }: Props) {
               onChange={(e) => setName(e.target.value)}
               placeholder="예: 이마트, 코스트코"
               autoFocus
-              className="w-full px-4 py-2.5 rounded-xl border border-stone-200 dark:border-stone-700 bg-stone-50 dark:bg-stone-800 text-stone-900 dark:text-stone-100 placeholder-stone-400 focus:outline-none focus:ring-2 focus:ring-orange-300 dark:focus:ring-orange-500 transition"
+              className="w-full px-4 py-2.5 rounded-xl border border-stone-200 dark:border-stone-700 bg-stone-50 dark:bg-stone-800 text-stone-900 dark:text-stone-100 placeholder-stone-400 focus:outline-none focus:ring-2 focus:ring-accent-300 dark:focus:ring-accent-500 transition"
             />
           </div>
 
@@ -61,7 +61,7 @@ export function CreateListModal({ onClose, onCreate }: Props) {
                 onClick={() => setType('strikethrough')}
                 className={`flex flex-col items-center gap-1.5 p-3 rounded-xl border-2 transition-all ${
                   type === 'strikethrough'
-                    ? 'border-orange-400 bg-orange-50 dark:bg-orange-950/40 text-orange-600 dark:text-orange-400'
+                    ? 'border-accent-400 bg-accent-50 dark:bg-accent-950/40 text-accent-600 dark:text-accent-400'
                     : 'border-stone-200 dark:border-stone-700 text-stone-500 dark:text-stone-400 hover:border-stone-300'
                 }`}
               >
@@ -74,7 +74,7 @@ export function CreateListModal({ onClose, onCreate }: Props) {
                 onClick={() => setType('delete')}
                 className={`flex flex-col items-center gap-1.5 p-3 rounded-xl border-2 transition-all ${
                   type === 'delete'
-                    ? 'border-orange-400 bg-orange-50 dark:bg-orange-950/40 text-orange-600 dark:text-orange-400'
+                    ? 'border-accent-400 bg-accent-50 dark:bg-accent-950/40 text-accent-600 dark:text-accent-400'
                     : 'border-stone-200 dark:border-stone-700 text-stone-500 dark:text-stone-400 hover:border-stone-300'
                 }`}
               >
@@ -88,7 +88,7 @@ export function CreateListModal({ onClose, onCreate }: Props) {
           <button
             type="submit"
             disabled={!name.trim() || loading}
-            className="w-full py-3 rounded-xl bg-orange-400 hover:bg-orange-500 disabled:bg-stone-200 dark:disabled:bg-stone-700 text-white disabled:text-stone-400 font-semibold transition-colors"
+            className="w-full py-3 rounded-xl bg-accent-400 hover:bg-accent-500 disabled:bg-stone-200 dark:disabled:bg-stone-700 text-white disabled:text-stone-400 font-semibold transition-colors"
           >
             {loading ? '만드는 중...' : '만들기'}
           </button>

--- a/src/components/shopping/ShoppingItem.tsx
+++ b/src/components/shopping/ShoppingItem.tsx
@@ -91,8 +91,8 @@ export function ShoppingItem({ item, listType, onCheck, onDelete, onRename, drag
         <span
           className={`w-6 h-6 rounded-full border-2 flex items-center justify-center transition-all ${
             item.is_checked
-              ? 'bg-orange-400 border-orange-400'
-              : 'border-stone-300 dark:border-stone-600 hover:border-orange-300'
+              ? 'bg-accent-400 border-accent-400'
+              : 'border-stone-300 dark:border-stone-600 hover:border-accent-300'
           }`}
         >
           {item.is_checked && (
@@ -114,7 +114,7 @@ export function ShoppingItem({ item, listType, onCheck, onDelete, onRename, drag
           }}
           onBlur={commitEdit}
           onKeyDown={handleKeyDown}
-          className="flex-1 text-stone-800 dark:text-stone-100 bg-transparent border-b border-orange-400 outline-none"
+          className="flex-1 text-stone-800 dark:text-stone-100 bg-transparent border-b border-accent-400 outline-none"
           aria-label="아이템 이름 수정"
         />
       ) : (

--- a/src/components/shopping/ShoppingListCard.tsx
+++ b/src/components/shopping/ShoppingListCard.tsx
@@ -120,7 +120,7 @@ export function ShoppingListCard({ list, previewItems = [], onDelete, onRename }
         aria-label={`${list.name} 장바구니 열기`}
         onClick={() => !confirming && !editing && router.push(`/shopping/${list.id}`)}
         onKeyDown={handleCardKeyDown}
-        className="group flex flex-col p-3.5 rounded-2xl bg-stone-50 dark:bg-stone-900 border border-stone-100 dark:border-stone-800 shadow-sm hover:border-orange-200 dark:hover:border-orange-900 hover:shadow-md hover:-translate-y-0.5 transition-all min-h-[160px] cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-orange-400 focus-visible:ring-offset-1"
+        className="group flex flex-col p-3.5 rounded-2xl bg-stone-50 dark:bg-stone-900 border border-stone-100 dark:border-stone-800 shadow-sm hover:border-accent-200 dark:hover:border-accent-900 hover:shadow-md hover:-translate-y-0.5 transition-all min-h-[160px] cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-accent-400 focus-visible:ring-offset-1"
       >
         {/* Header row: grip + cart icon + name + delete */}
         <div className="flex items-center gap-2 mb-3">
@@ -134,7 +134,7 @@ export function ShoppingListCard({ list, previewItems = [], onDelete, onRename }
             <GripVertical size={14} />
           </button>
 
-          <div className="p-1.5 rounded-xl bg-orange-50 dark:bg-orange-950/40 text-orange-400 flex-shrink-0">
+          <div className="p-1.5 rounded-xl bg-accent-50 dark:bg-accent-950/40 text-accent-400 flex-shrink-0">
             <ShoppingCart size={15} />
           </div>
 
@@ -150,7 +150,7 @@ export function ShoppingListCard({ list, previewItems = [], onDelete, onRename }
                 }}
                 onBlur={commitEdit}
                 onKeyDown={handleInputKeyDown}
-                className="w-full font-semibold text-sm text-stone-800 dark:text-stone-100 bg-transparent border-b border-orange-400 outline-none"
+                className="w-full font-semibold text-sm text-stone-800 dark:text-stone-100 bg-transparent border-b border-accent-400 outline-none"
                 aria-label="목록 이름 수정"
               />
             ) : (

--- a/src/components/tabs/CalendarTab.tsx
+++ b/src/components/tabs/CalendarTab.tsx
@@ -226,7 +226,7 @@ export function CalendarTab({ preferences, user, familyId, isInitializing }: Pro
   if (loading) {
     return (
       <div className="flex items-center justify-center min-h-screen">
-        <div className="w-8 h-8 rounded-full border-2 border-orange-300 border-t-orange-500 animate-spin" />
+        <div className="w-8 h-8 rounded-full border-2 border-accent-300 border-t-accent-500 animate-spin" />
       </div>
     )
   }
@@ -303,7 +303,7 @@ export function CalendarTab({ preferences, user, familyId, isInitializing }: Pro
 
       <button
         onClick={() => setEditingEvent({ date: selectedDate ?? today })}
-        className="fixed bottom-20 right-4 w-14 h-14 rounded-full bg-orange-400 hover:bg-orange-500 text-white shadow-lg flex items-center justify-center transition-colors z-30"
+        className="fixed bottom-20 right-4 w-14 h-14 rounded-full bg-accent-400 hover:bg-accent-500 text-white shadow-lg flex items-center justify-center transition-colors z-30"
       >
         <Plus size={24} />
       </button>

--- a/src/components/tabs/SettingsTab.tsx
+++ b/src/components/tabs/SettingsTab.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import { LogOut, Share2, Check, Users, Pencil, X } from 'lucide-react'
 import { supabase } from '@/lib/supabase'
 import { getMyFamilyMember, updateMyDisplayName } from '@/lib/family'
+import { APP_THEMES, DEFAULT_THEME } from '@/lib/preferences'
 import type { UserPreferences } from '@/lib/preferences'
 import type { AuthState } from '@/types/tabs'
 
@@ -13,6 +14,7 @@ const SUPPORTED_HOLIDAY_COUNTRIES = [
   { code: 'JP', label: '🇯🇵 일본' },
   { code: 'US', label: '🇺🇸 미국' },
 ]
+
 
 interface Props extends AuthState {
   onNavigateToTab: (tab: 'calendar' | 'shopping' | 'settings') => void
@@ -123,7 +125,7 @@ export function SettingsTab({ onNavigateToTab, preferences, updatePreferences, u
   if (isInitializing) {
     return (
       <div className="flex items-center justify-center min-h-screen">
-        <div className="w-8 h-8 rounded-full border-2 border-orange-300 border-t-orange-500 animate-spin" />
+        <div className="w-8 h-8 rounded-full border-2 border-accent-300 border-t-accent-500 animate-spin" />
       </div>
     )
   }
@@ -150,12 +152,12 @@ export function SettingsTab({ onNavigateToTab, preferences, updatePreferences, u
                 placeholder="이름 입력"
                 maxLength={20}
                 autoFocus
-                className="flex-1 px-3 py-2 rounded-xl border border-stone-200 dark:border-stone-700 bg-stone-50 dark:bg-stone-800 text-stone-800 dark:text-stone-100 text-sm focus:outline-none focus:ring-2 focus:ring-orange-300"
+                className="flex-1 px-3 py-2 rounded-xl border border-stone-200 dark:border-stone-700 bg-stone-50 dark:bg-stone-800 text-stone-800 dark:text-stone-100 text-sm focus:outline-none focus:ring-2 focus:ring-accent-300"
               />
               <button
                 onClick={handleSaveName}
                 disabled={savingName || !nameInput.trim()}
-                className="px-4 py-2 rounded-xl bg-orange-400 hover:bg-orange-500 disabled:opacity-50 text-white font-semibold text-sm transition-colors"
+                className="px-4 py-2 rounded-xl bg-accent-400 hover:bg-accent-500 disabled:opacity-50 text-white font-semibold text-sm transition-colors"
               >
                 저장
               </button>
@@ -189,7 +191,7 @@ export function SettingsTab({ onNavigateToTab, preferences, updatePreferences, u
           </span>
           <button
             onClick={handleShare}
-            className="flex items-center gap-1.5 px-3 py-2 rounded-xl bg-orange-400 hover:bg-orange-500 text-white text-sm font-semibold transition-colors shadow-sm"
+            className="flex items-center gap-1.5 px-3 py-2 rounded-xl bg-accent-400 hover:bg-accent-500 text-white text-sm font-semibold transition-colors shadow-sm"
           >
             {copied ? <Check size={14} /> : <Share2 size={14} />}
             {copied ? '복사됨' : '초대하기'}
@@ -210,7 +212,7 @@ export function SettingsTab({ onNavigateToTab, preferences, updatePreferences, u
             onChange={(e) => setJoinDisplayName(e.target.value)}
             placeholder="내 이름 (예: 엄마, 홍길동)"
             maxLength={20}
-            className="w-full px-3 py-2 rounded-xl border border-stone-200 dark:border-stone-700 bg-stone-50 dark:bg-stone-800 text-stone-800 dark:text-stone-100 text-sm focus:outline-none focus:ring-2 focus:ring-orange-300"
+            className="w-full px-3 py-2 rounded-xl border border-stone-200 dark:border-stone-700 bg-stone-50 dark:bg-stone-800 text-stone-800 dark:text-stone-100 text-sm focus:outline-none focus:ring-2 focus:ring-accent-300"
           />
           <div className="flex gap-2">
             <input
@@ -218,12 +220,12 @@ export function SettingsTab({ onNavigateToTab, preferences, updatePreferences, u
               onChange={(e) => setJoinCode(e.target.value.toUpperCase())}
               placeholder="초대 코드 입력"
               maxLength={6}
-              className="flex-1 px-3 py-2 rounded-xl border border-stone-200 dark:border-stone-700 bg-stone-50 dark:bg-stone-800 text-stone-800 dark:text-stone-100 font-mono tracking-widest text-sm focus:outline-none focus:ring-2 focus:ring-orange-300"
+              className="flex-1 px-3 py-2 rounded-xl border border-stone-200 dark:border-stone-700 bg-stone-50 dark:bg-stone-800 text-stone-800 dark:text-stone-100 font-mono tracking-widest text-sm focus:outline-none focus:ring-2 focus:ring-accent-300"
             />
             <button
               onClick={handleJoin}
               disabled={joining || joinCode.length < 6}
-              className="px-4 py-2 rounded-xl bg-orange-400 hover:bg-orange-500 disabled:opacity-50 text-white font-semibold text-sm transition-colors"
+              className="px-4 py-2 rounded-xl bg-accent-400 hover:bg-accent-500 disabled:opacity-50 text-white font-semibold text-sm transition-colors"
             >
               {joining ? '합류 중...' : '합류'}
             </button>
@@ -256,7 +258,7 @@ export function SettingsTab({ onNavigateToTab, preferences, updatePreferences, u
                 }}
                 className={`w-full flex items-center justify-between px-3 py-2.5 rounded-xl border transition-colors ${
                   selected
-                    ? 'border-orange-300 bg-orange-50 dark:bg-orange-950/30 dark:border-orange-700'
+                    ? 'border-accent-300 bg-accent-50 dark:bg-accent-950/30 dark:border-accent-700'
                     : 'border-stone-200 dark:border-stone-700 hover:bg-stone-50 dark:hover:bg-stone-800'
                 }`}
               >
@@ -264,12 +266,42 @@ export function SettingsTab({ onNavigateToTab, preferences, updatePreferences, u
                 <span
                   className={`w-5 h-5 rounded-full border-2 flex items-center justify-center transition-colors ${
                     selected
-                      ? 'border-orange-400 bg-orange-400'
+                      ? 'border-accent-400 bg-accent-400'
                       : 'border-stone-300 dark:border-stone-600'
                   }`}
                 >
                   {selected && <Check size={11} strokeWidth={3} className="text-white" />}
                 </span>
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      <div className="rounded-2xl bg-white dark:bg-stone-900 border border-stone-100 dark:border-stone-800 p-4 mb-4">
+        <p className="text-xs font-semibold text-stone-400 dark:text-stone-500 uppercase tracking-wide mb-3">
+          테마 색상
+        </p>
+        <div className="grid grid-cols-3 gap-2">
+          {APP_THEMES.map(({ key, label, color }) => {
+            const selected = (preferences?.app_theme ?? DEFAULT_THEME) === key
+            return (
+              <button
+                key={key}
+                onClick={() => updatePreferences({ app_theme: key })}
+                className={`flex flex-col items-center gap-2 py-3 px-2 rounded-xl border transition-all ${
+                  selected
+                    ? 'border-stone-400 bg-stone-50 dark:bg-stone-800'
+                    : 'border-stone-100 dark:border-stone-800 hover:bg-stone-50 dark:hover:bg-stone-800/60'
+                }`}
+              >
+                <span
+                  className="w-8 h-8 rounded-full flex items-center justify-center shadow-sm"
+                  style={{ backgroundColor: color }}
+                >
+                  {selected && <Check size={14} strokeWidth={3} className="text-white" />}
+                </span>
+                <span className="text-xs text-stone-600 dark:text-stone-400 font-medium">{label}</span>
               </button>
             )
           })}

--- a/src/components/tabs/ShoppingTab.tsx
+++ b/src/components/tabs/ShoppingTab.tsx
@@ -118,7 +118,7 @@ export function ShoppingTab({ user, familyId, isInitializing }: Props) {
   if (loading) {
     return (
       <div className="flex items-center justify-center min-h-[calc(100vh-5rem)]">
-        <div className="w-8 h-8 rounded-full border-2 border-orange-300 border-t-orange-500 animate-spin" />
+        <div className="w-8 h-8 rounded-full border-2 border-accent-300 border-t-accent-500 animate-spin" />
       </div>
     )
   }
@@ -134,7 +134,7 @@ export function ShoppingTab({ user, familyId, isInitializing }: Props) {
         </div>
         <button
           onClick={() => setShowModal(true)}
-          className="w-11 h-11 flex items-center justify-center rounded-full bg-orange-400 hover:bg-orange-500 text-white shadow-sm transition-colors"
+          className="w-11 h-11 flex items-center justify-center rounded-full bg-accent-400 hover:bg-accent-500 text-white shadow-sm transition-colors"
           aria-label="새 장바구니 추가"
         >
           <Plus size={20} />

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -1,6 +1,18 @@
 import { supabase } from './supabase'
 import type { Database } from '@/types/database'
 
+export const APP_THEMES = [
+  { key: 'tangerine', label: '탠저린', color: '#fb923c' },
+  { key: 'sage',      label: '세이지',   color: '#2dd4bf' },
+  { key: 'ocean',     label: '오션',     color: '#38bdf8' },
+  { key: 'rose',      label: '로즈',     color: '#fb7185' },
+  { key: 'violet',    label: '바이올렛', color: '#a78bfa' },
+  { key: 'denim',     label: '데님',     color: '#818cf8' },
+] as const
+
+export type AppTheme = typeof APP_THEMES[number]['key']
+export const DEFAULT_THEME: AppTheme = 'tangerine'
+
 export type UserPreferences = Database['public']['Tables']['user_preferences']['Row']
 
 export async function getUserPreferences(userId: string): Promise<UserPreferences | null> {

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -18,18 +18,21 @@ export type Database = {
         Row: {
           user_id: string
           holiday_countries: string[]
+          app_theme: string
           created_at: string
           updated_at: string
         }
         Insert: {
           user_id: string
           holiday_countries?: string[]
+          app_theme?: string
           created_at?: string
           updated_at?: string
         }
         Update: {
           user_id?: string
           holiday_countries?: string[]
+          app_theme?: string
           created_at?: string
           updated_at?: string
         }

--- a/supabase/migrations/20260404040000_add_app_theme_to_preferences.sql
+++ b/supabase/migrations/20260404040000_add_app_theme_to_preferences.sql
@@ -1,0 +1,2 @@
+ALTER TABLE user_preferences
+  ADD COLUMN app_theme text NOT NULL DEFAULT 'tangerine';


### PR DESCRIPTION
## Summary

- 설정 탭에 앱 전체 테마 색상 선택 기능 추가 (캘린더 색상과 별개)
- 선택한 테마는 해당 유저 계정에 종속되어 Supabase DB에 저장
- 6가지 모던 테마: 탠저린(기본) · 세이지 · 오션 · 로즈 · 바이올렛 · 데님

## Changes

- **DB migration**: `user_preferences.app_theme` 컬럼 추가 (default: `'tangerine'`)
- **CSS theme system**: `globals.css`에 테마별 CSS 변수 정의 → `@theme inline`으로 Tailwind `accent-*` 클래스에 연결
- **Theme application**: `TabsShell`에서 preferences 로드 시 `<html data-theme="...">` 속성 설정
- **Settings UI**: 3×2 색상 스와치 그리드 추가
- **Global refactor**: 앱 전체 `orange-*` → `accent-*` Tailwind 클래스 교체 (17개 파일)
- **Type safety**: `AppTheme` 유니언 타입, `DEFAULT_THEME` 상수를 `lib/preferences.ts`에서 export

## Manual Verification

- [x] 설정 탭에서 테마 선택 시 앱 전체 색상이 즉시 변경되는지 확인
- [x] 다른 기기/탭에서 로그인 시 저장된 테마가 적용되는지 확인
- [x] 다크 모드 + 각 테마 조합이 올바르게 보이는지 확인

## Prerequisites

Supabase 마이그레이션 실행 필요:
```
supabase db push
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)