### PR TITLE
docs: sync multilingual readmes

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -2,89 +2,186 @@
 
 [한국어](README.ko.md) | **[日本語]** | [English](README.md)
 
-カレンダー、買い物リスト、メモをひとつにまとめた、家族のリアルタイム共有アプリです。
-iOS・Android・Webのどのデバイスからでもアクセスでき、変更はすべての家族に即座に反映されます。
+Kokoは、1つの共有アプリシェルを中心に動く家族向けコラボレーションPWAです。
+現在のプロダクト範囲は、カレンダー、買い物リスト、家族の招待/参加、ユーザー設定、Web Pushリマインダーです。
 
----
+## 現在の実装範囲
 
-## 機能
+- メール許可リストで制限されたGoogle OAuthログイン
+- 自動の家族作成と招待コードによる家族参加
+- 家族全体イベントとカレンダー単位の表示制御を持つカレンダー
+- Web Pushによるイベントリマインダー
+- リアルタイム同期とドラッグ並び替えに対応した買い物リスト
+- テーマ、祝日対象国、旧暦表示のユーザー設定
+- モバイルとデスクトップでインストール可能なPWA体験
 
-| 機能 | 説明 |
-|------|------|
-| カレンダー | 家族の予定を登録・管理、プッシュ通知でリマインダー設定 |
-| 買い物リスト | 商品を追加、リアルタイムでチェック、完了済みアイテムに取り消し線 |
-| メモ | 家族共有メモ、全デバイスに即座に反映 |
-| 予定投票 | 予定確定前に家族の参加可否を投票で確認 |
-| リアルタイム同期 | すべての変更が全デバイスに即時反映 |
-| PWA対応 | iPhone・Androidのホーム画面に追加してネイティブアプリのように使用可能 |
+現在のUIで未実装の項目:
 
----
+- メモ
+- 予定投票
 
-## 動作の仕組み
+これらはスキーマと生成済み型には存在しますが、現在のフロントエンドの動線には接続されていません。
 
-```
-家族メンバーの操作
-(予定追加 · 買い物チェック · メモ記入 · 投票)
-    │
-    ▼
-Supabase Realtime
-    PostgreSQL の変更を検知
-    → WebSocket で接続中の全デバイスに即時ブロードキャスト
-    │
-    ▼
-全デバイス更新
-    カレンダー / 買い物リスト / メモが即時反映
-    │
-    ▼
-プッシュ通知（該当する場合）
-    PWA Web Push → iOS・Android
-```
+## ランタイム構成
 
----
+アプリは1つの家族シェルを常時マウントしたまま利用します。
+
+- `/calendar` が実際のタブアプリの単一エントリールートです
+- `/shopping` と `/settings` は `/calendar` へリダイレクトされます
+- `TabsShell` が calendar、shopping、settings の各タブを常時マウントし、表示だけを切り替えます
+- `src/app/shopping/[id]/page.tsx` だけは例外で独立した詳細ルートとして残っています
+
+この構成により、タブ切り替え時の再読み込みスピナーを減らし、状態も維持できます。
+
+## リアルタイム同期モデル
+
+Kokoは `postgres_changes` ではなく Supabase Realtime Broadcast を使います。
+
+基本パターンは次の通りです。
+
+1. mutationを実行します。
+2. 必要なローカル状態を更新します。
+3. チャネルが `SUBSCRIBED` になった後で手動の `refresh` broadcast を送ります。
+
+この方式は以下の範囲で使われます。
+
+- 家族単位の買い物リスト更新
+- 特定の買い物リスト内アイテム更新
+- 月単位のカレンダーイベント更新
+
+## 認証と家族モデル
+
+- ログインはGoogle OAuthのみです。
+- OAuthコード交換はSupabaseが自動で処理します。
+- コールバックページで、サインイン済みメールを `allowed_emails` に対して検証します。
+- 有効な招待コードから来た初回ログインメールは、コールバック検証時に自動許可される場合があります。
+- `/api/family` はDB RPCを呼び出して、ユーザーの家族を原子的に取得または作成します。
+- `/api/family/join` はDB RPCを呼び出して、招待コードで別の家族に参加させます。
+
+アクティブな家族は、カレンダー、買い物リスト、家族メンバーデータのテナント境界です。
 
 ## 技術スタック
 
 | カテゴリ | 技術 |
-|----------|------|
-| フロントエンド | Next.js 16 (TypeScript, Tailwind CSS, App Router) |
-| バックエンド / DB | Supabase (PostgreSQL, Realtime, Auth) |
-| プッシュ通知 | PWA Web Push (iOS 16.4+, Android) |
-| CI/CD | GitHub Actions |
+| --- | --- |
+| フロントエンド | Next.js 16, React 19, TypeScript |
+| スタイリング | Tailwind CSS v4 |
+| バックエンド / DB | Supabase Auth, PostgreSQL, Realtime Broadcast |
+| 通知 | Web Push + service worker |
 | ホスティング | Vercel |
-
----
+| テスト | Jest + Testing Library |
 
 ## プロジェクト構成
 
-```
-koko/
-├── src/
-│   ├── app/                # Next.js App Router ページ
-│   ├── components/         # 共通UIコンポーネント
-│   ├── lib/                # Supabase クライアント・ユーティリティ
-│   └── types/              # TypeScript 型定義
-├── public/                 # 静的ファイル、PWA マニフェスト
-├── .github/workflows/      # GitHub Actions CI
-└── CLAUDE.md               # AI コーディングエージェント指示
+```text
+src/
+  app/                ルートエントリとAPI route
+  components/         UI構成とタブコンテナ
+  hooks/              共有クライアントフック
+  lib/                Supabase CRUD、APIヘルパー、ユーティリティ
+  types/              生成済みDB型と共有アプリ型
+  __tests__/          API、lib、hook、component、機能回帰テスト
+public/
+  manifest.json       PWAマニフェスト
+  sw.js               プッシュ通知用サービスワーカー
+supabase/
+  migrations/         スキーマ、RLS、RPC、運用修正
 ```
 
----
+プロジェクトを変更するときは、次の順に読むのを推奨します。
 
-## はじめに
+1. `AGENTS.md`
+2. `PROJECT_MAP.md`
+3. `PATTERNS.md`
+4. `CHALLENGES.md`
+
+## 主要ファイル
+
+- [`src/components/TabsShell.tsx`](/Users/codingclef/workspace/koko/src/components/TabsShell.tsx): keep-alive アプリシェル
+- [`src/components/tabs/CalendarTab.tsx`](/Users/codingclef/workspace/koko/src/components/tabs/CalendarTab.tsx): カレンダー実行コンテナ
+- [`src/components/tabs/ShoppingTab.tsx`](/Users/codingclef/workspace/koko/src/components/tabs/ShoppingTab.tsx): 買い物一覧コンテナ
+- [`src/components/tabs/SettingsTab.tsx`](/Users/codingclef/workspace/koko/src/components/tabs/SettingsTab.tsx): 設定と家族アクション
+- [`src/hooks/useRealtimeSync.ts`](/Users/codingclef/workspace/koko/src/hooks/useRealtimeSync.ts): 共通broadcast購読パターン
+- [`src/app/api/family/route.ts`](/Users/codingclef/workspace/koko/src/app/api/family/route.ts): 原子的な家族取得/作成
+- [`src/app/api/family/join/route.ts`](/Users/codingclef/workspace/koko/src/app/api/family/join/route.ts): 招待コードによる家族参加
+- [`src/app/api/cron/send-reminders/route.ts`](/Users/codingclef/workspace/koko/src/app/api/cron/send-reminders/route.ts): 定期リマインダー送信
+
+## 環境変数
+
+`.env.local` には少なくとも次を設定してください。
+
+```env
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
+SUPABASE_SERVICE_ROLE_KEY=
+NEXT_PUBLIC_VAPID_PUBLIC_KEY=
+VAPID_PRIVATE_KEY=
+CRON_SECRET=
+```
+
+各変数の用途:
+
+- `NEXT_PUBLIC_SUPABASE_URL`: 共通のSupabaseプロジェクトURL
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY`: ブラウザクライアント認証と通常データアクセス
+- `SUPABASE_SERVICE_ROLE_KEY`: RPCと保護テーブルアクセス用のサーバーadmin client
+- `NEXT_PUBLIC_VAPID_PUBLIC_KEY`: ブラウザのプッシュ購読登録
+- `VAPID_PRIVATE_KEY`: サーバー側プッシュ送信
+- `CRON_SECRET`: リマインダーcron endpointの保護
+
+## ローカル開発
 
 ```bash
 npm install
 npm run dev
 ```
 
-ブラウザで [http://localhost:3000](http://localhost:3000) を開いてください。
+ブラウザで `http://localhost:3000` を開きます。
 
-### 環境変数
+日常的に推奨するコマンド:
 
-プロジェクトルートに `.env.local` ファイルを作成してください:
-
-```env
-NEXT_PUBLIC_SUPABASE_URL=your_supabase_url
-NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
+```bash
+npm run lint
+npm run test
+npx tsc --noEmit
 ```
 
+## テスト
+
+現在のリポジトリには次の領域の回帰テストが含まれています。
+
+- API routes
+- Supabase連携の `lib/*`
+- 共有 hooks
+- カレンダー、買い物、設定、シェルUIの挙動
+
+コードを変更するときは関連テストも更新し、作業完了前に `npx tsc --noEmit` を実行する必要があります。
+
+## データベースメモ
+
+スキーマとRLSは `supabase/migrations` にあります。
+
+現在重要なテーブル:
+
+- `families`
+- `family_members`
+- `allowed_emails`
+- `user_preferences`
+- `calendars`
+- `calendar_members`
+- `events`
+- `event_reminders`
+- `shopping_lists`
+- `shopping_items`
+- `push_subscriptions`
+
+現在重要なRPCおよびmigrationベースの挙動:
+
+- 原子的な家族作成
+- 招待コードによる原子的な家族参加
+- リマインダー取得と sent-at マーキング
+- 家族、買い物、カレンダーメンバーシップのRLS修正
+
+## ドキュメントメモ
+
+`PATTERNS.md` は維持すべき実装ルールをまとめます。
+`CHALLENGES.md` はそのルールが生まれた不具合と回帰背景を記録します。

--- a/README.ko.md
+++ b/README.ko.md
@@ -2,89 +2,186 @@
 
 **[한국어]** | [日本語](README.ja.md) | [English](README.md)
 
-캘린더, 장바구니, 메모를 하나로 통합한 가족 실시간 협업 앱입니다.
-iOS, Android, 웹 어디서든 접속 가능하며, 모든 가족에게 변경사항이 즉시 반영됩니다.
+Koko는 하나의 공유 앱 셸을 중심으로 동작하는 가족 협업 PWA입니다.
+현재 제품 범위는 캘린더, 장보기 목록, 가족 초대/합류, 사용자 설정, 웹 푸시 리마인더입니다.
 
----
+## 현재 구현 범위
 
-## 기능
+- 이메일 허용 목록으로 제한된 Google OAuth 로그인
+- 자동 가족 생성과 초대 코드 기반 가족 합류
+- 가족 공용 일정과 캘린더별 가시성을 지원하는 캘린더
+- Web Push 기반 이벤트 리마인더
+- 실시간 동기화와 드래그 정렬을 지원하는 장보기 목록
+- 테마, 공휴일 국가, 음력 표시를 위한 사용자 설정
+- 모바일과 데스크톱에서 설치 가능한 PWA 경험
 
-| 기능 | 설명 |
-|------|------|
-| 캘린더 | 가족 일정 등록 및 관리, 푸시 알림 설정 |
-| 장바구니 | 아이템 추가, 실시간 체크, 완료 항목 취소선 표시 |
-| 메모 | 가족 공유 메모, 모든 기기에 즉시 반영 |
-| 일정 투표 | 일정 확정 전 가족 참석 가능 여부 투표 |
-| 실시간 동기화 | 모든 변경사항이 전체 기기에 즉시 반영 |
-| PWA 지원 | 아이폰 / 안드로이드 홈 화면에 추가 — 네이티브 앱처럼 동작 |
+현재 UI에 구현되지 않은 항목:
 
----
+- 메모
+- 일정 투표
 
-## 동작 방식
+이 항목들은 스키마와 생성된 타입에는 존재하지만, 현재 프런트엔드 흐름에는 연결되어 있지 않습니다.
 
-```
-가족 구성원 액션
-(일정 추가 · 장바구니 체크 · 메모 작성 · 투표)
-    │
-    ▼
-Supabase Realtime
-    PostgreSQL 변경 감지
-    → WebSocket으로 연결된 모든 기기에 즉시 브로드캐스트
-    │
-    ▼
-전체 기기 업데이트
-    캘린더 / 장바구니 / 메모 즉시 반영
-    │
-    ▼
-푸시 알림 (해당하는 경우)
-    PWA Web Push → iOS 및 Android
-```
+## 런타임 구조
 
----
+앱은 하나의 가족 셸을 계속 마운트한 상태로 사용합니다.
+
+- `/calendar`가 실제 탭 앱의 단일 진입 라우트입니다
+- `/shopping`, `/settings`는 `/calendar`로 다시 리다이렉트됩니다
+- `TabsShell`이 calendar, shopping, settings 탭을 계속 마운트한 채로 유지하고 표시만 전환합니다
+- `src/app/shopping/[id]/page.tsx`만 예외적으로 독립 상세 라우트로 남아 있습니다
+
+이 구조 덕분에 탭 전환 시 재로딩 스피너가 줄고, 탭 상태도 유지됩니다.
+
+## 실시간 동기화 모델
+
+Koko는 `postgres_changes`가 아니라 Supabase Realtime Broadcast를 사용합니다.
+
+패턴은 다음과 같습니다.
+
+1. mutation을 수행합니다.
+2. 필요한 로컬 상태를 갱신합니다.
+3. 채널이 `SUBSCRIBED` 상태가 된 뒤 수동으로 `refresh` broadcast를 보냅니다.
+
+이 방식은 다음 범위에 사용됩니다.
+
+- 가족 단위 장보기 목록 새로고침
+- 특정 장보기 목록 내부 아이템 새로고침
+- 월 단위 캘린더 이벤트 새로고침
+
+## 인증 및 가족 모델
+
+- 로그인은 Google OAuth만 사용합니다.
+- OAuth 코드 교환은 Supabase가 자동으로 처리합니다.
+- 콜백 페이지에서 로그인된 이메일을 `allowed_emails` 기준으로 검증합니다.
+- 유효한 초대 코드로 들어온 첫 로그인 이메일은 콜백 검증 과정에서 자동 허용될 수 있습니다.
+- `/api/family`는 DB RPC를 호출해 사용자의 가족을 원자적으로 조회 또는 생성합니다.
+- `/api/family/join`은 DB RPC를 호출해 초대 코드로 다른 가족에 합류시킵니다.
+
+활성 가족은 캘린더, 장보기 목록, 가족 구성원 데이터의 테넌트 경계입니다.
 
 ## 기술 스택
 
 | 분류 | 기술 |
-|------|------|
-| 프론트엔드 | Next.js 16 (TypeScript, Tailwind CSS, App Router) |
-| 백엔드 / DB | Supabase (PostgreSQL, Realtime, Auth) |
-| 푸시 알림 | PWA Web Push (iOS 16.4+, Android) |
-| CI/CD | GitHub Actions |
+| --- | --- |
+| 프런트엔드 | Next.js 16, React 19, TypeScript |
+| 스타일링 | Tailwind CSS v4 |
+| 백엔드 / DB | Supabase Auth, PostgreSQL, Realtime Broadcast |
+| 알림 | Web Push + service worker |
 | 호스팅 | Vercel |
-
----
+| 테스트 | Jest + Testing Library |
 
 ## 프로젝트 구조
 
-```
-koko/
-├── src/
-│   ├── app/                # Next.js App Router 페이지
-│   ├── components/         # 공통 UI 컴포넌트
-│   ├── lib/                # Supabase 클라이언트, 유틸리티
-│   └── types/              # TypeScript 타입 정의
-├── public/                 # 정적 파일, PWA 매니페스트
-├── .github/workflows/      # GitHub Actions CI
-└── CLAUDE.md               # AI 코딩 에이전트 지침
+```text
+src/
+  app/                라우트 진입점과 API route
+  components/         UI 조합과 탭 컨테이너
+  hooks/              공용 클라이언트 훅
+  lib/                Supabase CRUD, API 헬퍼, 유틸리티
+  types/              생성된 DB 타입과 공용 앱 타입
+  __tests__/          API, lib, hook, component, 기능 회귀 테스트
+public/
+  manifest.json       PWA 매니페스트
+  sw.js               푸시 알림용 서비스 워커
+supabase/
+  migrations/         스키마, RLS, RPC, 운영 수정 이력
 ```
 
----
+프로젝트를 수정할 때는 아래 문서 순서로 읽는 것을 권장합니다.
 
-## 시작하기
+1. `AGENTS.md`
+2. `PROJECT_MAP.md`
+3. `PATTERNS.md`
+4. `CHALLENGES.md`
+
+## 주요 파일
+
+- [`src/components/TabsShell.tsx`](/Users/codingclef/workspace/koko/src/components/TabsShell.tsx): keep-alive 앱 셸
+- [`src/components/tabs/CalendarTab.tsx`](/Users/codingclef/workspace/koko/src/components/tabs/CalendarTab.tsx): 캘린더 런타임 컨테이너
+- [`src/components/tabs/ShoppingTab.tsx`](/Users/codingclef/workspace/koko/src/components/tabs/ShoppingTab.tsx): 장보기 개요 컨테이너
+- [`src/components/tabs/SettingsTab.tsx`](/Users/codingclef/workspace/koko/src/components/tabs/SettingsTab.tsx): 설정 및 가족 액션
+- [`src/hooks/useRealtimeSync.ts`](/Users/codingclef/workspace/koko/src/hooks/useRealtimeSync.ts): 공용 broadcast 구독 패턴
+- [`src/app/api/family/route.ts`](/Users/codingclef/workspace/koko/src/app/api/family/route.ts): 원자적 가족 생성/조회
+- [`src/app/api/family/join/route.ts`](/Users/codingclef/workspace/koko/src/app/api/family/join/route.ts): 초대 코드 기반 가족 합류
+- [`src/app/api/cron/send-reminders/route.ts`](/Users/codingclef/workspace/koko/src/app/api/cron/send-reminders/route.ts): 예약 리마인더 발송
+
+## 환경 변수
+
+`.env.local`에 최소한 아래 값을 설정해야 합니다.
+
+```env
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
+SUPABASE_SERVICE_ROLE_KEY=
+NEXT_PUBLIC_VAPID_PUBLIC_KEY=
+VAPID_PRIVATE_KEY=
+CRON_SECRET=
+```
+
+각 변수의 용도:
+
+- `NEXT_PUBLIC_SUPABASE_URL`: 공용 Supabase 프로젝트 URL
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY`: 브라우저 클라이언트 인증 및 일반 데이터 접근
+- `SUPABASE_SERVICE_ROLE_KEY`: RPC와 보호 테이블 접근용 서버 admin client
+- `NEXT_PUBLIC_VAPID_PUBLIC_KEY`: 브라우저 푸시 구독 등록
+- `VAPID_PRIVATE_KEY`: 서버 측 푸시 발송
+- `CRON_SECRET`: 리마인더 cron endpoint 보호
+
+## 로컬 개발
 
 ```bash
 npm install
 npm run dev
 ```
 
-브라우저에서 [http://localhost:3000](http://localhost:3000) 접속
+브라우저에서 `http://localhost:3000`을 엽니다.
 
-### 환경 변수
+일상적으로 권장하는 명령:
 
-프로젝트 루트에 `.env.local` 파일을 생성하세요:
-
-```env
-NEXT_PUBLIC_SUPABASE_URL=your_supabase_url
-NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
+```bash
+npm run lint
+npm run test
+npx tsc --noEmit
 ```
 
+## 테스트
+
+현재 저장소에는 다음 영역의 회귀 테스트가 포함되어 있습니다.
+
+- API routes
+- Supabase 연동 `lib/*`
+- 공용 hooks
+- 캘린더, 장보기, 설정, 셸 UI 동작
+
+코드를 변경할 때는 관련 테스트를 함께 갱신하고, 작업 완료 전에 `npx tsc --noEmit`를 실행해야 합니다.
+
+## 데이터베이스 메모
+
+스키마와 RLS는 `supabase/migrations`에 있습니다.
+
+현재 중요한 테이블:
+
+- `families`
+- `family_members`
+- `allowed_emails`
+- `user_preferences`
+- `calendars`
+- `calendar_members`
+- `events`
+- `event_reminders`
+- `shopping_lists`
+- `shopping_items`
+- `push_subscriptions`
+
+현재 중요한 RPC 및 migration 기반 동작:
+
+- 원자적 가족 생성
+- 초대 코드 기반 원자적 가족 합류
+- 리마인더 조회 및 sent-at 마킹
+- 가족, 장보기, 캘린더 멤버십 흐름의 RLS 수정
+
+## 문서 메모
+
+`PATTERNS.md`는 유지해야 할 구현 규칙을 정리합니다.
+`CHALLENGES.md`는 그 규칙이 생긴 버그와 회귀 배경을 기록합니다.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Koko
+# 🏠 Koko — Family Hub
+
+[한국어](README.ko.md) | [日本語](README.ja.md) | **[English]**
 
 Koko is a family collaboration PWA built around one shared app shell.
 The current product surface is calendar, shopping lists, family invite/join, user preferences, and web-push reminders.


### PR DESCRIPTION
## Summary
- restore the multilingual README header format in `README.md`
- update `README.ko.md` and `README.ja.md` to match the current implemented product scope and runtime model
- keep the three README files aligned on features, environment variables, and development notes

## Testing
- not run (documentation-only change)

- [ ] Manual visual verification not required for this documentation-only change