### PR TITLE
fix: streamline startup splash transition

### DIFF
--- a/src/__tests__/TabsShell.test.tsx
+++ b/src/__tests__/TabsShell.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { TabsShell } from '@/components/TabsShell'
 import { registerPushSubscription } from '@/lib/push'
 
@@ -6,7 +7,12 @@ const mockReplace = jest.fn()
 let mockTabParam: string | null = null
 let mockAuthLoading = false
 let mockFamilyLoading = false
+let mockCalendarsLoading = false
 let mockAuthUser: { id: string } | null = { id: 'user-1' }
+let mockFamilyError: Error | null = null
+let mockCalendarsError: Error | null = null
+const mockReloadFamily = jest.fn().mockResolvedValue(undefined)
+const mockReloadCalendars = jest.fn().mockResolvedValue(undefined)
 
 jest.mock('next/navigation', () => ({
   useRouter: () => ({ replace: mockReplace, push: jest.fn() }),
@@ -18,7 +24,22 @@ jest.mock('@/hooks/useAuth', () => ({
 }))
 
 jest.mock('@/hooks/useFamily', () => ({
-  useFamily: () => ({ familyId: 'fam-1', appRole: 'member', loading: mockFamilyLoading }),
+  useFamily: () => ({
+    familyId: 'fam-1',
+    appRole: 'member',
+    loading: mockFamilyLoading,
+    error: mockFamilyError,
+    reload: mockReloadFamily,
+  }),
+}))
+
+jest.mock('@/hooks/useCalendars', () => ({
+  useCalendars: () => ({
+    calendars: [],
+    loading: mockCalendarsLoading,
+    error: mockCalendarsError,
+    reload: mockReloadCalendars,
+  }),
 }))
 
 jest.mock('@/hooks/useUserPreferences', () => ({
@@ -56,9 +77,14 @@ jest.mock('@/components/BottomNav', () => ({
 describe('TabsShell', () => {
   beforeEach(() => {
     mockReplace.mockClear()
+    mockReloadFamily.mockClear()
+    mockReloadCalendars.mockClear()
     mockTabParam = null
     mockAuthLoading = false
     mockFamilyLoading = false
+    mockCalendarsLoading = false
+    mockFamilyError = null
+    mockCalendarsError = null
     mockAuthUser = { id: 'user-1' }
   })
 
@@ -73,6 +99,13 @@ describe('TabsShell', () => {
   it('인증 완료 후 가족 데이터 로딩 중에도 AppSplash를 표시한다', () => {
     mockAuthLoading = false
     mockFamilyLoading = true
+    render(<TabsShell />)
+    expect(screen.getByTestId('app-splash')).toBeInTheDocument()
+    expect(screen.queryByTestId('bottom-nav')).not.toBeInTheDocument()
+  })
+
+  it('캘린더 데이터 로딩 중에도 AppSplash를 표시한다', () => {
+    mockCalendarsLoading = true
     render(<TabsShell />)
     expect(screen.getByTestId('app-splash')).toBeInTheDocument()
     expect(screen.queryByTestId('bottom-nav')).not.toBeInTheDocument()
@@ -107,5 +140,25 @@ describe('TabsShell', () => {
   it('초기 진입 시 자동으로 푸시 구독을 요청하지 않는다', () => {
     render(<TabsShell />)
     expect(registerPushSubscription).not.toHaveBeenCalled()
+  })
+
+  it('초기 로딩 실패 시 splash 위 에러 다이얼로그를 표시한다', () => {
+    mockCalendarsError = new Error('calendar failed')
+    render(<TabsShell />)
+
+    expect(screen.getByTestId('app-splash')).toBeInTheDocument()
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument()
+    expect(screen.getByText('앱을 시작하지 못했어요')).toBeInTheDocument()
+  })
+
+  it('다시 시도 버튼 클릭 시 가족과 캘린더 로드를 모두 재시도한다', async () => {
+    mockCalendarsError = new Error('calendar failed')
+    const user = userEvent.setup()
+
+    render(<TabsShell />)
+    await user.click(screen.getByRole('button', { name: '다시 시도' }))
+
+    expect(mockReloadFamily).toHaveBeenCalled()
+    expect(mockReloadCalendars).toHaveBeenCalled()
   })
 })

--- a/src/__tests__/app/AuthCallbackPage.test.tsx
+++ b/src/__tests__/app/AuthCallbackPage.test.tsx
@@ -1,9 +1,14 @@
 import { render, screen } from '@testing-library/react'
 import AuthCallbackPage from '@/app/auth/callback/page'
 
+const mockReplace = jest.fn()
+let mockErrorParam: string | null = null
+
 jest.mock('next/navigation', () => ({
-  useRouter: () => ({ replace: jest.fn() }),
-  useSearchParams: () => ({ get: () => null }),
+  useRouter: () => ({ replace: mockReplace }),
+  useSearchParams: () => ({
+    get: (key: string) => key === 'error' ? mockErrorParam : null,
+  }),
 }))
 
 jest.mock('@/lib/supabase', () => ({
@@ -30,14 +35,15 @@ jest.mock('@/lib/api-client', () => ({
   postJson: jest.fn(),
 }))
 
-jest.mock('@/components/AppSplash', () => ({
-  AppSplash: () => <div data-testid="app-splash" />,
-}))
-
 describe('AuthCallbackPage', () => {
-  it('callback 처리 중에는 스피너 대신 AppSplash를 표시한다', () => {
+  beforeEach(() => {
+    mockReplace.mockClear()
+    mockErrorParam = null
+  })
+
+  it('callback 전이 단계에서는 시각적 splash를 렌더링하지 않는다', () => {
     render(<AuthCallbackPage />)
 
-    expect(screen.getByTestId('app-splash')).toBeInTheDocument()
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
   })
 })

--- a/src/__tests__/app/AuthCallbackPage.test.tsx
+++ b/src/__tests__/app/AuthCallbackPage.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react'
+import AuthCallbackPage from '@/app/auth/callback/page'
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: jest.fn() }),
+  useSearchParams: () => ({ get: () => null }),
+}))
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getSession: jest.fn().mockResolvedValue({ data: { session: null } }),
+      onAuthStateChange: jest.fn(() => ({
+        data: {
+          subscription: {
+            unsubscribe: jest.fn(),
+          },
+        },
+      })),
+      signOut: jest.fn(),
+    },
+  },
+}))
+
+jest.mock('@/lib/auth', () => ({
+  parseInviteCodeFromNext: jest.fn(() => null),
+}))
+
+jest.mock('@/lib/api-client', () => ({
+  postJson: jest.fn(),
+}))
+
+jest.mock('@/components/AppSplash', () => ({
+  AppSplash: () => <div data-testid="app-splash" />,
+}))
+
+describe('AuthCallbackPage', () => {
+  it('callback 처리 중에는 스피너 대신 AppSplash를 표시한다', () => {
+    render(<AuthCallbackPage />)
+
+    expect(screen.getByTestId('app-splash')).toBeInTheDocument()
+  })
+})

--- a/src/__tests__/app/LoginPage.test.tsx
+++ b/src/__tests__/app/LoginPage.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react'
+import LoginPage from '@/app/login/page'
+
+const mockReplace = jest.fn()
+let mockAuthLoading = false
+let mockAuthUser: { id: string } | null = null
+let mockErrorParam: string | null = null
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: mockReplace }),
+  useSearchParams: () => ({
+    get: (key: string) => {
+      if (key === 'next') return null
+      if (key === 'error') return mockErrorParam
+      return null
+    },
+  }),
+}))
+
+jest.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ user: mockAuthUser, loading: mockAuthLoading }),
+}))
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      signInWithOAuth: jest.fn(),
+    },
+  },
+}))
+
+jest.mock('@/components/AppSplash', () => ({
+  AppSplash: () => <div data-testid="app-splash" />,
+}))
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    mockReplace.mockClear()
+    mockAuthLoading = false
+    mockAuthUser = null
+    mockErrorParam = null
+  })
+
+  it('인증 확인 중에는 스피너 대신 AppSplash를 표시한다', () => {
+    mockAuthLoading = true
+
+    render(<LoginPage />)
+
+    expect(screen.getByTestId('app-splash')).toBeInTheDocument()
+    expect(screen.queryByText('Google로 로그인')).not.toBeInTheDocument()
+  })
+})

--- a/src/__tests__/app/LoginPage.test.tsx
+++ b/src/__tests__/app/LoginPage.test.tsx
@@ -49,4 +49,13 @@ describe('LoginPage', () => {
     expect(screen.getByTestId('app-splash')).toBeInTheDocument()
     expect(screen.queryByText('Google로 로그인')).not.toBeInTheDocument()
   })
+
+  it('callback 실패 에러는 표시만 하고 자동 재시도하지 않는다', () => {
+    mockErrorParam = 'auth_callback_failed'
+
+    render(<LoginPage />)
+
+    expect(screen.getByText('로그인 처리 중 문제가 발생했어요. 다시 시도해주세요.')).toBeInTheDocument()
+    expect(mockReplace).not.toHaveBeenCalled()
+  })
 })

--- a/src/__tests__/components/CalendarTab.picker.integration.test.tsx
+++ b/src/__tests__/components/CalendarTab.picker.integration.test.tsx
@@ -7,9 +7,6 @@ import { render, act, fireEvent, screen } from '@testing-library/react'
 import type { User } from '@supabase/supabase-js'
 import { CalendarTab } from '@/components/tabs/CalendarTab'
 
-jest.mock('@/hooks/useCalendars', () => ({
-  useCalendars: () => ({ calendars: [], loading: false, error: null, reload: jest.fn() }),
-}))
 jest.mock('@/hooks/useUserPreferences', () => ({
   useUserPreferences: () => ({ preferences: null, loading: false, updatePreferences: jest.fn() }),
 }))
@@ -64,6 +61,9 @@ const defaultProps = {
   user: { id: 'user-1' } as User,
   familyId: 'fam-1',
   isInitializing: false,
+  calendars: [],
+  calendarsError: null,
+  reloadCalendars: jest.fn(),
 }
 
 describe('CalendarTab + YearMonthPickerSheet 통합', () => {

--- a/src/__tests__/components/CalendarTab.test.tsx
+++ b/src/__tests__/components/CalendarTab.test.tsx
@@ -5,32 +5,6 @@ import { getCalendarMembers, getEventsByMonth, getFamilyMembers, setCalendarMemb
 
 // ── 의존성 모킹 ──────────────────────────────────────────────
 const mockReloadCalendars = jest.fn()
-const mockUseCalendars = jest.fn<
-  {
-    calendars: {
-      id: string
-      family_id: string
-      created_by: string
-      name: string
-      color: string
-      created_at: string
-      updated_at: string
-    }[]
-    loading: false
-    error: null
-    reload: typeof mockReloadCalendars
-  },
-  [string | null]
->(() => ({
-  calendars: [],
-  loading: false,
-  error: null,
-  reload: mockReloadCalendars,
-}))
-
-jest.mock('@/hooks/useCalendars', () => ({
-  useCalendars: (familyId: string | null) => mockUseCalendars(familyId),
-}))
 jest.mock('@/hooks/useUserPreferences', () => ({
   useUserPreferences: () => ({ preferences: null, loading: false, updatePreferences: jest.fn() }),
 }))
@@ -150,6 +124,25 @@ const mockGetCalendarMembers = getCalendarMembers as jest.MockedFunction<typeof 
 const mockSetCalendarMembers = setCalendarMembers as jest.MockedFunction<typeof setCalendarMembers>
 const mockUpdateCalendar = updateCalendar as jest.MockedFunction<typeof updateCalendar>
 let consoleErrorSpy: jest.SpyInstance
+const mockCalendars = [{
+  id: 'cal-1',
+  family_id: 'fam-1',
+  created_by: 'user-1',
+  name: '가족',
+  color: '#f97316',
+  created_at: '',
+  updated_at: '',
+}]
+
+const defaultProps = {
+  preferences: null,
+  user: { id: 'user-1' } as User,
+  familyId: 'fam-1',
+  isInitializing: false,
+  calendars: mockCalendars,
+  calendarsError: null,
+  reloadCalendars: mockReloadCalendars,
+}
 
 describe('CalendarTab — touch-action 스크롤 차단', () => {
   beforeAll(() => {
@@ -162,20 +155,6 @@ describe('CalendarTab — touch-action 스크롤 차단', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-    mockUseCalendars.mockReturnValue({
-      calendars: [{
-        id: 'cal-1',
-        family_id: 'fam-1',
-        created_by: 'user-1',
-        name: '가족',
-        color: '#f97316',
-        created_at: '',
-        updated_at: '',
-      }],
-      loading: false,
-      error: null,
-      reload: mockReloadCalendars,
-    })
     mockGetEventsByMonth.mockResolvedValue([])
     mockGetFamilyMembers.mockResolvedValue([])
     mockGetCalendarMembers.mockResolvedValue([])
@@ -183,12 +162,7 @@ describe('CalendarTab — touch-action 스크롤 차단', () => {
 
   it('모달이 없을 때 컨테이너에 touch-action: none이 적용된다', async () => {
     const { container } = render(
-      <CalendarTab
-        preferences={null}
-        user={{ id: 'user-1' } as User}
-        familyId="fam-1"
-        isInitializing={false}
-      />
+      <CalendarTab {...defaultProps} />
     )
     await act(async () => {})
 
@@ -196,19 +170,13 @@ describe('CalendarTab — touch-action 스크롤 차단', () => {
     expect(wrapper.style.touchAction).toBe('none')
   })
 
-  it('초기 이벤트 로드 실패 시 오류 상태와 재시도 버튼을 표시한다', async () => {
+  it('초기 이벤트 로드 실패 시 전체 스피너 대신 오류 배너와 캘린더 그리드를 유지한다', async () => {
     mockGetEventsByMonth.mockRejectedValue(new Error('load failed'))
 
-    render(
-      <CalendarTab
-        preferences={null}
-        user={{ id: 'user-1' } as User}
-        familyId="fam-1"
-        isInitializing={false}
-      />
-    )
+    render(<CalendarTab {...defaultProps} />)
 
-    expect(await screen.findByText('캘린더를 불러오지 못했어요')).toBeInTheDocument()
+    expect(await screen.findByText('이번 달 일정을 불러오지 못했어요.')).toBeInTheDocument()
+    expect(screen.getByTestId('calendar-grid')).toBeInTheDocument()
     expect(screen.getByText('다시 시도')).toBeInTheDocument()
   })
 
@@ -217,14 +185,7 @@ describe('CalendarTab — touch-action 스크롤 차단', () => {
       .mockRejectedValueOnce(new Error('load failed'))
       .mockResolvedValue([])
 
-    render(
-      <CalendarTab
-        preferences={null}
-        user={{ id: 'user-1' } as User}
-        familyId="fam-1"
-        isInitializing={false}
-      />
-    )
+    render(<CalendarTab {...defaultProps} />)
 
     const retryButton = await screen.findByText('다시 시도')
     fireEvent.click(retryButton)
@@ -237,14 +198,7 @@ describe('CalendarTab — touch-action 스크롤 차단', () => {
   it('캘린더 멤버 조회 실패 시 mutation error를 표시한다', async () => {
     mockGetCalendarMembers.mockRejectedValueOnce(new Error('members failed'))
 
-    render(
-      <CalendarTab
-        preferences={null}
-        user={{ id: 'user-1' } as User}
-        familyId="fam-1"
-        isInitializing={false}
-      />
-    )
+    render(<CalendarTab {...defaultProps} />)
 
     fireEvent.click(await screen.findByTestId('calendar-filter-edit'))
 
@@ -252,14 +206,7 @@ describe('CalendarTab — touch-action 스크롤 차단', () => {
   })
 
   it('연월 헤더 버튼 클릭 시 YearMonthPickerSheet가 열린다', async () => {
-    render(
-      <CalendarTab
-        preferences={null}
-        user={{ id: 'user-1' } as User}
-        familyId="fam-1"
-        isInitializing={false}
-      />
-    )
+    render(<CalendarTab {...defaultProps} />)
     await act(async () => {})
 
     const today = new Date()
@@ -271,14 +218,7 @@ describe('CalendarTab — touch-action 스크롤 차단', () => {
 
   it('피커 취소 시 연월이 변경되지 않고 피커가 닫힌다', async () => {
     const today = new Date()
-    render(
-      <CalendarTab
-        preferences={null}
-        user={{ id: 'user-1' } as User}
-        familyId="fam-1"
-        isInitializing={false}
-      />
-    )
+    render(<CalendarTab {...defaultProps} />)
     await act(async () => {})
 
     fireEvent.click(screen.getByRole('button', { name: new RegExp(`${today.getFullYear()}년`) }))
@@ -292,14 +232,7 @@ describe('CalendarTab — touch-action 스크롤 차단', () => {
 
   it('피커 확인 시 선택한 연월로 이동하고 피커가 닫힌다', async () => {
     const today = new Date()
-    render(
-      <CalendarTab
-        preferences={null}
-        user={{ id: 'user-1' } as User}
-        familyId="fam-1"
-        isInitializing={false}
-      />
-    )
+    render(<CalendarTab {...defaultProps} />)
     await act(async () => {})
 
     fireEvent.click(screen.getByRole('button', { name: new RegExp(`${today.getFullYear()}년`) }))
@@ -314,12 +247,7 @@ describe('CalendarTab — touch-action 스크롤 차단', () => {
   it('피커가 열린 상태에서 isModalOpen이 true가 되어 touch-action이 auto로 바뀐다', async () => {
     const today = new Date()
     const { container } = render(
-      <CalendarTab
-        preferences={null}
-        user={{ id: 'user-1' } as User}
-        familyId="fam-1"
-        isInitializing={false}
-      />
+      <CalendarTab {...defaultProps} />
     )
     await act(async () => {})
 
@@ -347,14 +275,7 @@ describe('CalendarTab — touch-action 스크롤 차단', () => {
       return []
     })
 
-    render(
-      <CalendarTab
-        preferences={null}
-        user={{ id: 'user-1' } as User}
-        familyId="fam-1"
-        isInitializing={false}
-      />
-    )
+    render(<CalendarTab {...defaultProps} />)
 
     expect(await screen.findByTestId('calendar-grid')).toBeInTheDocument()
 
@@ -382,20 +303,6 @@ describe('CalendarTab — handleCalendarUpdate', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-    mockUseCalendars.mockReturnValue({
-      calendars: [{
-        id: 'cal-1',
-        family_id: 'fam-1',
-        created_by: 'user-1',
-        name: '가족',
-        color: '#f97316',
-        created_at: '',
-        updated_at: '',
-      }],
-      loading: false,
-      error: null,
-      reload: mockReloadCalendars,
-    })
     mockGetEventsByMonth.mockResolvedValue([])
     mockGetFamilyMembers.mockResolvedValue([])
     mockGetCalendarMembers.mockResolvedValue([])
@@ -404,14 +311,7 @@ describe('CalendarTab — handleCalendarUpdate', () => {
   })
 
   const openCalendarList = async () => {
-    render(
-      <CalendarTab
-        preferences={null}
-        user={{ id: 'user-1' } as User}
-        familyId="fam-1"
-        isInitializing={false}
-      />
-    )
+    render(<CalendarTab {...defaultProps} />)
     await act(async () => {})
     fireEvent.click(screen.getByRole('button', { name: '캘린더 리스트' }))
     await screen.findByTestId('calendar-list-sheet')

--- a/src/__tests__/components/CalendarTab.test.tsx
+++ b/src/__tests__/components/CalendarTab.test.tsx
@@ -180,6 +180,16 @@ describe('CalendarTab — touch-action 스크롤 차단', () => {
     expect(screen.getByText('다시 시도')).toBeInTheDocument()
   })
 
+  it('초기 이벤트 로딩 중이나 빈 상태에서는 메인 상태 문구를 표시하지 않는다', async () => {
+    render(<CalendarTab {...defaultProps} />)
+
+    expect(screen.getByTestId('calendar-grid')).toBeInTheDocument()
+    expect(screen.queryByText('이번 달 일정을 불러오는 중이에요.')).not.toBeInTheDocument()
+    expect(screen.queryByText('이번 달 등록된 일정이 없어요.')).not.toBeInTheDocument()
+    await act(async () => {})
+    expect(screen.queryByText('이번 달 등록된 일정이 없어요.')).not.toBeInTheDocument()
+  })
+
   it('재시도 버튼 클릭 시 캘린더 데이터를 다시 불러온다', async () => {
     mockGetEventsByMonth
       .mockRejectedValueOnce(new Error('load failed'))

--- a/src/__tests__/hooks/useFamily.test.ts
+++ b/src/__tests__/hooks/useFamily.test.ts
@@ -20,6 +20,7 @@ describe('useFamily', () => {
     expect(result.current.familyId).toBeNull()
     expect(result.current.appRole).toBe('member')
     expect(result.current.loading).toBe(true)
+    expect(typeof result.current.reload).toBe('function')
   })
 
   it('API 성공 시 familyId와 appRole이 설정되고 loading이 false가 된다', async () => {
@@ -29,6 +30,7 @@ describe('useFamily', () => {
     expect(result.current.familyId).toBe('fam-1')
     expect(result.current.appRole).toBe('member')
     expect(mockPostJsonWithAuth).toHaveBeenCalledWith('/api/family/me')
+    expect(typeof result.current.reload).toBe('function')
   })
 
   it('admin인 경우 appRole이 admin으로 설정된다', async () => {

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -5,18 +5,34 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import { supabase } from '@/lib/supabase'
 import { parseInviteCodeFromNext } from '@/lib/auth'
 import { postJson } from '@/lib/api-client'
-import { AppSplash } from '@/components/AppSplash'
 
 function AuthCallbackInner() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const handledRef = useRef(false)
+  const fallbackTimerRef = useRef<number | null>(null)
 
   useEffect(() => {
+    const routeToLoginError = (code: string) => {
+      if (handledRef.current) return
+      handledRef.current = true
+      router.replace(`/login?error=${code}`)
+    }
+
+    const callbackError = searchParams.get('error')
+    if (callbackError) {
+      routeToLoginError('auth_callback_failed')
+      return
+    }
+
     const handleSession = async (email: string) => {
       // 중복 실행 방지 (getSession + onAuthStateChange 둘 다 트리거될 수 있음)
       if (handledRef.current) return
       handledRef.current = true
+      if (fallbackTimerRef.current !== null) {
+        window.clearTimeout(fallbackTimerRef.current)
+        fallbackTimerRef.current = null
+      }
 
       const next = searchParams.get('next') ?? '/calendar'
       const isAppInvite = next.startsWith('/join-app')
@@ -51,29 +67,39 @@ function AuthCallbackInner() {
 
     // Supabase가 이미 세션을 처리한 경우 (effect 실행 전 자동 교환 완료)
     supabase.auth.getSession().then(({ data: { session } }) => {
-      if (session?.user?.email) {
+      if (session && session.user?.email) {
         handleSession(session.user.email)
+        return
       }
+
+      fallbackTimerRef.current = window.setTimeout(() => {
+        routeToLoginError('auth_callback_failed')
+      }, 800)
     })
 
     // Supabase가 effect 실행 후 세션을 처리하는 경우
     const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
-      if (event === 'SIGNED_IN' && session?.user?.email) {
+      if (event === 'SIGNED_IN' && session && session.user?.email) {
         handleSession(session.user.email)
+      } else if (event === 'SIGNED_OUT') {
+        routeToLoginError('auth_callback_failed')
       }
     })
 
-    return () => subscription.unsubscribe()
+    return () => {
+      subscription.unsubscribe()
+      if (fallbackTimerRef.current !== null) {
+        window.clearTimeout(fallbackTimerRef.current)
+      }
+    }
   }, [router, searchParams])
 
-  return (
-    <AppSplash />
-  )
+  return null
 }
 
 export default function AuthCallbackPage() {
   return (
-    <Suspense fallback={<AppSplash />}>
+    <Suspense fallback={null}>
       <AuthCallbackInner />
     </Suspense>
   )

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import { supabase } from '@/lib/supabase'
 import { parseInviteCodeFromNext } from '@/lib/auth'
 import { postJson } from '@/lib/api-client'
+import { AppSplash } from '@/components/AppSplash'
 
 function AuthCallbackInner() {
   const router = useRouter()
@@ -66,19 +67,13 @@ function AuthCallbackInner() {
   }, [router, searchParams])
 
   return (
-    <div className="flex items-center justify-center min-h-screen">
-      <div className="w-8 h-8 rounded-full border-2 border-accent-300 border-t-accent-500 animate-spin" />
-    </div>
+    <AppSplash />
   )
 }
 
 export default function AuthCallbackPage() {
   return (
-    <Suspense fallback={
-      <div className="flex items-center justify-center min-h-screen">
-        <div className="w-8 h-8 rounded-full border-2 border-accent-300 border-t-accent-500 animate-spin" />
-      </div>
-    }>
+    <Suspense fallback={<AppSplash />}>
       <AuthCallbackInner />
     </Suspense>
   )

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -193,7 +193,7 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .splash-logo-fade-in {
-  animation: splash-logo-fade-in 0.24s ease-out;
+  animation: splash-logo-fade-in 0.36s ease-out;
 }
 
 .no-scrollbar::-webkit-scrollbar {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -181,6 +181,21 @@ h1, h2, h3, h4, h5, h6 {
   animation: modal-slide-down 0.28s ease-in forwards;
 }
 
+@keyframes splash-logo-fade-in {
+  from {
+    opacity: 0;
+    transform: scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.splash-logo-fade-in {
+  animation: splash-logo-fade-in 0.24s ease-out;
+}
+
 .no-scrollbar::-webkit-scrollbar {
   display: none;
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -50,6 +50,12 @@ function LoginInner() {
           </div>
         )}
 
+        {error === 'auth_callback_failed' && (
+          <div className="w-full px-4 py-3 rounded-xl bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-900 text-red-600 dark:text-red-400 text-sm text-center">
+            로그인 처리 중 문제가 발생했어요. 다시 시도해주세요.
+          </div>
+        )}
+
         <button
           onClick={handleGoogleLogin}
           className="w-full flex items-center justify-center gap-3 px-6 py-3.5 rounded-2xl border border-stone-200 dark:border-stone-700 bg-white dark:bg-stone-900 text-stone-700 dark:text-stone-200 font-semibold text-sm hover:bg-stone-50 dark:hover:bg-stone-800 transition-colors shadow-sm"

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { supabase } from '@/lib/supabase'
 import { useAuth } from '@/hooks/useAuth'
+import { AppSplash } from '@/components/AppSplash'
 
 function LoginInner() {
   const { user, loading } = useAuth()
@@ -29,11 +30,7 @@ function LoginInner() {
   }
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-screen">
-        <div className="w-8 h-8 rounded-full border-2 border-accent-300 border-t-accent-500 animate-spin" />
-      </div>
-    )
+    return <AppSplash />
   }
 
   return (
@@ -72,11 +69,7 @@ function LoginInner() {
 
 export default function LoginPage() {
   return (
-    <Suspense fallback={
-      <div className="flex items-center justify-center min-h-screen">
-        <div className="w-8 h-8 rounded-full border-2 border-accent-300 border-t-accent-500 animate-spin" />
-      </div>
-    }>
+    <Suspense fallback={<AppSplash />}>
       <LoginInner />
     </Suspense>
   )

--- a/src/components/AppSplash.tsx
+++ b/src/components/AppSplash.tsx
@@ -3,7 +3,7 @@ import Image from 'next/image'
 export function AppSplash() {
   return (
     <div role="status" aria-label="앱을 불러오는 중" className="fixed inset-0 flex items-center justify-center bg-[var(--background)]">
-      <div className="rounded-full bg-[var(--surface-overlay)] ring-1 ring-[var(--surface-ring)] p-6">
+      <div className="splash-logo-fade-in rounded-full bg-[var(--surface-overlay)] ring-1 ring-[var(--surface-ring)] p-6">
         <Image
           src="/logo.webp"
           alt=""

--- a/src/components/AppSplash.tsx
+++ b/src/components/AppSplash.tsx
@@ -1,9 +1,13 @@
 import Image from 'next/image'
 
-export function AppSplash() {
+interface Props {
+  animateLogo?: boolean
+}
+
+export function AppSplash({ animateLogo = false }: Props) {
   return (
     <div role="status" aria-label="앱을 불러오는 중" className="fixed inset-0 flex items-center justify-center bg-[var(--background)]">
-      <div className="splash-logo-fade-in rounded-full bg-[var(--surface-overlay)] ring-1 ring-[var(--surface-ring)] p-6">
+      <div className={`${animateLogo ? 'splash-logo-fade-in ' : ''}rounded-full bg-[var(--surface-overlay)] ring-1 ring-[var(--surface-ring)] p-6`}>
         <Image
           src="/logo.webp"
           alt=""

--- a/src/components/TabsShell.tsx
+++ b/src/components/TabsShell.tsx
@@ -8,6 +8,7 @@ import { SettingsTab } from '@/components/tabs/SettingsTab'
 import { BottomNav } from '@/components/BottomNav'
 import { useAuth } from '@/hooks/useAuth'
 import { useFamily } from '@/hooks/useFamily'
+import { useCalendars } from '@/hooks/useCalendars'
 import { useUserPreferences } from '@/hooks/useUserPreferences'
 import { type Tab, TABS } from '@/types/tabs'
 import { AppSplash } from '@/components/AppSplash'
@@ -16,9 +17,16 @@ export function TabsShell() {
   const searchParams = useSearchParams()
   const router = useRouter()
   const { user, loading: authLoading } = useAuth()
-  const { familyId, appRole, loading: familyLoading, error: familyError } = useFamily(user)
+  const { familyId, appRole, loading: familyLoading, error: familyError, reload: reloadFamily } = useFamily(user)
+  const {
+    calendars,
+    loading: calendarsLoading,
+    error: calendarsError,
+    reload: reloadCalendars,
+  } = useCalendars(familyId)
   const { preferences, updatePreferences } = useUserPreferences(user)
-  const isInitializing = authLoading || familyLoading
+  const isInitializing = authLoading || familyLoading || calendarsLoading
+  const startupError = familyError || calendarsError
 
   // 인증됨 + 앱 접근권 있음 + 아직 가족 없음 → 온보딩 필요
   // familyError가 있으면 DB 장애로 판단, 온보딩으로 잘못 보내지 않는다
@@ -44,7 +52,51 @@ export function TabsShell() {
     }
   }, [preferences?.app_theme])
 
-  if (isInitializing) return <AppSplash />
+  const handleStartupRetry = async () => {
+    await Promise.allSettled([reloadFamily(), reloadCalendars()])
+  }
+
+  if (isInitializing || startupError) {
+    return (
+      <>
+        <AppSplash />
+        {startupError && (
+          <div className="fixed inset-0 z-10 flex items-center justify-center bg-black/40 px-6">
+            <div
+              role="alertdialog"
+              aria-labelledby="startup-error-title"
+              aria-describedby="startup-error-description"
+              className="w-full max-w-sm rounded-3xl bg-white p-6 shadow-2xl dark:bg-stone-900"
+            >
+              <h2 id="startup-error-title" className="text-lg font-bold text-stone-900 dark:text-stone-100">
+                앱을 시작하지 못했어요
+              </h2>
+              <p
+                id="startup-error-description"
+                className="mt-2 text-sm leading-6 text-stone-600 dark:text-stone-300"
+              >
+                네트워크 또는 서버 상태를 확인한 뒤 다시 시도해주세요.
+              </p>
+              <div className="mt-5 flex gap-2">
+                <button
+                  onClick={() => void handleStartupRetry()}
+                  className="flex-1 rounded-2xl bg-accent-400 px-4 py-3 text-sm font-semibold text-white transition-colors hover:bg-accent-500"
+                >
+                  다시 시도
+                </button>
+                <button
+                  onClick={() => window.location.reload()}
+                  className="flex-1 rounded-2xl border border-stone-200 px-4 py-3 text-sm font-semibold text-stone-700 transition-colors hover:bg-stone-50 dark:border-stone-700 dark:text-stone-200 dark:hover:bg-stone-800"
+                >
+                  새로고침
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </>
+    )
+  }
   if (!user) return null
   if (needsFamilyOnboarding) return null
 
@@ -60,6 +112,9 @@ export function TabsShell() {
           user={user}
           familyId={familyId}
           isInitializing={isInitializing}
+          calendars={calendars}
+          calendarsError={calendarsError}
+          reloadCalendars={reloadCalendars}
         />
       </div>
       <div style={{ display: activeTab === 'shopping' ? 'contents' : 'none' }}>

--- a/src/components/TabsShell.tsx
+++ b/src/components/TabsShell.tsx
@@ -25,8 +25,9 @@ export function TabsShell() {
     reload: reloadCalendars,
   } = useCalendars(familyId)
   const { preferences, updatePreferences } = useUserPreferences(user)
-  const isInitializing = authLoading || familyLoading || calendarsLoading
-  const startupError = familyError || calendarsError
+  const shouldLoadCalendars = Boolean(familyId) && !familyError
+  const isInitializing = authLoading || familyLoading || (shouldLoadCalendars && calendarsLoading)
+  const startupError = !isInitializing ? (familyError || calendarsError) : null
 
   // 인증됨 + 앱 접근권 있음 + 아직 가족 없음 → 온보딩 필요
   // familyError가 있으면 DB 장애로 판단, 온보딩으로 잘못 보내지 않는다
@@ -59,7 +60,7 @@ export function TabsShell() {
   if (isInitializing || startupError) {
     return (
       <>
-        <AppSplash />
+        <AppSplash animateLogo />
         {startupError && (
           <div className="fixed inset-0 z-10 flex items-center justify-center bg-black/40 px-6">
             <div

--- a/src/components/tabs/CalendarTab.tsx
+++ b/src/components/tabs/CalendarTab.tsx
@@ -3,7 +3,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useSwipe } from '@/hooks/useSwipe'
 import { ChevronDown, ChevronLeft, ChevronRight, Plus } from 'lucide-react'
-import { useCalendars } from '@/hooks/useCalendars'
 import { useAsyncData } from '@/hooks/useAsyncData'
 import { useHolidays } from '@/hooks/useHolidays'
 import type { UserPreferences } from '@/lib/preferences'
@@ -38,6 +37,9 @@ import type { Calendar } from '@/lib/calendar'
 
 interface Props extends AuthState {
   preferences: UserPreferences | null
+  calendars: Calendar[]
+  calendarsError: unknown
+  reloadCalendars: () => Promise<unknown>
 }
 
 const MAX_MONTH_EVENT_CACHE = 12
@@ -58,14 +60,14 @@ function getAdjacentMonth(year: number, month: number, delta: -1 | 1) {
     : { year, month: month + 1 }
 }
 
-export function CalendarTab({ preferences, user, familyId, isInitializing }: Props) {
-  const {
-    calendars,
-    loading: calLoading,
-    error: calendarsError,
-    reload: reloadCalendars,
-  } = useCalendars(familyId)
-
+export function CalendarTab({
+  preferences,
+  user,
+  familyId,
+  calendars,
+  calendarsError,
+  reloadCalendars,
+}: Props) {
   const today = new Date()
   const [year, setYear] = useState(today.getFullYear())
   const [month, setMonth] = useState(today.getMonth())
@@ -537,19 +539,10 @@ export function CalendarTab({ preferences, user, familyId, isInitializing }: Pro
     setSelectedEvent(null)
   }
 
-  const loading = isInitializing || calLoading || familyMembersLoading || (!hasLoadedEvents && eventsLoading)
-  const fetchError = calendarsError || familyMembersError || eventsError
+  const fetchError = calendarsError
 
   const handleRetry = async () => {
     await Promise.all([reloadCalendars(), reloadFamilyMembers(), reloadEvents()])
-  }
-
-  if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-screen">
-        <div className="w-8 h-8 rounded-full border-2 border-accent-300 border-t-accent-500 animate-spin" />
-      </div>
-    )
   }
 
   if (fetchError) {
@@ -647,6 +640,39 @@ export function CalendarTab({ preferences, user, familyId, isInitializing }: Pro
         {mutationError && (
           <div className="mt-3 rounded-xl border border-red-100 bg-red-50 px-4 py-3 text-sm text-red-500 dark:border-red-900/40 dark:bg-red-950/30 dark:text-red-400">
             {mutationError}
+          </div>
+        )}
+
+        {familyMembersLoading && (
+          <div className="mt-3 rounded-xl border border-stone-200 bg-stone-50 px-4 py-3 text-sm text-stone-500 dark:border-stone-800 dark:bg-stone-900 dark:text-stone-400">
+            가족 구성원 정보를 불러오는 중이에요.
+          </div>
+        )}
+
+        {Boolean(familyMembersError) && (
+          <div className="mt-3 rounded-xl border border-amber-100 bg-amber-50 px-4 py-3 text-sm text-amber-600 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-400">
+            가족 구성원 정보를 아직 불러오지 못했어요. 캘린더는 계속 사용할 수 있어요.
+          </div>
+        )}
+
+        {eventsLoading && !hasLoadedEvents && (
+          <div className="mt-3 rounded-xl border border-stone-200 bg-stone-50 px-4 py-3 text-sm text-stone-500 dark:border-stone-800 dark:bg-stone-900 dark:text-stone-400">
+            이번 달 일정을 불러오는 중이에요.
+          </div>
+        )}
+
+        {!eventsLoading && Boolean(eventsError) && (
+          <div className="mt-3 rounded-xl border border-amber-100 bg-amber-50 px-4 py-3 text-sm text-amber-600 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-400">
+            이번 달 일정을 불러오지 못했어요.
+            <button onClick={() => void handleRetry()} className="ml-2 font-semibold underline underline-offset-2">
+              다시 시도
+            </button>
+          </div>
+        )}
+
+        {!eventsLoading && !eventsError && hasLoadedEvents && events.length === 0 && (
+          <div className="mt-3 rounded-xl border border-stone-200 bg-stone-50 px-4 py-3 text-sm text-stone-500 dark:border-stone-800 dark:bg-stone-900 dark:text-stone-400">
+            이번 달 등록된 일정이 없어요.
           </div>
         )}
       </div>

--- a/src/components/tabs/CalendarTab.tsx
+++ b/src/components/tabs/CalendarTab.tsx
@@ -643,36 +643,12 @@ export function CalendarTab({
           </div>
         )}
 
-        {familyMembersLoading && (
-          <div className="mt-3 rounded-xl border border-stone-200 bg-stone-50 px-4 py-3 text-sm text-stone-500 dark:border-stone-800 dark:bg-stone-900 dark:text-stone-400">
-            가족 구성원 정보를 불러오는 중이에요.
-          </div>
-        )}
-
-        {Boolean(familyMembersError) && (
-          <div className="mt-3 rounded-xl border border-amber-100 bg-amber-50 px-4 py-3 text-sm text-amber-600 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-400">
-            가족 구성원 정보를 아직 불러오지 못했어요. 캘린더는 계속 사용할 수 있어요.
-          </div>
-        )}
-
-        {eventsLoading && !hasLoadedEvents && (
-          <div className="mt-3 rounded-xl border border-stone-200 bg-stone-50 px-4 py-3 text-sm text-stone-500 dark:border-stone-800 dark:bg-stone-900 dark:text-stone-400">
-            이번 달 일정을 불러오는 중이에요.
-          </div>
-        )}
-
         {!eventsLoading && Boolean(eventsError) && (
           <div className="mt-3 rounded-xl border border-amber-100 bg-amber-50 px-4 py-3 text-sm text-amber-600 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-400">
             이번 달 일정을 불러오지 못했어요.
             <button onClick={() => void handleRetry()} className="ml-2 font-semibold underline underline-offset-2">
               다시 시도
             </button>
-          </div>
-        )}
-
-        {!eventsLoading && !eventsError && hasLoadedEvents && events.length === 0 && (
-          <div className="mt-3 rounded-xl border border-stone-200 bg-stone-50 px-4 py-3 text-sm text-stone-500 dark:border-stone-800 dark:bg-stone-900 dark:text-stone-400">
-            이번 달 등록된 일정이 없어요.
           </div>
         )}
       </div>

--- a/src/hooks/useFamily.ts
+++ b/src/hooks/useFamily.ts
@@ -10,7 +10,7 @@ interface FamilyData {
 }
 
 export function useFamily(user: User | null) {
-  const { value, loading, error } = useAsyncData<FamilyData>({
+  const { value, loading, error, reload } = useAsyncData<FamilyData>({
     enabled: Boolean(user),
     initialValue: { familyId: null, appRole: 'member' },
     reloadKey: user?.id,
@@ -27,5 +27,6 @@ export function useFamily(user: User | null) {
     appRole: value?.appRole ?? 'member',
     loading,
     error,
+    reload,
   }
 }


### PR DESCRIPTION
## Summary
- `TabsShell`이 초기 auth/family/calendar 진입 게이트를 직접 관리하도록 변경했습니다.
- `CalendarTab`의 전체 화면 스피너를 제거하고, 메인 화면에서는 상태 문구를 숨긴 채 이벤트 로딩 실패 시에만 비차단형 경고 배너를 표시하도록 정리했습니다.
- 로그인 페이지와 OAuth callback 페이지의 로딩 UI를 `AppSplash`로 통일해 `스피너 -> 로고` 중복 흐름을 제거했습니다.
- 시작 splash 로고에 짧은 페이드인 애니메이션을 추가했습니다.
- 초기 splash 게이트, 로그인/callback splash, 캘린더 부분 로딩 흐름을 검증하는 테스트를 함께 갱신했습니다.

## Testing
- `npx tsc --noEmit`
- `npm test -- --runInBand`

## Manual Verification
- [ ] 앱 실행 시 `로고 -> 캘린더` 흐름으로 보이고 중간 전체 스피너가 나타나지 않는지 확인
- [ ] 로그인 후 OAuth callback 경로에서도 원형 스피너 대신 splash 로고가 표시되는지 확인
- [ ] 초기 family 또는 calendar 로딩 실패 시 splash 위 에러 다이얼로그와 `다시 시도`/`새로고침` 동작 확인
- [ ] 캘린더 기본 레이아웃이 먼저 렌더되고, 정상 시에는 상단 상태 문구가 없으며 이벤트 실패 시에만 작은 경고 배너가 보이는지 확인
- [ ] splash 로고가 과하지 않게 짧게 페이드인되는지 확인