### PR TITLE
feat: add calendar list management screen with per-calendar settings

### DIFF
--- a/src/__tests__/components/CalendarDetailScreen.test.tsx
+++ b/src/__tests__/components/CalendarDetailScreen.test.tsx
@@ -1,0 +1,164 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { CalendarDetailScreen } from '@/components/calendar/CalendarDetailScreen'
+import type { Calendar, FamilyMember } from '@/lib/calendar'
+
+jest.mock('@/lib/calendar', () => ({
+  CALENDAR_COLORS: ['#f97316'],
+  CALENDAR_COLOR_NAMES: { '#f97316': '주황색' },
+}))
+
+const mockCalendar: Calendar = {
+  id: 'cal-1',
+  family_id: 'fam-1',
+  created_by: 'user-1',
+  name: '가족',
+  color: '#f97316',
+  created_at: '',
+  updated_at: '',
+}
+
+const otherMember: FamilyMember = {
+  id: 'fm-2',
+  user_id: 'user-2',
+  family_id: 'fam-1',
+  display_name: '엄마',
+  role: 'member',
+  created_at: '',
+}
+
+const defaultProps = {
+  calendar: mockCalendar,
+  familyMembers: [otherMember],
+  currentUserId: 'user-1',
+  onBack: jest.fn(),
+  onSave: jest.fn(),
+  onDelete: jest.fn(),
+}
+
+describe('CalendarDetailScreen', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  it('멤버 로드 실패(memberLoadError) 시 onSave에 null 전달', async () => {
+    defaultProps.onSave.mockResolvedValue({ status: 'success' })
+
+    render(
+      <CalendarDetailScreen
+        {...defaultProps}
+        memberIds={null}
+        memberLoadError={true}
+      />
+    )
+
+    fireEvent.click(screen.getByText('저장'))
+
+    await waitFor(() => {
+      expect(defaultProps.onSave).toHaveBeenCalledWith('cal-1', '가족', '#f97316', null)
+    })
+  })
+
+  it('멤버 로딩 중(memberIds null, 에러 없음) 시 저장 버튼 비활성화', () => {
+    render(
+      <CalendarDetailScreen
+        {...defaultProps}
+        memberIds={null}
+        memberLoadError={false}
+      />
+    )
+
+    expect(screen.getByText('저장').closest('button')).toBeDisabled()
+  })
+
+  it('onSave가 success 반환 시 onBack 호출', async () => {
+    defaultProps.onSave.mockResolvedValue({ status: 'success' })
+
+    render(
+      <CalendarDetailScreen
+        {...defaultProps}
+        memberIds={['user-1']}
+        memberLoadError={false}
+      />
+    )
+
+    fireEvent.click(screen.getByText('저장'))
+
+    await waitFor(() => {
+      expect(defaultProps.onBack).toHaveBeenCalled()
+    })
+  })
+
+  it('onSave가 partial 반환 시 onBack 호출', async () => {
+    defaultProps.onSave.mockResolvedValue({ status: 'partial' })
+
+    render(
+      <CalendarDetailScreen
+        {...defaultProps}
+        memberIds={['user-1']}
+        memberLoadError={false}
+      />
+    )
+
+    fireEvent.click(screen.getByText('저장'))
+
+    await waitFor(() => {
+      expect(defaultProps.onBack).toHaveBeenCalled()
+    })
+  })
+
+  it('onSave가 throw 시 화면 유지 + 에러 표시', async () => {
+    defaultProps.onSave.mockRejectedValue(new Error('save failed'))
+
+    render(
+      <CalendarDetailScreen
+        {...defaultProps}
+        memberIds={['user-1']}
+        memberLoadError={false}
+      />
+    )
+
+    fireEvent.click(screen.getByText('저장'))
+
+    await waitFor(() => {
+      expect(screen.getByText('저장에 실패했습니다. 다시 시도해주세요.')).toBeInTheDocument()
+    })
+    expect(defaultProps.onBack).not.toHaveBeenCalled()
+  })
+
+  it('삭제 성공 시 onBack 호출', async () => {
+    defaultProps.onDelete.mockResolvedValue(undefined)
+
+    render(
+      <CalendarDetailScreen
+        {...defaultProps}
+        memberIds={['user-1']}
+        memberLoadError={false}
+      />
+    )
+
+    fireEvent.click(screen.getByText('캘린더 삭제'))
+    fireEvent.click(screen.getByText('정말 삭제'))
+
+    await waitFor(() => {
+      expect(defaultProps.onBack).toHaveBeenCalled()
+    })
+  })
+
+  it('삭제 실패 시 화면 유지 + 에러 표시', async () => {
+    defaultProps.onDelete.mockRejectedValue(new Error('delete failed'))
+
+    render(
+      <CalendarDetailScreen
+        {...defaultProps}
+        memberIds={['user-1']}
+        memberLoadError={false}
+      />
+    )
+
+    fireEvent.click(screen.getByText('캘린더 삭제'))
+    fireEvent.click(screen.getByText('정말 삭제'))
+
+    await waitFor(() => {
+      expect(screen.getByText('삭제에 실패했습니다. 다시 시도해주세요.')).toBeInTheDocument()
+    })
+    expect(defaultProps.onBack).not.toHaveBeenCalled()
+  })
+})

--- a/src/__tests__/components/CalendarListSheet.test.tsx
+++ b/src/__tests__/components/CalendarListSheet.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { CalendarListSheet } from '@/components/calendar/CalendarListSheet'
+import type { Calendar, FamilyMember } from '@/lib/calendar'
+
+jest.mock('@/lib/calendar', () => ({
+  getCalendarMembers: jest.fn().mockResolvedValue([]),
+  getCalendarMembersForCalendars: jest.fn().mockResolvedValue([]),
+  CALENDAR_COLORS: ['#f97316'],
+  CALENDAR_COLOR_NAMES: { '#f97316': '주황색' },
+}))
+
+jest.mock('@/components/calendar/CalendarDetailScreen', () => ({
+  CalendarDetailScreen: ({
+    onBack,
+    onSave,
+  }: {
+    onBack: () => void
+    onSave: (id: string, name: string, color: string, memberIds: string[] | null) => Promise<{ status: string }>
+  }) => (
+    <div data-testid="calendar-detail">
+      <button onClick={onBack}>뒤로</button>
+      {/* 실제 컴포넌트처럼 save 후 onBack 호출 */}
+      <button onClick={() => onSave('cal-1', '가족', '#f97316', null).then(onBack)}>저장(null멤버)</button>
+      <button onClick={() => onSave('cal-1', '가족', '#f97316', []).then(onBack)}>저장(빈멤버)</button>
+    </div>
+  ),
+}))
+
+const mockCalendars: Calendar[] = [{
+  id: 'cal-1',
+  family_id: 'fam-1',
+  created_by: 'user-1',
+  name: '가족',
+  color: '#f97316',
+  created_at: '',
+  updated_at: '',
+}]
+
+const defaultProps = {
+  calendars: mockCalendars,
+  familyMembers: [] as FamilyMember[],
+  currentUserId: 'user-1',
+  onClose: jest.fn(),
+  onAdd: jest.fn(),
+  onSave: jest.fn().mockResolvedValue({ status: 'success' }),
+  onDelete: jest.fn(),
+}
+
+describe('CalendarListSheet', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    defaultProps.onSave.mockResolvedValue({ status: 'success' })
+  })
+
+  it('캘린더 클릭 시 상세 뷰로 진입', async () => {
+    render(<CalendarListSheet {...defaultProps} />)
+
+    fireEvent.click(screen.getByText('가족'))
+
+    expect(await screen.findByTestId('calendar-detail')).toBeInTheDocument()
+  })
+
+  it('뒤로 클릭 시 리스트 뷰로 복귀', async () => {
+    render(<CalendarListSheet {...defaultProps} />)
+
+    fireEvent.click(screen.getByText('가족'))
+    await screen.findByTestId('calendar-detail')
+
+    fireEvent.click(screen.getByText('뒤로'))
+
+    expect(screen.queryByTestId('calendar-detail')).not.toBeInTheDocument()
+    expect(screen.getByText('가족')).toBeInTheDocument()
+  })
+
+  it('새로운 캘린더 만들기 클릭 시 onAdd 호출', () => {
+    render(<CalendarListSheet {...defaultProps} />)
+
+    fireEvent.click(screen.getByText('새로운 캘린더 만들기'))
+
+    expect(defaultProps.onAdd).toHaveBeenCalled()
+  })
+
+  it('onSave가 partial 반환 시 리스트 뷰에 경고 배너 표시', async () => {
+    defaultProps.onSave.mockResolvedValue({ status: 'partial' })
+
+    render(<CalendarListSheet {...defaultProps} />)
+
+    fireEvent.click(screen.getByText('가족'))
+    await screen.findByTestId('calendar-detail')
+
+    fireEvent.click(screen.getByText('저장(빈멤버)'))
+
+    await waitFor(() => {
+      expect(screen.getByText('캘린더 정보는 저장됐지만 멤버는 저장하지 못했어요')).toBeInTheDocument()
+    })
+  })
+})

--- a/src/__tests__/components/CalendarTab.test.tsx
+++ b/src/__tests__/components/CalendarTab.test.tsx
@@ -1,7 +1,7 @@
 import { render, act, fireEvent, screen, waitFor } from '@testing-library/react'
 import type { User } from '@supabase/supabase-js'
 import { CalendarTab } from '@/components/tabs/CalendarTab'
-import { getCalendarMembers, getEventsByMonth, getFamilyMembers } from '@/lib/calendar'
+import { getCalendarMembers, getEventsByMonth, getFamilyMembers, setCalendarMembers, updateCalendar } from '@/lib/calendar'
 
 // ── 의존성 모킹 ──────────────────────────────────────────────
 const mockReloadCalendars = jest.fn()
@@ -111,7 +111,19 @@ jest.mock('@/components/calendar/CalendarFormModal', () => ({
   CalendarFormModal: () => <div />,
 }))
 jest.mock('@/components/calendar/CalendarListSheet', () => ({
-  CalendarListSheet: () => <div />,
+  CalendarListSheet: ({
+    onSave,
+    onDelete,
+  }: {
+    onSave: (calendarId: string, name: string, color: string, memberIds: string[] | null) => Promise<{ status: string }>
+    onDelete: (calendarId: string) => Promise<void>
+  }) => (
+    <div data-testid="calendar-list-sheet">
+      <button data-testid="list-save-null-members" onClick={() => onSave('cal-1', '가족', '#f97316', null)} />
+      <button data-testid="list-save-with-members" onClick={() => onSave('cal-1', '가족', '#f97316', ['user-2'])} />
+      <button data-testid="list-delete" onClick={() => onDelete('cal-1')} />
+    </div>
+  ),
 }))
 jest.mock('@/components/calendar/YearMonthPickerSheet', () => ({
   YearMonthPickerSheet: ({
@@ -135,6 +147,8 @@ jest.mock('@/components/calendar/YearMonthPickerSheet', () => ({
 const mockGetEventsByMonth = getEventsByMonth as jest.MockedFunction<typeof getEventsByMonth>
 const mockGetFamilyMembers = getFamilyMembers as jest.MockedFunction<typeof getFamilyMembers>
 const mockGetCalendarMembers = getCalendarMembers as jest.MockedFunction<typeof getCalendarMembers>
+const mockSetCalendarMembers = setCalendarMembers as jest.MockedFunction<typeof setCalendarMembers>
+const mockUpdateCalendar = updateCalendar as jest.MockedFunction<typeof updateCalendar>
 let consoleErrorSpy: jest.SpyInstance
 
 describe('CalendarTab — touch-action 스크롤 차단', () => {
@@ -352,5 +366,89 @@ describe('CalendarTab — touch-action 스크롤 차단', () => {
     await act(async () => {
       resolvePrefetch?.([])
     })
+  })
+})
+
+describe('CalendarTab — handleCalendarUpdate', () => {
+  let consoleErrorSpy: jest.SpyInstance
+
+  beforeAll(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterAll(() => {
+    consoleErrorSpy.mockRestore()
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseCalendars.mockReturnValue({
+      calendars: [{
+        id: 'cal-1',
+        family_id: 'fam-1',
+        created_by: 'user-1',
+        name: '가족',
+        color: '#f97316',
+        created_at: '',
+        updated_at: '',
+      }],
+      loading: false,
+      error: null,
+      reload: mockReloadCalendars,
+    })
+    mockGetEventsByMonth.mockResolvedValue([])
+    mockGetFamilyMembers.mockResolvedValue([])
+    mockGetCalendarMembers.mockResolvedValue([])
+    mockUpdateCalendar.mockResolvedValue(undefined)
+    mockSetCalendarMembers.mockResolvedValue(undefined)
+  })
+
+  const openCalendarList = async () => {
+    render(
+      <CalendarTab
+        preferences={null}
+        user={{ id: 'user-1' } as User}
+        familyId="fam-1"
+        isInitializing={false}
+      />
+    )
+    await act(async () => {})
+    fireEvent.click(screen.getByRole('button', { name: '캘린더 리스트' }))
+    await screen.findByTestId('calendar-list-sheet')
+  }
+
+  it('memberIds null 이면 setCalendarMembers를 호출하지 않는다', async () => {
+    await openCalendarList()
+
+    fireEvent.click(screen.getByTestId('list-save-null-members'))
+
+    await waitFor(() => {
+      expect(mockUpdateCalendar).toHaveBeenCalledWith('cal-1', { name: '가족', color: '#f97316' })
+      expect(mockSetCalendarMembers).not.toHaveBeenCalled()
+    })
+  })
+
+  it('memberIds 배열이면 setCalendarMembers를 호출한다', async () => {
+    await openCalendarList()
+
+    fireEvent.click(screen.getByTestId('list-save-with-members'))
+
+    await waitFor(() => {
+      expect(mockSetCalendarMembers).toHaveBeenCalledWith('cal-1', 'user-1', ['user-2'])
+    })
+  })
+
+  it('setCalendarMembers 실패 시 CalendarTab 에러 배너를 표시하지 않는다 (부분 성공)', async () => {
+    mockSetCalendarMembers.mockRejectedValue(new Error('member save failed'))
+
+    await openCalendarList()
+    fireEvent.click(screen.getByTestId('list-save-with-members'))
+
+    await waitFor(() => {
+      expect(mockUpdateCalendar).toHaveBeenCalled()
+      expect(mockSetCalendarMembers).toHaveBeenCalled()
+    })
+    // 부분 성공은 throw가 아닌 partial 반환이므로 CalendarTab 에러 배너 없음
+    expect(screen.queryByText('캘린더를 저장하지 못했어요')).not.toBeInTheDocument()
   })
 })

--- a/src/components/calendar/CalendarDetailScreen.tsx
+++ b/src/components/calendar/CalendarDetailScreen.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react'
 import { ChevronLeft, Check } from 'lucide-react'
-import { CALENDAR_COLORS, CALENDAR_COLOR_NAMES, type Calendar, type FamilyMember } from '@/lib/calendar'
+import { CALENDAR_COLORS, CALENDAR_COLOR_NAMES, type Calendar, type FamilyMember, type SaveResult } from '@/lib/calendar'
 
 interface Props {
   calendar: Calendar
@@ -19,10 +19,10 @@ interface Props {
   onBack: () => void
   /**
    * memberIds가 null(에러 포함) 이면 멤버 변경 저장 skip.
-   * 공통 배너: 이름/색상 실패 → "저장하지 못했어요"
-   *           이름/색상 성공 + 멤버 실패 → CalendarTab 핸들러가 throw, 여기서 catch.
+   * 이름/색상 실패 → throw → 이 컴포넌트 catch → 화면 유지 + 에러 표시
+   * 이름/색상 성공 + 멤버 실패 → { status: 'partial' } 반환 → onBack() 호출
    */
-  onSave: (calendarId: string, name: string, color: string, memberIds: string[] | null) => Promise<void>
+  onSave: (calendarId: string, name: string, color: string, memberIds: string[] | null) => Promise<SaveResult>
   /** 성공 시 onBack() 호출. 실패 시 detail 화면 유지 + 에러 표시 */
   onDelete: (calendarId: string) => Promise<void>
 }

--- a/src/components/calendar/CalendarDetailScreen.tsx
+++ b/src/components/calendar/CalendarDetailScreen.tsx
@@ -1,0 +1,285 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { ChevronLeft, Check } from 'lucide-react'
+import { CALENDAR_COLORS, CALENDAR_COLOR_NAMES, type Calendar, type FamilyMember } from '@/lib/calendar'
+
+interface Props {
+  calendar: Calendar
+  /**
+   * null = 멤버 로딩 중 (저장 비활성화)
+   * string[] = 로드 완료
+   * memberLoadError=true 일 때도 null 유지 (빈 배열로 위장하지 않음)
+   */
+  memberIds: string[] | null
+  /** true 면 멤버 섹션에 에러 문구 표시, 저장 시 setCalendarMembers skip */
+  memberLoadError: boolean
+  familyMembers: FamilyMember[]
+  currentUserId: string
+  onBack: () => void
+  /**
+   * memberIds가 null(에러 포함) 이면 멤버 변경 저장 skip.
+   * 공통 배너: 이름/색상 실패 → "저장하지 못했어요"
+   *           이름/색상 성공 + 멤버 실패 → CalendarTab 핸들러가 throw, 여기서 catch.
+   */
+  onSave: (calendarId: string, name: string, color: string, memberIds: string[] | null) => Promise<void>
+  /** 성공 시 onBack() 호출. 실패 시 detail 화면 유지 + 에러 표시 */
+  onDelete: (calendarId: string) => Promise<void>
+}
+
+export function CalendarDetailScreen({
+  calendar,
+  memberIds,
+  memberLoadError,
+  familyMembers,
+  currentUserId,
+  onBack,
+  onSave,
+  onDelete,
+}: Props) {
+  const [name, setName] = useState(calendar.name)
+  const [color, setColor] = useState(calendar.color)
+
+  // owner(currentUserId) 제외한 나머지 구성원만 선택 대상
+  const selectableMembers = familyMembers.filter((m) => m.user_id !== currentUserId)
+
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+  useEffect(() => {
+    if (memberIds !== null) {
+      setSelectedIds(new Set(memberIds.filter((id) => id !== currentUserId)))
+    }
+  }, [memberIds, currentUserId])
+
+  const [saving, setSaving] = useState(false)
+  // 공통 에러 배너 (저장 버튼 바로 위) — 상황별 메시지 구분
+  const [saveError, setSaveError] = useState<string | null>(null)
+  const [confirmDelete, setConfirmDelete] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
+
+  const membersStillLoading = memberIds === null && !memberLoadError
+  const isSaveDisabled = membersStillLoading || saving
+
+  const toggleMember = (userId: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(userId)) next.delete(userId)
+      else next.add(userId)
+      return next
+    })
+  }
+
+  const handleSave = async () => {
+    if (!name.trim() || saving) return
+    setSaving(true)
+    setSaveError(null)
+    try {
+      // memberLoadError 또는 아직 null 이면 null 전달 → 핸들러가 멤버 저장 skip
+      const memberIdsToSave = memberLoadError || memberIds === null
+        ? null
+        : Array.from(selectedIds)
+      await onSave(calendar.id, name.trim(), color, memberIdsToSave)
+      onBack()
+    } catch (e) {
+      console.error('[CalendarDetailScreen] save failed:', e)
+      setSaveError('저장에 실패했습니다. 다시 시도해주세요.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (!confirmDelete) {
+      setConfirmDelete(true)
+      return
+    }
+    setDeleting(true)
+    setDeleteError(null)
+    try {
+      await onDelete(calendar.id)
+      onBack() // 삭제 성공 시에만 리스트로 복귀
+    } catch (e) {
+      console.error('[CalendarDetailScreen] delete failed:', e)
+      setDeleteError('삭제에 실패했습니다. 다시 시도해주세요.')
+      setConfirmDelete(false)
+    } finally {
+      setDeleting(false)
+    }
+  }
+
+  return (
+    <div className="absolute inset-0 flex flex-col bg-stone-50 dark:bg-stone-950 overflow-hidden">
+      {/* 헤더 */}
+      <div className="flex items-center gap-1 px-4 pt-12 pb-4 shrink-0 bg-stone-50 dark:bg-stone-950">
+        <button
+          onClick={onBack}
+          className="flex items-center justify-center min-h-[44px] min-w-[44px] -ml-2.5 rounded-xl text-stone-500 dark:text-stone-400 hover:bg-stone-100 dark:hover:bg-stone-800 transition-colors"
+          aria-label="뒤로"
+        >
+          <ChevronLeft size={22} />
+        </button>
+        <h1 className="text-xl font-bold text-stone-800 dark:text-stone-100 truncate">
+          {calendar.name}
+        </h1>
+      </div>
+
+      {/* 스크롤 영역 */}
+      <div className="flex-1 overflow-y-auto px-4 pb-safe space-y-4">
+
+        {/* 기본 정보 */}
+        <div className="rounded-2xl bg-white dark:bg-stone-900 border border-stone-100 dark:border-stone-800 p-4">
+          <p className="text-xs font-semibold text-stone-400 dark:text-stone-500 uppercase tracking-wide mb-3">
+            기본 정보
+          </p>
+
+          {/* 이름 */}
+          <div className="mb-4">
+            <label className="block text-xs text-stone-500 dark:text-stone-400 mb-1.5">이름</label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="캘린더 이름"
+              maxLength={30}
+              className="w-full px-3 py-2.5 rounded-xl border border-stone-200 dark:border-stone-700 bg-stone-50 dark:bg-stone-800 text-stone-800 dark:text-stone-100 placeholder:text-stone-400 focus:outline-none focus:ring-2 focus:ring-accent-400 text-sm"
+            />
+          </div>
+
+          {/* 색상 */}
+          <div>
+            <label className="block text-xs text-stone-500 dark:text-stone-400 mb-2">색상</label>
+            <div className="flex gap-1 flex-wrap">
+              {CALENDAR_COLORS.map((c) => (
+                <button
+                  key={c}
+                  onClick={() => setColor(c)}
+                  aria-pressed={color === c}
+                  aria-label={CALENDAR_COLOR_NAMES[c] ?? c}
+                  className="flex items-center justify-center min-w-[44px] min-h-[44px] rounded-full transition-transform"
+                >
+                  <span
+                    className="w-8 h-8 rounded-full block"
+                    style={{
+                      backgroundColor: c,
+                      transform: color === c ? 'scale(1.25)' : 'scale(1)',
+                      outline: color === c ? `2px solid ${c}` : 'none',
+                      outlineOffset: '2px',
+                      transition: 'transform 150ms ease-out',
+                    }}
+                  />
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* 멤버 — 가족 구성원이 본인 외에 있을 때만 표시 */}
+        {selectableMembers.length > 0 && (
+          <div className="rounded-2xl bg-white dark:bg-stone-900 border border-stone-100 dark:border-stone-800 p-4">
+            <p className="text-xs font-semibold text-stone-400 dark:text-stone-500 uppercase tracking-wide mb-3">
+              멤버
+            </p>
+
+            {/* 현재 상태 설명 — 섹션 안에 표시 */}
+            {memberIds === null && !memberLoadError && (
+              <div className="flex items-center gap-2 py-2">
+                <div className="w-4 h-4 rounded-full border-2 border-accent-300 border-t-accent-500 animate-spin shrink-0" />
+                <p className="text-sm text-stone-400 dark:text-stone-500">멤버 정보를 불러오는 중...</p>
+              </div>
+            )}
+
+            {memberLoadError && (
+              <p className="text-sm text-stone-400 dark:text-stone-500">
+                멤버 정보를 불러오지 못했어요. 이번 저장에는 멤버 변경이 반영되지 않습니다.
+              </p>
+            )}
+
+            {/* 멤버 선택 UI — 로드 완료 시에만 표시 */}
+            {memberIds !== null && !memberLoadError && (
+              <div className="space-y-2">
+                {selectableMembers.map((member) => {
+                  const selected = selectedIds.has(member.user_id)
+                  return (
+                    <button
+                      key={member.user_id}
+                      onClick={() => toggleMember(member.user_id)}
+                      role="checkbox"
+                      aria-checked={selected}
+                      className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-xl border transition-colors ${
+                        selected
+                          ? 'border-accent-300 bg-accent-50 dark:bg-accent-950/30 dark:border-accent-700'
+                          : 'border-stone-200 dark:border-stone-700 bg-stone-50 dark:bg-stone-800 hover:bg-stone-100 dark:hover:bg-stone-700'
+                      }`}
+                    >
+                      <div
+                        className={`w-5 h-5 rounded-full border-2 flex items-center justify-center shrink-0 transition-colors ${
+                          selected
+                            ? 'border-accent-400 bg-accent-400'
+                            : 'border-stone-300 dark:border-stone-600'
+                        }`}
+                      >
+                        {selected && <Check size={12} className="text-white" />}
+                      </div>
+                      <span className="text-sm text-stone-800 dark:text-stone-100 font-medium">
+                        {member.display_name}
+                      </span>
+                    </button>
+                  )
+                })}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* 저장 버튼 — 에러 배너는 버튼 바로 위 (저장 액션 결과 설명) */}
+        <div>
+          {saveError && (
+            <p className="text-xs text-red-400 mb-2 text-center">{saveError}</p>
+          )}
+          <button
+            onClick={handleSave}
+            disabled={isSaveDisabled || !name.trim()}
+            className="w-full py-3 rounded-2xl bg-accent-400 hover:bg-accent-500 disabled:opacity-40 text-white font-semibold text-sm transition-colors"
+          >
+            {saving ? '저장 중...' : '저장'}
+          </button>
+        </div>
+
+        {/* 위험 구역 — 일반 설정 카드와 시각적으로 분리 */}
+        <div className="rounded-2xl border border-red-100 dark:border-red-900/40 p-4">
+          <p className="text-xs font-semibold text-red-400 dark:text-red-500 uppercase tracking-wide mb-3">
+            위험 구역
+          </p>
+          {deleteError && (
+            <p className="text-xs text-red-400 mb-2">{deleteError}</p>
+          )}
+          {confirmDelete ? (
+            <div className="flex gap-2">
+              <button
+                onClick={() => setConfirmDelete(false)}
+                disabled={deleting}
+                className="flex-1 py-2.5 rounded-xl bg-stone-100 dark:bg-stone-800 text-stone-600 dark:text-stone-300 font-semibold text-sm transition-colors hover:bg-stone-200 dark:hover:bg-stone-700"
+              >
+                취소
+              </button>
+              <button
+                onClick={handleDelete}
+                disabled={deleting}
+                className="flex-1 py-2.5 rounded-xl bg-red-500 hover:bg-red-600 disabled:opacity-50 text-white font-semibold text-sm transition-colors"
+              >
+                {deleting ? '삭제 중...' : '정말 삭제'}
+              </button>
+            </div>
+          ) : (
+            <button
+              onClick={handleDelete}
+              className="w-full py-2.5 rounded-xl border border-red-200 dark:border-red-800 text-red-500 hover:bg-red-50 dark:hover:bg-red-950/30 font-semibold text-sm transition-colors"
+            >
+              캘린더 삭제
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/calendar/CalendarListSheet.tsx
+++ b/src/components/calendar/CalendarListSheet.tsx
@@ -1,20 +1,39 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Plus, X } from 'lucide-react'
-import { getCalendarMembersForCalendars, type Calendar, type CalendarMember, type FamilyMember } from '@/lib/calendar'
+import {
+  getCalendarMembers,
+  getCalendarMembersForCalendars,
+  type Calendar,
+  type CalendarMember,
+  type FamilyMember,
+} from '@/lib/calendar'
+import { CalendarDetailScreen } from '@/components/calendar/CalendarDetailScreen'
 
 interface Props {
   calendars: Calendar[]
   familyMembers: FamilyMember[]
+  currentUserId: string
   onClose: () => void
   onAdd: () => void
-  onEdit: (calendar: Calendar) => void
+  onSave: (calendarId: string, name: string, color: string, memberIds: string[] | null) => Promise<void>
+  onDelete: (calendarId: string) => Promise<void>
 }
 
+type View = 'list' | 'detail'
 type MemberMap = Record<string, CalendarMember[]>
 
-export function CalendarListSheet({ calendars, familyMembers, onClose, onAdd, onEdit }: Props) {
+export function CalendarListSheet({
+  calendars,
+  familyMembers,
+  currentUserId,
+  onClose,
+  onAdd,
+  onSave,
+  onDelete,
+}: Props) {
+  // ── 리스트 뷰 ──────────────────────────────────────────────
   const [memberMap, setMemberMap] = useState<MemberMap>({})
 
   useEffect(() => {
@@ -36,83 +55,140 @@ export function CalendarListSheet({ calendars, familyMembers, onClose, onAdd, on
 
   const getInitial = (userId: string) => getMemberName(userId).charAt(0).toUpperCase()
 
+  // ── 상세 뷰 ────────────────────────────────────────────────
+  const [view, setView] = useState<View>('list')
+  const [selectedCalendar, setSelectedCalendar] = useState<Calendar | null>(null)
+  const [memberIds, setMemberIds] = useState<string[] | null>(null)
+  const [memberLoadError, setMemberLoadError] = useState(false)
+  // 빠른 선택 전환 시 이전 요청의 응답이 뒤늦게 도착하는 것을 방지
+  const memberLoadSeqRef = useRef(0)
+
+  const handleSelectCalendar = (cal: Calendar) => {
+    setSelectedCalendar(cal)
+    setMemberIds(null)
+    setMemberLoadError(false)
+    setView('detail')
+
+    const seq = ++memberLoadSeqRef.current
+    getCalendarMembers(cal.id)
+      .then((members) => {
+        if (seq !== memberLoadSeqRef.current) return
+        setMemberIds(members.map((m) => m.user_id))
+      })
+      .catch((e) => {
+        if (seq !== memberLoadSeqRef.current) return
+        console.error('[CalendarListSheet] getCalendarMembers failed:', e)
+        setMemberLoadError(true)
+      })
+  }
+
+  const handleBack = () => {
+    setView('list')
+    setSelectedCalendar(null)
+    setMemberIds(null)
+    setMemberLoadError(false)
+  }
+
   return (
-    <div className="fixed inset-0 z-[70] flex flex-col bg-white dark:bg-stone-950">
-      {/* 헤더 */}
-      <div className="flex items-center justify-between px-4 pt-12 pb-4 shrink-0">
-        <h1 className="text-xl font-bold text-stone-800 dark:text-stone-100">캘린더 리스트</h1>
-        <button onClick={onClose} className="p-2 text-stone-400 hover:text-stone-600">
-          <X size={22} />
-        </button>
-      </div>
-
-      {/* 목록 */}
-      <div className="flex-1 overflow-y-auto px-4 pb-safe space-y-2">
-        <p className="text-xs text-stone-400 dark:text-stone-500 mb-3">
-          캘린더 ({calendars.length})
-        </p>
-
-        {calendars.map((cal) => {
-          const members = memberMap[cal.id] ?? []
-          const visibleMembers = members.slice(0, 3)
-          const overflow = members.length - visibleMembers.length
-
-          return (
+    <div className="fixed inset-0 z-[70] bg-white dark:bg-stone-950 overflow-hidden">
+      {/* 리스트 뷰 */}
+      {view === 'list' && (
+        <div className="flex flex-col h-full">
+          {/* 헤더 */}
+          <div className="flex items-center justify-between px-4 pt-12 pb-4 shrink-0">
+            <h1 className="text-xl font-bold text-stone-800 dark:text-stone-100">캘린더 리스트</h1>
             <button
-              key={cal.id}
-              onClick={() => onEdit(cal)}
+              onClick={onClose}
+              aria-label="닫기"
+              className="flex items-center justify-center min-h-[44px] min-w-[44px] rounded-xl text-stone-400 hover:text-stone-600 dark:hover:text-stone-300 hover:bg-stone-100 dark:hover:bg-stone-800 transition-colors"
+            >
+              <X size={22} />
+            </button>
+          </div>
+
+          {/* 목록 */}
+          <div className="flex-1 overflow-y-auto px-4 pb-safe space-y-2">
+            <p className="text-xs text-stone-400 dark:text-stone-500 mb-3">
+              캘린더 ({calendars.length})
+            </p>
+
+            {calendars.map((cal) => {
+              const members = memberMap[cal.id] ?? []
+              const visibleMembers = members.slice(0, 3)
+              const overflow = members.length - visibleMembers.length
+
+              return (
+                <button
+                  key={cal.id}
+                  onClick={() => handleSelectCalendar(cal)}
+                  className="w-full flex items-center gap-4 p-3 rounded-2xl hover:bg-stone-50 dark:hover:bg-stone-900 transition-colors text-left"
+                >
+                  {/* 캘린더 색상 썸네일 */}
+                  <div
+                    className="w-16 h-16 rounded-2xl shrink-0"
+                    style={{ backgroundColor: cal.color }}
+                  />
+
+                  {/* 이름 + 멤버 아바타 */}
+                  <div className="flex-1 min-w-0">
+                    <p className="font-semibold text-stone-800 dark:text-stone-100 truncate">
+                      {cal.name}
+                    </p>
+                    {members.length > 0 && (
+                      <div className="flex items-center gap-1 mt-1.5">
+                        <div className="flex -space-x-1.5">
+                          {visibleMembers.map((m) => (
+                            <div
+                              key={m.user_id}
+                              className="w-6 h-6 rounded-full flex items-center justify-center text-[10px] font-bold text-white ring-2 ring-white dark:ring-stone-950"
+                              style={{ backgroundColor: cal.color }}
+                              title={getMemberName(m.user_id)}
+                            >
+                              {getInitial(m.user_id)}
+                            </div>
+                          ))}
+                          {overflow > 0 && (
+                            <div className="w-6 h-6 rounded-full bg-stone-300 dark:bg-stone-600 flex items-center justify-center text-[10px] font-bold text-stone-600 dark:text-stone-300 ring-2 ring-white dark:ring-stone-950">
+                              +{overflow}
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+
+                  <span className="text-stone-300 dark:text-stone-600 text-lg">›</span>
+                </button>
+              )
+            })}
+
+            {/* 새 캘린더 만들기 */}
+            <button
+              onClick={onAdd}
               className="w-full flex items-center gap-4 p-3 rounded-2xl hover:bg-stone-50 dark:hover:bg-stone-900 transition-colors text-left"
             >
-              {/* 캘린더 색상 썸네일 */}
-              <div
-                className="w-16 h-16 rounded-2xl shrink-0"
-                style={{ backgroundColor: cal.color }}
-              />
-
-              {/* 이름 + 멤버 아바타 */}
-              <div className="flex-1 min-w-0">
-                <p className="font-semibold text-stone-800 dark:text-stone-100 truncate">
-                  {cal.name}
-                </p>
-                {members.length > 0 && (
-                  <div className="flex items-center gap-1 mt-1.5">
-                    <div className="flex -space-x-1.5">
-                      {visibleMembers.map((m) => (
-                        <div
-                          key={m.user_id}
-                          className="w-6 h-6 rounded-full flex items-center justify-center text-[10px] font-bold text-white ring-2 ring-white dark:ring-stone-950"
-                          style={{ backgroundColor: cal.color }}
-                          title={getMemberName(m.user_id)}
-                        >
-                          {getInitial(m.user_id)}
-                        </div>
-                      ))}
-                      {overflow > 0 && (
-                        <div className="w-6 h-6 rounded-full bg-stone-300 dark:bg-stone-600 flex items-center justify-center text-[10px] font-bold text-stone-600 dark:text-stone-300 ring-2 ring-white dark:ring-stone-950">
-                          +{overflow}
-                        </div>
-                      )}
-                    </div>
-                  </div>
-                )}
+              <div className="w-16 h-16 rounded-2xl bg-stone-100 dark:bg-stone-800 flex items-center justify-center shrink-0">
+                <Plus size={28} className="text-stone-400 dark:text-stone-500" />
               </div>
-
-              <span className="text-stone-300 dark:text-stone-600 text-lg">›</span>
+              <p className="text-stone-400 dark:text-stone-500 font-medium">새로운 캘린더 만들기</p>
             </button>
-          )
-        })}
-
-        {/* 새 캘린더 만들기 */}
-        <button
-          onClick={onAdd}
-          className="w-full flex items-center gap-4 p-3 rounded-2xl hover:bg-stone-50 dark:hover:bg-stone-900 transition-colors text-left"
-        >
-          <div className="w-16 h-16 rounded-2xl bg-stone-100 dark:bg-stone-800 flex items-center justify-center shrink-0">
-            <Plus size={28} className="text-stone-400 dark:text-stone-500" />
           </div>
-          <p className="text-stone-400 dark:text-stone-500 font-medium">새로운 캘린더 만들기</p>
-        </button>
-      </div>
+        </div>
+      )}
+
+      {/* 상세 뷰 — 리스트 위에 absolute로 덮어씌움 */}
+      {view === 'detail' && selectedCalendar && (
+        <CalendarDetailScreen
+          calendar={selectedCalendar}
+          memberIds={memberIds}
+          memberLoadError={memberLoadError}
+          familyMembers={familyMembers}
+          currentUserId={currentUserId}
+          onBack={handleBack}
+          onSave={onSave}
+          onDelete={onDelete}
+        />
+      )}
     </div>
   )
 }

--- a/src/components/calendar/CalendarListSheet.tsx
+++ b/src/components/calendar/CalendarListSheet.tsx
@@ -8,6 +8,7 @@ import {
   type Calendar,
   type CalendarMember,
   type FamilyMember,
+  type SaveResult,
 } from '@/lib/calendar'
 import { CalendarDetailScreen } from '@/components/calendar/CalendarDetailScreen'
 
@@ -17,7 +18,7 @@ interface Props {
   currentUserId: string
   onClose: () => void
   onAdd: () => void
-  onSave: (calendarId: string, name: string, color: string, memberIds: string[] | null) => Promise<void>
+  onSave: (calendarId: string, name: string, color: string, memberIds: string[] | null) => Promise<SaveResult>
   onDelete: (calendarId: string) => Promise<void>
 }
 
@@ -35,6 +36,7 @@ export function CalendarListSheet({
 }: Props) {
   // ── 리스트 뷰 ──────────────────────────────────────────────
   const [memberMap, setMemberMap] = useState<MemberMap>({})
+  const [listWarning, setListWarning] = useState<string | null>(null)
 
   useEffect(() => {
     if (calendars.length === 0) return
@@ -67,6 +69,7 @@ export function CalendarListSheet({
     setSelectedCalendar(cal)
     setMemberIds(null)
     setMemberLoadError(false)
+    setListWarning(null)
     setView('detail')
 
     const seq = ++memberLoadSeqRef.current
@@ -89,6 +92,19 @@ export function CalendarListSheet({
     setMemberLoadError(false)
   }
 
+  const handleSave = async (
+    calendarId: string,
+    name: string,
+    color: string,
+    memberIds: string[] | null,
+  ): Promise<SaveResult> => {
+    const result = await onSave(calendarId, name, color, memberIds)
+    if (result.status === 'partial') {
+      setListWarning('캘린더 정보는 저장됐지만 멤버는 저장하지 못했어요')
+    }
+    return result
+  }
+
   return (
     <div className="fixed inset-0 z-[70] bg-white dark:bg-stone-950 overflow-hidden">
       {/* 리스트 뷰 */}
@@ -108,6 +124,11 @@ export function CalendarListSheet({
 
           {/* 목록 */}
           <div className="flex-1 overflow-y-auto px-4 pb-safe space-y-2">
+            {listWarning && (
+              <div className="mb-1 rounded-xl border border-amber-100 bg-amber-50 px-4 py-3 text-sm text-amber-600 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-400">
+                {listWarning}
+              </div>
+            )}
             <p className="text-xs text-stone-400 dark:text-stone-500 mb-3">
               캘린더 ({calendars.length})
             </p>
@@ -185,7 +206,7 @@ export function CalendarListSheet({
           familyMembers={familyMembers}
           currentUserId={currentUserId}
           onBack={handleBack}
-          onSave={onSave}
+          onSave={handleSave}
           onDelete={onDelete}
         />
       )}

--- a/src/components/tabs/CalendarTab.tsx
+++ b/src/components/tabs/CalendarTab.tsx
@@ -405,6 +405,53 @@ export function CalendarTab({ preferences, user, familyId, isInitializing }: Pro
     }
   }
 
+  /** CalendarDetailScreen 에서 기존 캘린더 수정 시 사용 */
+  const handleCalendarUpdate = async (
+    calendarId: string,
+    name: string,
+    color: string,
+    memberUserIds: string[] | null,
+  ) => {
+    if (!user) return
+    setMutationError(null)
+
+    try {
+      await updateCalendar(calendarId, { name, color })
+      // memberUserIds 가 null 이면 멤버 로드 실패 상태 — setCalendarMembers skip
+      if (memberUserIds !== null) {
+        await setCalendarMembers(calendarId, user.id, memberUserIds)
+      }
+      await reloadCalendarContext()
+    } catch (e) {
+      console.error('[CalendarTab] handleCalendarUpdate failed:', e)
+      setMutationError('캘린더를 저장하지 못했어요')
+      await reloadCalendarContext()
+      throw e
+    }
+  }
+
+  /** CalendarDetailScreen 에서 캘린더 삭제 시 사용 */
+  const handleCalendarDeleteById = async (calendarId: string) => {
+    if (!familyId) return
+    setMutationError(null)
+
+    try {
+      clearFamilyMonthEventsCache(familyId)
+      await deleteCalendar(calendarId)
+      setActiveIds((prev) => {
+        const next = new Set(prev)
+        next.delete(calendarId)
+        return next
+      })
+      await Promise.allSettled([reloadCalendarContext(), refreshEvents()])
+    } catch (e) {
+      console.error('[CalendarTab] handleCalendarDeleteById failed:', e)
+      setMutationError('캘린더를 삭제하지 못했어요')
+      await Promise.allSettled([reloadCalendarContext(), refreshEvents()])
+      throw e
+    }
+  }
+
   const handleEventSave = async (params: {
     calendarId: string | null
     title: string
@@ -663,13 +710,15 @@ export function CalendarTab({ preferences, user, familyId, isInitializing }: Pro
         />
       )}
 
-      {showCalendarList && (
+      {showCalendarList && user && (
         <CalendarListSheet
           calendars={calendars}
           familyMembers={familyMembers}
+          currentUserId={user.id}
           onClose={() => setShowCalendarList(false)}
           onAdd={() => { setShowCalendarList(false); openCalendarForm() }}
-          onEdit={(cal) => { setShowCalendarList(false); openCalendarForm(cal) }}
+          onSave={handleCalendarUpdate}
+          onDelete={handleCalendarDeleteById}
         />
       )}
 

--- a/src/components/tabs/CalendarTab.tsx
+++ b/src/components/tabs/CalendarTab.tsx
@@ -23,6 +23,7 @@ import {
   setReminders,
   type CalendarEvent,
   type FamilyMember,
+  type SaveResult,
 } from '@/lib/calendar'
 import { CalendarFilter } from '@/components/calendar/CalendarFilter'
 import { CalendarGrid } from '@/components/calendar/CalendarGrid'
@@ -411,23 +412,33 @@ export function CalendarTab({ preferences, user, familyId, isInitializing }: Pro
     name: string,
     color: string,
     memberUserIds: string[] | null,
-  ) => {
-    if (!user) return
+  ): Promise<SaveResult> => {
+    if (!user) return { status: 'success' }
     setMutationError(null)
 
+    // 기본 정보 저장 실패 → 전체 실패 (throw)
     try {
       await updateCalendar(calendarId, { name, color })
-      // memberUserIds 가 null 이면 멤버 로드 실패 상태 — setCalendarMembers skip
-      if (memberUserIds !== null) {
-        await setCalendarMembers(calendarId, user.id, memberUserIds)
-      }
-      await reloadCalendarContext()
     } catch (e) {
       console.error('[CalendarTab] handleCalendarUpdate failed:', e)
       setMutationError('캘린더를 저장하지 못했어요')
       await reloadCalendarContext()
       throw e
     }
+
+    // memberUserIds 가 null 이면 멤버 로드 실패 상태 — setCalendarMembers skip
+    if (memberUserIds !== null) {
+      try {
+        await setCalendarMembers(calendarId, user.id, memberUserIds)
+      } catch (e) {
+        console.error('[CalendarTab] setCalendarMembers failed:', e)
+        await reloadCalendarContext()
+        return { status: 'partial' }
+      }
+    }
+
+    await reloadCalendarContext()
+    return { status: 'success' }
   }
 
   /** CalendarDetailScreen 에서 캘린더 삭제 시 사용 */

--- a/src/lib/calendar.ts
+++ b/src/lib/calendar.ts
@@ -29,6 +29,8 @@ export const CALENDAR_COLOR_NAMES: Record<string, string> = {
   '#eab308': '노란색',
 }
 
+export type SaveResult = { status: 'success' } | { status: 'partial' }
+
 export const REMINDER_OPTIONS: { label: string; minutes: number }[] = [
   { label: '5분 전', minutes: 5 },
   { label: '10분 전', minutes: 10 },

--- a/src/lib/calendar.ts
+++ b/src/lib/calendar.ts
@@ -18,6 +18,17 @@ export const CALENDAR_COLORS = [
   '#eab308', // yellow
 ]
 
+export const CALENDAR_COLOR_NAMES: Record<string, string> = {
+  '#f97316': '주황색',
+  '#3b82f6': '파란색',
+  '#22c55e': '초록색',
+  '#a855f7': '보라색',
+  '#ec4899': '분홍색',
+  '#14b8a6': '청록색',
+  '#ef4444': '빨간색',
+  '#eab308': '노란색',
+}
+
 export const REMINDER_OPTIONS: { label: string; minutes: number }[] = [
   { label: '5분 전', minutes: 5 },
   { label: '10분 전', minutes: 10 },


### PR DESCRIPTION
## Summary

- **CalendarDetailScreen (신규)**: 캘린더별 설정 전용 전체화면. 기본 정보(이름/색상), 멤버 섹션(비동기 로드), 위험 구역(삭제) 구성. 추후 음력/휴일/알림 섹션 확장 가능한 구조
- **CalendarListSheet 수정**: `view: 'list' | 'detail'` 내부 뷰 전환. 캘린더 클릭 시 즉시 상세 화면 진입 후 멤버를 background에서 로드. sequence counter로 빠른 전환 시 stale promise 방지
- **CalendarTab 수정**: `handleCalendarUpdate` (id 기반 수정), `handleCalendarDeleteById` 추가. CalendarListSheet props에서 `onEdit` 제거, `onSave`/`onDelete` 추가
- **calendar.ts**: `CALENDAR_COLOR_NAMES` 맵 추가 (hex → 한국어 색상명, a11y용)

### 설계 결정 사항

- 멤버 로드 실패 시 `memberIds`를 `[]`가 아닌 `null` 유지 → 저장 시 `setCalendarMembers` skip, 기존 멤버 보호
- 삭제 성공 후에만 `onBack()` 호출 → 실패 시 상세 화면 유지 + 에러 표시
- `CalendarFormModal`은 신규 생성 전용으로 유지

## Testing

- [ ] 캘린더 리스트에서 캘린더 클릭 시 상세 화면 즉시 진입
- [ ] 멤버 섹션 로딩 스피너 → 로드 완료 후 체크박스 표시
- [ ] 이름/색상 변경 후 저장 → 리스트로 복귀 + 반영 확인
- [ ] 멤버 변경 후 저장 → setCalendarMembers 정상 동작
- [ ] 멤버 로드 실패 시 에러 문구 표시, 저장 버튼 활성 (이름/색상만 저장)
- [ ] 삭제 → 확인 → 성공 시 리스트 복귀, 해당 캘린더 사라짐
- [ ] 삭제 실패 시 상세 화면 유지 + 에러 표시
- [ ] 새 캘린더 만들기 → 기존 CalendarFormModal 정상 동작
- [ ] 라이트/다크 모드 양쪽에서 UI 확인
- [ ] PWA 모바일에서 터치 타겟 확인 (44px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)