### PR TITLE
docs: require CI monitoring after PR creation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ These rules apply to every task without exception.
 2. When asking the user to run a command or tool, include a Korean explanation.
 3. Whenever code is written or modified, add or update tests with it.
 4. After writing or modifying code, run `npx tsc --noEmit` before considering the work complete.
-5. GitHub Actions CI must pass before merge.
+5. After creating a PR, monitor GitHub Actions CI until it completes. If any check fails, fix the issue and repeat until CI passes.
 6. Manual visual verification items must be listed as checkboxes in the PR.
 
 ## Engineering Rules


### PR DESCRIPTION
## Summary
- AGENTS 작업 규칙에 PR 생성 후 GitHub Actions CI를 끝까지 확인하는 규칙을 추가했습니다.
- CI 실패 시 수정 후 다시 통과할 때까지 반복하도록 명시했습니다.

## Testing
- 테스트는 실행하지 않았습니다. 문서 규칙만 변경했습니다.