### PR TITLE
refactor: extract useRealtimeSync hook to eliminate duplicate Realtime patterns

### DIFF
--- a/src/__tests__/hooks/useRealtimeSync.test.ts
+++ b/src/__tests__/hooks/useRealtimeSync.test.ts
@@ -1,0 +1,152 @@
+import { renderHook, act } from '@testing-library/react'
+import { useRealtimeSync } from '@/hooks/useRealtimeSync'
+
+const mockSend = jest.fn()
+const mockRemoveChannel = jest.fn()
+let subscribeCb: ((status: string) => void) | undefined
+let broadcastCb: (() => void) | undefined
+
+const mockChannel = {
+  on: jest.fn(),
+  subscribe: jest.fn(),
+  send: mockSend,
+}
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    channel: jest.fn(),
+    removeChannel: jest.fn(),
+  },
+}))
+
+import { supabase } from '@/lib/supabase'
+const mockSupabaseChannel = supabase.channel as jest.Mock
+const mockSupabaseRemoveChannel = supabase.removeChannel as jest.Mock
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  subscribeCb = undefined
+  broadcastCb = undefined
+
+  mockChannel.on.mockImplementation((_type: string, _filter: unknown, cb: () => void) => {
+    broadcastCb = cb
+    return mockChannel
+  })
+  mockChannel.subscribe.mockImplementation((cb: (status: string) => void) => {
+    subscribeCb = cb
+    return mockChannel
+  })
+
+  mockSupabaseChannel.mockReturnValue(mockChannel)
+  mockSupabaseRemoveChannel.mockImplementation(mockRemoveChannel)
+})
+
+describe('useRealtimeSync', () => {
+  it('channelName이 null이면 채널을 구독하지 않는다', () => {
+    const onRefresh = jest.fn()
+    renderHook(() => useRealtimeSync(null, onRefresh))
+    expect(mockSupabaseChannel).not.toHaveBeenCalled()
+    expect(onRefresh).not.toHaveBeenCalled()
+  })
+
+  it('channelName이 주어지면 채널을 구독한다', () => {
+    const onRefresh = jest.fn()
+    renderHook(() => useRealtimeSync('test-channel', onRefresh))
+    expect(mockSupabaseChannel).toHaveBeenCalledWith('test-channel')
+    expect(mockChannel.on).toHaveBeenCalledWith('broadcast', { event: 'refresh' }, expect.any(Function))
+    expect(mockChannel.subscribe).toHaveBeenCalled()
+  })
+
+  it('SUBSCRIBED 상태가 되면 onRefresh를 호출한다', () => {
+    const onRefresh = jest.fn()
+    renderHook(() => useRealtimeSync('test-channel', onRefresh))
+
+    act(() => { subscribeCb?.('SUBSCRIBED') })
+
+    expect(onRefresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('SUBSCRIBED 아닌 상태에서는 onRefresh를 호출하지 않는다', () => {
+    const onRefresh = jest.fn()
+    renderHook(() => useRealtimeSync('test-channel', onRefresh))
+
+    act(() => { subscribeCb?.('CONNECTING') })
+
+    expect(onRefresh).not.toHaveBeenCalled()
+  })
+
+  it('broadcast 이벤트를 수신하면 onRefresh를 호출한다', () => {
+    const onRefresh = jest.fn()
+    renderHook(() => useRealtimeSync('test-channel', onRefresh))
+
+    act(() => { broadcastCb?.() })
+
+    expect(onRefresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('SUBSCRIBED 전에는 broadcast()를 전송하지 않는다', () => {
+    const onRefresh = jest.fn()
+    const { result } = renderHook(() => useRealtimeSync('test-channel', onRefresh))
+
+    act(() => { result.current() })
+
+    expect(mockSend).not.toHaveBeenCalled()
+  })
+
+  it('SUBSCRIBED 후 broadcast()를 호출하면 채널로 전송한다', () => {
+    const onRefresh = jest.fn()
+    const { result } = renderHook(() => useRealtimeSync('test-channel', onRefresh))
+
+    act(() => { subscribeCb?.('SUBSCRIBED') })
+    act(() => { result.current() })
+
+    expect(mockSend).toHaveBeenCalledWith({
+      type: 'broadcast',
+      event: 'refresh',
+      payload: {},
+    })
+  })
+
+  it('언마운트 시 채널을 제거한다', () => {
+    const onRefresh = jest.fn()
+    const { unmount } = renderHook(() => useRealtimeSync('test-channel', onRefresh))
+
+    unmount()
+
+    expect(mockSupabaseRemoveChannel).toHaveBeenCalledWith(mockChannel)
+  })
+
+  it('channelName 변경 시 이전 채널을 제거하고 새 채널을 구독한다', () => {
+    const onRefresh = jest.fn()
+    const { rerender } = renderHook(
+      ({ name }: { name: string }) => useRealtimeSync(name, onRefresh),
+      { initialProps: { name: 'channel-a' } }
+    )
+
+    expect(mockSupabaseChannel).toHaveBeenCalledWith('channel-a')
+
+    rerender({ name: 'channel-b' })
+
+    expect(mockSupabaseRemoveChannel).toHaveBeenCalledTimes(1)
+    expect(mockSupabaseChannel).toHaveBeenCalledWith('channel-b')
+  })
+
+  it('onRefresh가 변경되어도 채널을 재구독하지 않는다', () => {
+    const onRefresh1 = jest.fn()
+    const onRefresh2 = jest.fn()
+    const { rerender } = renderHook(
+      ({ cb }: { cb: () => void }) => useRealtimeSync('fixed-channel', cb),
+      { initialProps: { cb: onRefresh1 } }
+    )
+
+    rerender({ cb: onRefresh2 })
+
+    // 채널 재구독 없이 1번만 생성
+    expect(mockSupabaseChannel).toHaveBeenCalledTimes(1)
+
+    // 최신 콜백(onRefresh2)이 broadcast 수신에 사용된다
+    act(() => { broadcastCb?.() })
+    expect(onRefresh2).toHaveBeenCalledTimes(1)
+    expect(onRefresh1).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/shopping/[id]/page.tsx
+++ b/src/app/shopping/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import { ArrowLeft } from 'lucide-react'
 import {
@@ -24,6 +24,7 @@ import {
 import { ShoppingItem } from '@/components/shopping/ShoppingItem'
 import { AddItemInput } from '@/components/shopping/AddItemInput'
 import { supabase } from '@/lib/supabase'
+import { useRealtimeSync } from '@/hooks/useRealtimeSync'
 import type { ShoppingItem as ShoppingItemType, ShoppingList } from '@/lib/shopping'
 
 export default function ShoppingDetailPage() {
@@ -38,18 +39,21 @@ export default function ShoppingDetailPage() {
   const [list, setList] = useState<ShoppingList | null>(null)
   const [items, setItems] = useState<ShoppingItemType[]>([])
   const [loading, setLoading] = useState(true)
-  const channelRef = useRef<ReturnType<typeof supabase.channel> | null>(null)
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
     useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 5 } })
   )
 
+  const refreshItems = useCallback(() => {
+    if (!id) return
+    getShoppingItems(id).then(setItems)
+  }, [id])
+
+  const broadcast = useRealtimeSync(id ? `list_items_${id}` : null, refreshItems)
+
   useEffect(() => {
     if (!id) return
-
-    const refreshItems = () => getShoppingItems(id).then(setItems)
-
     const init = async () => {
       const { data } = await supabase
         .from('shopping_lists')
@@ -62,21 +66,7 @@ export default function ShoppingDetailPage() {
       setLoading(false)
     }
     init()
-
-    const channel = supabase
-      .channel(`list_items_${id}`)
-      .on('broadcast', { event: 'refresh' }, refreshItems)
-      .subscribe((status) => {
-        if (status === 'SUBSCRIBED') refreshItems()
-      })
-
-    channelRef.current = channel
-    return () => { supabase.removeChannel(channel) }
   }, [id])
-
-  const broadcast = () => {
-    channelRef.current?.send({ type: 'broadcast', event: 'refresh', payload: {} })
-  }
 
   const handleAdd = async (name: string) => {
     if (!user) return

--- a/src/components/tabs/CalendarTab.tsx
+++ b/src/components/tabs/CalendarTab.tsx
@@ -31,7 +31,7 @@ import { DayEventsSheet } from '@/components/calendar/DayEventsSheet'
 import { EventDetailSheet } from '@/components/calendar/EventDetailSheet'
 import { EventFormModal } from '@/components/calendar/EventFormModal'
 import { CalendarFormModal } from '@/components/calendar/CalendarFormModal'
-import { supabase } from '@/lib/supabase'
+import { useRealtimeSync } from '@/hooks/useRealtimeSync'
 import type { Calendar } from '@/lib/calendar'
 
 interface Props extends AuthState {
@@ -58,7 +58,6 @@ export function CalendarTab({ preferences, user, familyId, isInitializing }: Pro
   const [calendarMemberIds, setCalendarMemberIds] = useState<string[]>([])
   const [showCalendarList, setShowCalendarList] = useState(false)
 
-  const channelRef = useRef<ReturnType<typeof supabase.channel> | null>(null)
   const containerRef = useRef<HTMLDivElement>(null)
 
   const [slideKey, setSlideKey] = useState(0)
@@ -81,22 +80,13 @@ export function CalendarTab({ preferences, user, familyId, isInitializing }: Pro
       .catch((e) => console.error('[CalendarTab] loadEvents failed:', e))
   }, [familyId, year, month])
 
+  const channelName = familyId ? `family_events_${familyId}_${year}_${month}` : null
+  const broadcast = useRealtimeSync(channelName, loadEvents)
+
   useEffect(() => {
     if (!familyId) return
     loadEvents()
-
-    const channel = supabase
-      .channel(`family_events_${familyId}_${year}_${month}`)
-      .on('broadcast', { event: 'refresh' }, loadEvents)
-      .subscribe()
-    channelRef.current = channel
-
-    return () => { supabase.removeChannel(channel) }
   }, [familyId, year, month, loadEvents])
-
-  const broadcast = () => {
-    channelRef.current?.send({ type: 'broadcast', event: 'refresh', payload: {} })
-  }
 
   const prevMonth = () => {
     setSlideDir('right')

--- a/src/components/tabs/ShoppingTab.tsx
+++ b/src/components/tabs/ShoppingTab.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { Plus, ShoppingCart, AlertTriangle } from 'lucide-react'
 import {
   DndContext,
@@ -21,7 +21,7 @@ import {
 } from '@/lib/shopping'
 import { ShoppingListCard } from '@/components/shopping/ShoppingListCard'
 import { CreateListModal } from '@/components/shopping/CreateListModal'
-import { supabase } from '@/lib/supabase'
+import { useRealtimeSync } from '@/hooks/useRealtimeSync'
 import type { ShoppingListWithPreview, ListType } from '@/lib/shopping'
 
 // 라우트 이동으로 컴포넌트가 언마운트되어도 데이터를 유지하는 세션 캐시.
@@ -36,7 +36,6 @@ export function ShoppingTab({ user, familyId, isInitializing }: Props) {
   )
   const [fetchError, setFetchError] = useState(false)
   const [showModal, setShowModal] = useState(false)
-  const channelRef = useRef<ReturnType<typeof supabase.channel> | null>(null)
 
   // lastKnownLists가 null이면 한 번도 로드된 적 없는 첫 진입 → 스피너 표시
   // null이 아니면 캐시 데이터가 있으므로 auth 초기화 중에도 즉시 표시
@@ -55,33 +54,22 @@ export function ShoppingTab({ user, familyId, isInitializing }: Props) {
     })
   }
 
-  useEffect(() => {
+  const refresh = useCallback(() => {
     if (!familyId) return
-
-    const refresh = () =>
-      getShoppingListsWithPreviews(familyId)
-        .then(updateLists)
-        .catch((e) => {
-          console.error('[ShoppingTab] getShoppingListsWithPreviews failed:', e)
-          setFetchError(true)
-        })
-    refresh()
-
-    const channel = supabase
-      .channel(`family_lists_${familyId}`)
-      .on('broadcast', { event: 'refresh' }, refresh)
-      .subscribe((status) => {
-        if (status === 'SUBSCRIBED') refresh()
+    getShoppingListsWithPreviews(familyId)
+      .then(updateLists)
+      .catch((e) => {
+        console.error('[ShoppingTab] getShoppingListsWithPreviews failed:', e)
+        setFetchError(true)
       })
-
-    channelRef.current = channel
-
-    return () => { supabase.removeChannel(channel) }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [familyId])
 
-  const broadcast = () => {
-    channelRef.current?.send({ type: 'broadcast', event: 'refresh', payload: {} })
-  }
+  const broadcast = useRealtimeSync(familyId ? `family_lists_${familyId}` : null, refresh)
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
 
   const handleCreate = async (name: string, type: ListType) => {
     if (!familyId || !user) return

--- a/src/hooks/useRealtimeSync.ts
+++ b/src/hooks/useRealtimeSync.ts
@@ -1,0 +1,49 @@
+import { useCallback, useEffect, useRef } from 'react'
+import { supabase } from '@/lib/supabase'
+
+/**
+ * Supabase Realtime broadcast 구독을 관리하는 훅.
+ * - channelName이 null이면 구독하지 않는다.
+ * - SUBSCRIBED 시점과 broadcast 수신 시 onRefresh를 호출한다.
+ * - broadcast()는 채널이 SUBSCRIBED 상태일 때만 전송한다 (PATTERNS.md 참조).
+ */
+export function useRealtimeSync(
+  channelName: string | null,
+  onRefresh: () => void
+): () => void {
+  const onRefreshRef = useRef(onRefresh)
+  useEffect(() => {
+    onRefreshRef.current = onRefresh
+  })
+
+  const channelRef = useRef<ReturnType<typeof supabase.channel> | null>(null)
+  const channelReadyRef = useRef(false)
+
+  useEffect(() => {
+    if (!channelName) return
+
+    channelReadyRef.current = false
+    const channel = supabase
+      .channel(channelName)
+      .on('broadcast', { event: 'refresh' }, () => onRefreshRef.current())
+      .subscribe((status) => {
+        if (status === 'SUBSCRIBED') {
+          channelReadyRef.current = true
+          onRefreshRef.current()
+        }
+      })
+    channelRef.current = channel
+
+    return () => {
+      channelReadyRef.current = false
+      channelRef.current = null
+      supabase.removeChannel(channel)
+    }
+  }, [channelName])
+
+  return useCallback(() => {
+    if (channelReadyRef.current) {
+      channelRef.current?.send({ type: 'broadcast', event: 'refresh', payload: {} })
+    }
+  }, [])
+}


### PR DESCRIPTION
## Summary

- `ShoppingTab`, `CalendarTab`, `ShoppingDetailPage` 3곳에 중복된 Supabase Realtime broadcast 구독 패턴을 `useRealtimeSync(channelName, onRefresh)` 훅으로 추출
- PATTERNS.md의 `channelReadyRef` 규칙 적용 — SUBSCRIBED 상태일 때만 `broadcast()` 전송
- `onRefreshRef` 패턴으로 콜백이 변경되어도 채널 재구독 없이 항상 최신 함수 사용

## Test plan

- [x] `useRealtimeSync` 유닛 테스트 10개 전체 통과
- [x] 전체 테스트 241개 통과 (33 suites)
- [x] `npx tsc --noEmit` 오류 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)