### PR TITLE
fix: show splash screen before login redirect to prevent tab flash

### DIFF
--- a/src/__tests__/TabsShell.test.tsx
+++ b/src/__tests__/TabsShell.test.tsx
@@ -3,6 +3,8 @@ import { TabsShell } from '@/components/TabsShell'
 
 const mockReplace = jest.fn()
 let mockTabParam: string | null = null
+let mockAuthLoading = false
+let mockAuthUser: { id: string } | null = { id: 'user-1' }
 
 jest.mock('next/navigation', () => ({
   useRouter: () => ({ replace: mockReplace, push: jest.fn() }),
@@ -10,11 +12,11 @@ jest.mock('next/navigation', () => ({
 }))
 
 jest.mock('@/hooks/useAuth', () => ({
-  useAuth: () => ({ user: null, loading: true }),
+  useAuth: () => ({ user: mockAuthUser, loading: mockAuthLoading }),
 }))
 
 jest.mock('@/hooks/useFamily', () => ({
-  useFamily: () => ({ familyId: null, loading: true }),
+  useFamily: () => ({ familyId: null, loading: false }),
 }))
 
 jest.mock('@/hooks/useUserPreferences', () => ({
@@ -26,7 +28,11 @@ jest.mock('@/lib/supabase', () => ({
 }))
 
 jest.mock('@/lib/push', () => ({
-  registerPushSubscription: jest.fn(),
+  registerPushSubscription: jest.fn().mockResolvedValue(undefined),
+}))
+
+jest.mock('@/components/AppSplash', () => ({
+  AppSplash: () => <div data-testid="app-splash" />,
 }))
 
 jest.mock('@/components/tabs/CalendarTab', () => ({
@@ -49,6 +55,22 @@ describe('TabsShell', () => {
   beforeEach(() => {
     mockReplace.mockClear()
     mockTabParam = null
+    mockAuthLoading = false
+    mockAuthUser = { id: 'user-1' }
+  })
+
+  it('인증 로딩 중에는 AppSplash를 표시한다', () => {
+    mockAuthLoading = true
+    mockAuthUser = null
+    render(<TabsShell />)
+    expect(screen.getByTestId('app-splash')).toBeInTheDocument()
+    expect(screen.queryByTestId('bottom-nav')).not.toBeInTheDocument()
+  })
+
+  it('미인증 상태에서는 탭을 렌더링하지 않는다', () => {
+    mockAuthUser = null
+    render(<TabsShell />)
+    expect(screen.queryByTestId('bottom-nav')).not.toBeInTheDocument()
   })
 
   it('?tab 파라미터가 없으면 캘린더 탭이 표시된다', () => {

--- a/src/components/AppSplash.tsx
+++ b/src/components/AppSplash.tsx
@@ -1,0 +1,7 @@
+export function AppSplash() {
+  return (
+    <div className="fixed inset-0 bg-[var(--background)]">
+      {/* TODO: 로고 추가 */}
+    </div>
+  )
+}

--- a/src/components/TabsShell.tsx
+++ b/src/components/TabsShell.tsx
@@ -11,6 +11,7 @@ import { useFamily } from '@/hooks/useFamily'
 import { useUserPreferences } from '@/hooks/useUserPreferences'
 import { registerPushSubscription } from '@/lib/push'
 import { type Tab, TABS } from '@/types/tabs'
+import { AppSplash } from '@/components/AppSplash'
 
 export function TabsShell() {
   const searchParams = useSearchParams()
@@ -38,6 +39,9 @@ export function TabsShell() {
       document.documentElement.setAttribute('data-theme', preferences.app_theme)
     }
   }, [preferences?.app_theme])
+
+  if (authLoading) return <AppSplash />
+  if (!user) return null
 
   const handleTabChange = (tab: Tab) => {
     router.replace(tab === 'calendar' ? '/calendar' : `/calendar?tab=${tab}`)


### PR DESCRIPTION
## Summary

- 미인증 상태로 접속 시, 인증 확인 전에 하단 탭 UI가 잠깐 노출되는 flash 현상 수정
- `authLoading` 중에는 `AppSplash` (배경색만 있는 최소 화면) 렌더링
- `user`가 없으면 `null` 반환 (redirect useEffect가 `/login`으로 이동)
- `AppSplash`에 로고 자리 주석 추가 — 추후 로고 이미지 추가 예정

## 변경 파일

- `src/components/AppSplash.tsx` (신규) — 로고 자리 포함한 최소 splash 컴포넌트
- `src/components/TabsShell.tsx` — auth 가드 추가
- `src/__tests__/TabsShell.test.tsx` — 로딩/미인증 상태 테스트 케이스 추가

## 수동 확인 항목

- [x] 로그아웃 상태에서 앱 접속 시 하단 탭이 노출되지 않고 배경색 화면이 짧게 보인 후 로그인 페이지로 이동하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)