### PR TITLE
feat: add lunar calendar display toggle setting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@dnd-kit/utilities": "^3.2.2",
         "@supabase/supabase-js": "^2.100.1",
         "date-holidays": "^3.26.12",
+        "korean-lunar-calendar": "^0.3.6",
         "lucide-react": "^1.7.0",
         "next": "16.2.1",
         "next-themes": "^0.4.6",
@@ -8013,6 +8014,15 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/korean-lunar-calendar": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/korean-lunar-calendar/-/korean-lunar-calendar-0.3.6.tgz",
+      "integrity": "sha512-9jpZUH8ph6GsBgIGy8al6z6OfG6TdSIDB99Zj73B35ohtG12EFj3CGE5NzjBsXFiJUUjEr08/XCjfh+flXZVPw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16.14.0"
       }
     },
     "node_modules/language-subtag-registry": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@supabase/supabase-js": "^2.100.1",
     "date-holidays": "^3.26.12",
+    "korean-lunar-calendar": "^0.3.6",
     "lucide-react": "^1.7.0",
     "next": "16.2.1",
     "next-themes": "^0.4.6",

--- a/src/__tests__/components/CalendarGrid.test.tsx
+++ b/src/__tests__/components/CalendarGrid.test.tsx
@@ -3,6 +3,13 @@ import { CalendarGrid, isMultiDayAllDay, computeSegments } from '@/components/ca
 import type { Calendar, CalendarEvent } from '@/lib/calendar'
 import type { Holiday } from '@/hooks/useHolidays'
 
+jest.mock('korean-lunar-calendar', () => {
+  return jest.fn().mockImplementation(() => ({
+    setSolarDate: jest.fn(),
+    getLunarCalendar: jest.fn().mockReturnValue({ month: 4, day: 20 }),
+  }))
+})
+
 // ── Fixtures ────────────────────────────────────────────────
 
 const calendars: Calendar[] = [
@@ -306,6 +313,23 @@ describe('CalendarGrid', () => {
     // 두 번째 bar (isEnd=true): ‹ 있음, › 없음
     expect(bars[1].textContent).toMatch(/‹/)
     expect(bars[1].textContent).not.toMatch(/›/)
+  })
+
+  it('showLunar=true 이면 음력 날짜가 표시된다', () => {
+    render(<CalendarGrid {...defaultProps} showLunar={true} />)
+    // 모킹된 값 4/20이 여러 셀에 표시되어야 함
+    const lunarLabels = screen.getAllByText('4/20')
+    expect(lunarLabels.length).toBeGreaterThan(0)
+  })
+
+  it('showLunar=false 이면 음력 날짜가 표시되지 않는다', () => {
+    render(<CalendarGrid {...defaultProps} showLunar={false} />)
+    expect(screen.queryByText('4/20')).not.toBeInTheDocument()
+  })
+
+  it('showLunar 기본값(미전달)이면 음력 날짜가 표시되지 않는다', () => {
+    render(<CalendarGrid {...defaultProps} />)
+    expect(screen.queryByText('4/20')).not.toBeInTheDocument()
   })
 
   it('멀티데이 이벤트 bar 클릭 시 이벤트 시작일로 onSelectDate가 호출된다', () => {

--- a/src/__tests__/hooks/useUserPreferences.test.ts
+++ b/src/__tests__/hooks/useUserPreferences.test.ts
@@ -41,6 +41,7 @@ describe('useUserPreferences', () => {
       user_id: 'user-1',
       holiday_countries: ['KR', 'JP'],
       app_theme: 'tangerine',
+      show_lunar: false,
       created_at: '',
       updated_at: '',
     }
@@ -74,6 +75,7 @@ describe('useUserPreferences', () => {
       user_id: 'user-1',
       holiday_countries: ['KR'],
       app_theme: 'tangerine',
+      show_lunar: false,
       created_at: '',
       updated_at: '',
     }
@@ -95,6 +97,7 @@ describe('useUserPreferences', () => {
       user_id: 'user-1',
       holiday_countries: ['KR'],
       app_theme: 'ocean',
+      show_lunar: false,
       created_at: '',
       updated_at: '',
     }
@@ -119,6 +122,7 @@ describe('useUserPreferences', () => {
       user_id: 'user-1',
       holiday_countries: ['KR'],
       app_theme: 'violet',
+      show_lunar: false,
       created_at: '',
       updated_at: '',
     }

--- a/src/__tests__/lib/preferences.test.ts
+++ b/src/__tests__/lib/preferences.test.ts
@@ -32,6 +32,7 @@ describe('getUserPreferences', () => {
       user_id: 'user-1',
       holiday_countries: ['KR', 'JP'],
       app_theme: 'tangerine',
+      show_lunar: false,
       created_at: '',
       updated_at: '',
     }
@@ -61,6 +62,7 @@ describe('upsertUserPreferences', () => {
       user_id: 'user-1',
       holiday_countries: ['KR'],
       app_theme: 'tangerine',
+      show_lunar: false,
       created_at: '',
       updated_at: '',
     }
@@ -75,6 +77,7 @@ describe('upsertUserPreferences', () => {
       user_id: 'user-1',
       holiday_countries: [],
       app_theme: 'ocean',
+      show_lunar: false,
       created_at: '',
       updated_at: '',
     }

--- a/src/components/calendar/CalendarGrid.tsx
+++ b/src/components/calendar/CalendarGrid.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useMemo } from 'react'
+import KoreanLunarCalendar from 'korean-lunar-calendar'
 import type { Calendar, CalendarEvent } from '@/lib/calendar'
 import type { Holiday } from '@/hooks/useHolidays'
 
@@ -132,12 +133,13 @@ interface Props {
   holidays?: Holiday[]
   selectedDate: Date | null
   onSelectDate: (date: Date) => void
+  showLunar?: boolean
   className?: string
 }
 
 export function CalendarGrid({
   year, month, events, calendars, activeIds,
-  holidays = [], selectedDate, onSelectDate, className,
+  holidays = [], selectedDate, onSelectDate, showLunar = false, className,
 }: Props) {
   const cells = useMemo(() => buildGrid(year, month), [year, month])
   const today = useMemo(() => new Date(), [])
@@ -175,6 +177,18 @@ export function CalendarGrid({
     if (!event.calendar_id) return '#94a3b8'
     return calendarMap.get(event.calendar_id)?.color ?? '#94a3b8'
   }
+
+  const lunarDateMap = useMemo(() => {
+    if (!showLunar) return new Map<number, string>()
+    const map = new Map<number, string>()
+    const calendar = new KoreanLunarCalendar()
+    for (const cell of cells) {
+      calendar.setSolarDate(cell.date.getFullYear(), cell.date.getMonth() + 1, cell.date.getDate())
+      const lunar = calendar.getLunarCalendar()
+      map.set(cell.date.getTime(), `${lunar.month}/${lunar.day}`)
+    }
+    return map
+  }, [showLunar, cells])
 
   const rows = useMemo(() => {
     const result: DayCell[][] = []
@@ -229,31 +243,42 @@ export function CalendarGrid({
                       } border-stone-100 dark:border-stone-800`}
                     >
                       {/* 날짜 숫자 */}
-                      <span
-                        className={`text-xs font-medium w-6 h-6 flex items-center justify-center rounded-full mx-auto mb-0.5 ${
-                          isToday
-                            ? 'bg-accent-400 text-white font-bold'
-                            : isSelected
-                            ? 'underline underline-offset-2 decoration-accent-400 font-bold ' + (
-                                !cell.isCurrentMonth
-                                  ? 'text-stone-300 dark:text-stone-600'
-                                  : isSun
-                                  ? 'text-red-400'
-                                  : isSat
-                                  ? 'text-blue-400'
-                                  : 'text-stone-700 dark:text-stone-200'
-                              )
-                            : !cell.isCurrentMonth
-                            ? 'text-stone-300 dark:text-stone-600'
-                            : isSun
-                            ? 'text-red-400 dark:text-red-400'
-                            : isSat
-                            ? 'text-blue-400 dark:text-blue-400'
-                            : 'text-stone-700 dark:text-stone-200'
-                        }`}
-                      >
-                        {cell.date.getDate()}
-                      </span>
+                      <div className="flex flex-col items-center mx-auto mb-0.5">
+                        <span
+                          className={`text-xs font-medium w-6 h-6 flex items-center justify-center rounded-full ${
+                            isToday
+                              ? 'bg-accent-400 text-white font-bold'
+                              : isSelected
+                              ? 'underline underline-offset-2 decoration-accent-400 font-bold ' + (
+                                  !cell.isCurrentMonth
+                                    ? 'text-stone-300 dark:text-stone-600'
+                                    : isSun
+                                    ? 'text-red-400'
+                                    : isSat
+                                    ? 'text-blue-400'
+                                    : 'text-stone-700 dark:text-stone-200'
+                                )
+                              : !cell.isCurrentMonth
+                              ? 'text-stone-300 dark:text-stone-600'
+                              : isSun
+                              ? 'text-red-400 dark:text-red-400'
+                              : isSat
+                              ? 'text-blue-400 dark:text-blue-400'
+                              : 'text-stone-700 dark:text-stone-200'
+                          }`}
+                        >
+                          {cell.date.getDate()}
+                        </span>
+                        {showLunar && (
+                          <span className={`text-[9px] leading-tight ${
+                            !cell.isCurrentMonth
+                              ? 'text-stone-300 dark:text-stone-600'
+                              : 'text-stone-400 dark:text-stone-500'
+                          }`}>
+                            {lunarDateMap.get(cell.date.getTime())}
+                          </span>
+                        )}
+                      </div>
 
                       {/* 멀티데이 lane 공간 확보용 spacer */}
                       <div aria-hidden="true" style={{ height: laneAreaHeight }} />

--- a/src/components/tabs/CalendarTab.tsx
+++ b/src/components/tabs/CalendarTab.tsx
@@ -287,6 +287,7 @@ export function CalendarTab({ preferences, user, familyId, isInitializing }: Pro
               prev?.toDateString() === date.toDateString() ? null : date
             )
           }}
+          showLunar={preferences?.show_lunar ?? false}
           className="h-full pb-16"
         />
       </div>

--- a/src/components/tabs/SettingsTab.tsx
+++ b/src/components/tabs/SettingsTab.tsx
@@ -285,6 +285,32 @@ export function SettingsTab({ onNavigateToTab, preferences, updatePreferences, u
         <p className="text-xs text-stone-400 dark:text-stone-500 mt-2">합류하면 현재 내 가족에서 나가고 새 가족으로 이동합니다</p>
       </div>
 
+      {/* 캘린더 표시 설정 */}
+      <div className="rounded-2xl bg-white dark:bg-stone-900 border border-stone-100 dark:border-stone-800 p-4 mb-4">
+        <p className="text-xs font-semibold text-stone-400 dark:text-stone-500 uppercase tracking-wide mb-3">
+          캘린더 표시
+        </p>
+        <div className="flex items-center justify-between py-1">
+          <span className="text-sm text-stone-700 dark:text-stone-300">음력</span>
+          <button
+            role="switch"
+            aria-checked={preferences?.show_lunar ?? false}
+            onClick={() => updatePreferences({ show_lunar: !(preferences?.show_lunar ?? false) })}
+            className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+              (preferences?.show_lunar ?? false)
+                ? 'bg-accent-400'
+                : 'bg-stone-200 dark:bg-stone-700'
+            }`}
+          >
+            <span
+              className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${
+                (preferences?.show_lunar ?? false) ? 'translate-x-6' : 'translate-x-1'
+              }`}
+            />
+          </button>
+        </div>
+      </div>
+
       {/* 휴일 표시 */}
       <div className="rounded-2xl bg-white dark:bg-stone-900 border border-stone-100 dark:border-stone-800 p-4 mb-4">
         <p className="text-xs font-semibold text-stone-400 dark:text-stone-500 uppercase tracking-wide mb-3">

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -34,6 +34,7 @@ export type Database = {
           user_id: string
           holiday_countries: string[]
           app_theme: string
+          show_lunar: boolean
           created_at: string
           updated_at: string
         }
@@ -41,6 +42,7 @@ export type Database = {
           user_id: string
           holiday_countries?: string[]
           app_theme?: string
+          show_lunar?: boolean
           created_at?: string
           updated_at?: string
         }
@@ -48,6 +50,7 @@ export type Database = {
           user_id?: string
           holiday_countries?: string[]
           app_theme?: string
+          show_lunar?: boolean
           created_at?: string
           updated_at?: string
         }

--- a/supabase/migrations/20260407000000_add_show_lunar_to_preferences.sql
+++ b/supabase/migrations/20260407000000_add_show_lunar_to_preferences.sql
@@ -1,0 +1,2 @@
+ALTER TABLE user_preferences
+  ADD COLUMN IF NOT EXISTS show_lunar boolean NOT NULL DEFAULT false;


### PR DESCRIPTION
## Summary

- 설정 화면에 **음력** ON/OFF 토글 추가 (캘린더 표시 섹션)
- 음력 ON 시 캘린더 각 날짜 셀 아래에 음력 날짜(예: `3/10`) 표시
- `korean-lunar-calendar` 라이브러리 사용 (한국 음력 기준, 정확도 높음)
- 한 달치 음력을 `useMemo`로 한 번에 계산 — month/year 변경 시에만 재계산

## Changes

- `supabase/migrations/` — `user_preferences.show_lunar boolean DEFAULT false` 컬럼 추가 (리모트 DB 적용 완료)
- `src/types/database.ts` — `UserPreferences` 타입에 `show_lunar` 추가
- `SettingsTab.tsx` — 음력 토글 UI 추가
- `CalendarGrid.tsx` — `showLunar` prop, 음력 날짜 렌더링
- `CalendarTab.tsx` — `preferences.show_lunar` → `CalendarGrid`에 전달

## Test plan

- [ ] 설정 → 캘린더 표시 섹션에 음력 토글이 표시되는지 확인
- [ ] 음력 ON → 캘린더 각 날짜 아래 음력 날짜(예: `3/10`)가 표시되는지 확인
- [ ] 음력 OFF → 음력 날짜가 사라지는지 확인
- [ ] 설정 저장 후 앱 재시작해도 음력 설정이 유지되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)