### PR TITLE
feat: make event + reminder save atomic via DB RPC

### DIFF
--- a/src/__tests__/api/events/patch.test.ts
+++ b/src/__tests__/api/events/patch.test.ts
@@ -12,11 +12,13 @@ jest.mock('@/lib/push-utils', () => ({
 
 const mockGetUser = jest.fn()
 const mockFrom = jest.fn()
+const mockRpc = jest.fn()
 
 jest.mock('@/lib/supabase-admin', () => ({
   supabaseAdmin: {
     auth: { getUser: (token: unknown) => mockGetUser(token) },
     from: (table: unknown) => mockFrom(table),
+    rpc: (fn: unknown, args: unknown) => mockRpc(fn, args),
   },
 }))
 
@@ -59,6 +61,7 @@ beforeEach(() => {
     data: { user: { id: ACTOR_USER_ID, email: 'actor@test.com' } },
     error: null,
   })
+  mockRpc.mockResolvedValue({ error: null })
 })
 
 function mockEventFetch(existing: Record<string, unknown> | null = mockExisting) {
@@ -93,13 +96,6 @@ function mockFamilyAccess(isMember = true) {
     maybeSingle: jest.fn().mockResolvedValue(
       isMember ? { data: { user_id: ACTOR_USER_ID } } : { data: null }
     ),
-  }))
-}
-
-function mockEventUpdate() {
-  mockFrom.mockImplementationOnce(() => ({
-    update: jest.fn().mockReturnThis(),
-    eq: jest.fn().mockResolvedValue({ error: null }),
   }))
 }
 
@@ -141,7 +137,6 @@ describe('PATCH /api/events/[id]', () => {
   it('변경사항 없으면 204를 반환하고 알림을 보내지 않는다', async () => {
     mockEventFetch()
     mockCalendarAccess()
-    mockEventUpdate()
     const res = await PATCH(makeRequest({ title: mockExisting.title }), makeParams())
     expect(res.status).toBe(204)
     expect(mockSendEventNotification).not.toHaveBeenCalled()
@@ -150,8 +145,6 @@ describe('PATCH /api/events/[id]', () => {
   it('변경사항 있으면 204를 반환하고 알림을 보낸다', async () => {
     mockEventFetch()
     mockCalendarAccess()
-    mockEventUpdate()
-    mockSendEventNotification.mockResolvedValue(undefined)
     const res = await PATCH(makeRequest({ title: '새 제목' }), makeParams())
     expect(res.status).toBe(204)
     expect(mockSendEventNotification).toHaveBeenCalledWith(
@@ -159,34 +152,31 @@ describe('PATCH /api/events/[id]', () => {
     )
   })
 
-  it('reminderMinutes가 있으면 event_reminders를 교체한다', async () => {
+  it('update_event_with_reminders RPC를 호출한다', async () => {
     mockEventFetch()
     mockCalendarAccess()
-    mockEventUpdate()
-    // event_reminders delete
-    mockFrom.mockImplementationOnce(() => ({
-      delete: jest.fn().mockReturnThis(),
-      eq: jest.fn().mockResolvedValue({ error: null }),
-    }))
-    // event_reminders insert
-    const reminderInsert = jest.fn().mockResolvedValue({ error: null })
-    mockFrom.mockImplementationOnce(() => ({ insert: reminderInsert }))
-    mockSendEventNotification.mockResolvedValue(undefined)
-
     await PATCH(makeRequest({ reminderMinutes: [30] }), makeParams())
-    expect(mockFrom).toHaveBeenCalledWith('event_reminders')
-    expect(reminderInsert).toHaveBeenCalled()
+    expect(mockRpc).toHaveBeenCalledWith(
+      'update_event_with_reminders',
+      expect.objectContaining({ p_reminder_minutes: [30] })
+    )
   })
 
-  it('reminder delete 실패 시 500을 반환한다', async () => {
+  it('reminderMinutes 미제공 시 p_reminder_minutes를 null로 전달한다', async () => {
     mockEventFetch()
     mockCalendarAccess()
-    mockEventUpdate()
-    mockFrom.mockImplementationOnce(() => ({
-      delete: jest.fn().mockReturnThis(),
-      eq: jest.fn().mockResolvedValue({ error: { message: 'delete error' } }),
-    }))
-    const res = await PATCH(makeRequest({ reminderMinutes: [30] }), makeParams())
+    await PATCH(makeRequest({ title: '새 제목' }), makeParams())
+    expect(mockRpc).toHaveBeenCalledWith(
+      'update_event_with_reminders',
+      expect.objectContaining({ p_reminder_minutes: null })
+    )
+  })
+
+  it('RPC 실패 시 500을 반환한다', async () => {
+    mockEventFetch()
+    mockCalendarAccess()
+    mockRpc.mockResolvedValue({ error: { message: 'rpc error' } })
+    const res = await PATCH(makeRequest({ title: '새 제목' }), makeParams())
     expect(res.status).toBe(500)
   })
 })

--- a/src/__tests__/api/events/post.test.ts
+++ b/src/__tests__/api/events/post.test.ts
@@ -12,17 +12,20 @@ jest.mock('@/lib/push-utils', () => ({
 
 const mockGetUser = jest.fn()
 const mockFrom = jest.fn()
+const mockRpc = jest.fn()
 
 jest.mock('@/lib/supabase-admin', () => ({
   supabaseAdmin: {
     auth: { getUser: (token: unknown) => mockGetUser(token) },
     from: (table: unknown) => mockFrom(table),
+    rpc: (fn: unknown, args: unknown) => mockRpc(fn, args),
   },
 }))
 
 const ACTOR_USER_ID = 'actor-user'
 const FAMILY_ID = 'fam-1'
 const CALENDAR_ID = 'cal-1'
+const CREATED_EVENT = { id: 'evt-1', title: '생일 파티', family_id: FAMILY_ID }
 
 function makeRequest(body: Record<string, unknown>, token = 'valid-token') {
   return new NextRequest('http://localhost/api/events', {
@@ -80,12 +83,12 @@ function mockCalendarAccess(calendarFound = true, isMember = true) {
   }))
 }
 
-function mockEventInsert(event: Record<string, unknown> | null = { id: 'evt-1', title: '생일 파티' }) {
-  mockFrom.mockImplementationOnce(() => ({
-    insert: jest.fn().mockReturnThis(),
-    select: jest.fn().mockReturnThis(),
-    single: jest.fn().mockResolvedValue(event ? { data: event, error: null } : { data: null, error: { message: 'insert error' } }),
-  }))
+function mockRpcSuccess(event = CREATED_EVENT) {
+  mockRpc.mockResolvedValue({ data: [event], error: null })
+}
+
+function mockRpcFailure() {
+  mockRpc.mockResolvedValue({ data: null, error: { message: 'rpc error' } })
 }
 
 describe('POST /api/events', () => {
@@ -123,8 +126,7 @@ describe('POST /api/events', () => {
   it('이벤트를 생성하고 201을 반환한다', async () => {
     mockFamilyMember()
     mockCalendarAccess()
-    mockEventInsert()
-    mockSendEventNotification.mockResolvedValue(undefined)
+    mockRpcSuccess()
 
     const res = await POST(makeRequest(baseBody))
     expect(res.status).toBe(201)
@@ -132,38 +134,33 @@ describe('POST /api/events', () => {
     expect(json.id).toBe('evt-1')
   })
 
+  it('create_event_with_reminders RPC를 호출한다', async () => {
+    mockFamilyMember()
+    mockCalendarAccess()
+    mockRpcSuccess()
+
+    await POST(makeRequest({ ...baseBody, reminderMinutes: [30, 60] }))
+    expect(mockRpc).toHaveBeenCalledWith(
+      'create_event_with_reminders',
+      expect.objectContaining({ p_reminder_minutes: [30, 60] })
+    )
+  })
+
   it('calendarId가 null이면 캘린더 검증을 건너뛴다', async () => {
     mockFamilyMember()
-    mockEventInsert()
-    mockSendEventNotification.mockResolvedValue(undefined)
+    mockRpcSuccess()
 
     const res = await POST(makeRequest({ ...baseBody, calendarId: null }))
     expect(res.status).toBe(201)
     expect(mockFrom).not.toHaveBeenCalledWith('calendars')
   })
 
-  it('reminderMinutes가 있으면 event_reminders에 insert한다', async () => {
+  it('RPC 실패 시 500을 반환한다', async () => {
     mockFamilyMember()
     mockCalendarAccess()
-    mockEventInsert()
-    const reminderInsert = jest.fn().mockResolvedValue({ error: null })
-    mockFrom.mockImplementationOnce(() => ({ insert: reminderInsert }))
-    mockSendEventNotification.mockResolvedValue(undefined)
+    mockRpcFailure()
 
-    await POST(makeRequest({ ...baseBody, reminderMinutes: [30, 60] }))
-    expect(mockFrom).toHaveBeenCalledWith('event_reminders')
-    expect(reminderInsert).toHaveBeenCalled()
-  })
-
-  it('reminder insert 실패 시 500을 반환한다', async () => {
-    mockFamilyMember()
-    mockCalendarAccess()
-    mockEventInsert()
-    mockFrom.mockImplementationOnce(() => ({
-      insert: jest.fn().mockResolvedValue({ error: { message: 'reminder error' } }),
-    }))
-
-    const res = await POST(makeRequest({ ...baseBody, reminderMinutes: [30] }))
+    const res = await POST(makeRequest(baseBody))
     expect(res.status).toBe(500)
   })
 })

--- a/src/app/api/events/[id]/route.ts
+++ b/src/app/api/events/[id]/route.ts
@@ -54,54 +54,44 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
     }
   }
 
-  const updates: Record<string, unknown> = {}
-  if (body.title !== undefined) updates.title = body.title
-  if (body.description !== undefined) updates.description = body.description
-  if (body.startAt !== undefined) updates.start_at = body.startAt
-  if (body.endAt !== undefined) updates.end_at = body.endAt
-  if (body.isAllDay !== undefined) updates.is_all_day = body.isAllDay
-  if (body.calendarId !== undefined) updates.calendar_id = body.calendarId
+  const newTitle = body.title ?? existing.title
+  const newDescription = body.description !== undefined ? body.description : existing.description
+  const newStartAt = body.startAt ?? existing.start_at
+  const newEndAt = body.endAt !== undefined ? body.endAt : existing.end_at
+  const newIsAllDay = body.isAllDay ?? existing.is_all_day
+  const newCalendarId = body.calendarId !== undefined ? body.calendarId : existing.calendar_id
 
-  const changed = Object.entries(updates).some(
-    ([k, v]) => existing[k as keyof typeof existing] !== v
-  )
+  const changed =
+    newTitle !== existing.title ||
+    newDescription !== existing.description ||
+    newStartAt !== existing.start_at ||
+    newEndAt !== existing.end_at ||
+    newIsAllDay !== existing.is_all_day ||
+    newCalendarId !== existing.calendar_id
 
-  const { error: updateError } = await supabaseAdmin
-    .from('events')
-    .update({ ...updates, updated_at: new Date().toISOString() })
-    .eq('id', eventId)
+  const { error: rpcError } = await supabaseAdmin.rpc('update_event_with_reminders', {
+    p_event_id: eventId,
+    p_title: newTitle,
+    p_description: newDescription,
+    p_start_at: newStartAt,
+    p_end_at: newEndAt,
+    p_is_all_day: newIsAllDay,
+    p_calendar_id: newCalendarId,
+    p_reminder_minutes: body.reminderMinutes ?? null,
+  })
 
-  if (updateError) {
+  if (rpcError) {
     return NextResponse.json({ error: 'Failed to update event' }, { status: 500 })
-  }
-
-  if (body.reminderMinutes !== undefined) {
-    const { error: deleteError } = await supabaseAdmin
-      .from('event_reminders')
-      .delete()
-      .eq('event_id', eventId)
-    if (deleteError) {
-      return NextResponse.json({ error: 'Failed to update reminders' }, { status: 500 })
-    }
-
-    if (body.reminderMinutes.length > 0) {
-      const { error: insertError } = await supabaseAdmin
-        .from('event_reminders')
-        .insert(body.reminderMinutes.map((m) => ({ event_id: eventId, remind_minutes_before: m })))
-      if (insertError) {
-        return NextResponse.json({ error: 'Failed to update reminders' }, { status: 500 })
-      }
-    }
   }
 
   if (changed) {
     fireEventNotification({
       familyId: existing.family_id,
-      calendarId: (updates.calendar_id !== undefined ? updates.calendar_id : existing.calendar_id) as string | null,
+      calendarId: newCalendarId,
       actorUserId,
       action: 'updated',
-      eventTitle: (updates.title ?? existing.title) as string,
-      eventStartAt: (updates.start_at ?? existing.start_at) as string,
+      eventTitle: newTitle,
+      eventStartAt: newStartAt,
     })
   }
 

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -43,32 +43,23 @@ export async function POST(req: NextRequest) {
     }
   }
 
-  const { data: event, error: eventError } = await supabaseAdmin
-    .from('events')
-    .insert({
-      family_id: member.family_id,
-      created_by: actorUserId,
-      calendar_id: calendarId,
-      title,
-      description,
-      start_at: startAt,
-      end_at: endAt,
-      is_all_day: isAllDay,
-    })
-    .select()
-    .single()
-
-  if (eventError || !event) {
-    return NextResponse.json({ error: 'Failed to create event' }, { status: 500 })
-  }
-
-  if (reminderMinutes.length > 0) {
-    const { error: reminderError } = await supabaseAdmin
-      .from('event_reminders')
-      .insert(reminderMinutes.map((m) => ({ event_id: event.id, remind_minutes_before: m })))
-    if (reminderError) {
-      return NextResponse.json({ error: 'Failed to save reminders' }, { status: 500 })
+  const { data: events, error: rpcError } = await supabaseAdmin.rpc(
+    'create_event_with_reminders',
+    {
+      p_family_id: member.family_id,
+      p_created_by: actorUserId,
+      p_calendar_id: calendarId,
+      p_title: title,
+      p_description: description,
+      p_start_at: startAt,
+      p_end_at: endAt,
+      p_is_all_day: isAllDay,
+      p_reminder_minutes: reminderMinutes,
     }
+  )
+
+  if (rpcError || !events?.length) {
+    return NextResponse.json({ error: 'Failed to create event' }, { status: 500 })
   }
 
   fireEventNotification({
@@ -80,5 +71,5 @@ export async function POST(req: NextRequest) {
     eventStartAt: startAt,
   })
 
-  return NextResponse.json(event, { status: 201 })
+  return NextResponse.json(events[0], { status: 201 })
 }

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -540,6 +540,45 @@ export type Database = {
           family_id: string
         }[]
       }
+      create_event_with_reminders: {
+        Args: {
+          p_family_id: string
+          p_created_by: string
+          p_calendar_id: string | null
+          p_title: string
+          p_description: string | null
+          p_start_at: string
+          p_end_at: string | null
+          p_is_all_day: boolean
+          p_reminder_minutes: number[]
+        }
+        Returns: {
+          id: string
+          family_id: string
+          created_by: string
+          calendar_id: string | null
+          title: string
+          description: string | null
+          start_at: string
+          end_at: string | null
+          is_all_day: boolean
+          created_at: string
+          updated_at: string
+        }[]
+      }
+      update_event_with_reminders: {
+        Args: {
+          p_event_id: string
+          p_title: string
+          p_description: string | null
+          p_start_at: string
+          p_end_at: string | null
+          p_is_all_day: boolean
+          p_calendar_id: string | null
+          p_reminder_minutes: number[] | null
+        }
+        Returns: undefined
+      }
     }
     Enums: {
       [_ in never]: never

--- a/supabase/migrations/20260412000000_atomic_event_save.sql
+++ b/supabase/migrations/20260412000000_atomic_event_save.sql
@@ -1,0 +1,89 @@
+-- ============================================================
+-- Atomic event + reminder save RPCs
+-- Replaces sequential INSERT/UPDATE + reminder INSERT/DELETE
+-- with single-transaction functions.
+-- ============================================================
+
+-- ============================================================
+-- create_event_with_reminders
+-- ============================================================
+create or replace function create_event_with_reminders(
+  p_family_id        uuid,
+  p_created_by       uuid,
+  p_calendar_id      uuid,
+  p_title            text,
+  p_description      text,
+  p_start_at         timestamptz,
+  p_end_at           timestamptz,
+  p_is_all_day       boolean,
+  p_reminder_minutes integer[]
+)
+returns setof events
+language plpgsql
+security definer
+as $$
+declare
+  v_event events;
+begin
+  insert into events (
+    family_id, created_by, calendar_id,
+    title, description,
+    start_at, end_at, is_all_day
+  )
+  values (
+    p_family_id, p_created_by, p_calendar_id,
+    p_title, p_description,
+    p_start_at, p_end_at, p_is_all_day
+  )
+  returning * into v_event;
+
+  if cardinality(p_reminder_minutes) > 0 then
+    insert into event_reminders (event_id, remind_minutes_before)
+    select v_event.id, unnest(p_reminder_minutes);
+  end if;
+
+  return next v_event;
+end;
+$$;
+
+-- ============================================================
+-- update_event_with_reminders
+-- p_reminder_minutes = NULL  → reminders unchanged
+-- p_reminder_minutes = '{}'  → all reminders deleted
+-- p_reminder_minutes = '{n}' → reminders replaced
+-- ============================================================
+create or replace function update_event_with_reminders(
+  p_event_id         uuid,
+  p_title            text,
+  p_description      text,
+  p_start_at         timestamptz,
+  p_end_at           timestamptz,
+  p_is_all_day       boolean,
+  p_calendar_id      uuid,
+  p_reminder_minutes integer[]
+)
+returns void
+language plpgsql
+security definer
+as $$
+begin
+  update events
+  set
+    title       = p_title,
+    description = p_description,
+    start_at    = p_start_at,
+    end_at      = p_end_at,
+    is_all_day  = p_is_all_day,
+    calendar_id = p_calendar_id
+  where id = p_event_id;
+
+  if p_reminder_minutes is not null then
+    delete from event_reminders where event_id = p_event_id;
+
+    if cardinality(p_reminder_minutes) > 0 then
+      insert into event_reminders (event_id, remind_minutes_before)
+      select p_event_id, unnest(p_reminder_minutes);
+    end if;
+  end if;
+end;
+$$;

--- a/supabase/migrations/20260412000000_atomic_event_save.sql
+++ b/supabase/migrations/20260412000000_atomic_event_save.sql
@@ -21,6 +21,7 @@ create or replace function create_event_with_reminders(
 returns setof events
 language plpgsql
 security definer
+set search_path = public
 as $$
 declare
   v_event events;
@@ -46,6 +47,12 @@ begin
 end;
 $$;
 
+-- 이 함수는 service role(API route)에서만 호출해야 한다.
+-- anon/authenticated 클라이언트가 route 검증을 우회하지 못하도록 실행 권한을 제거한다.
+revoke execute on function create_event_with_reminders(
+  uuid, uuid, uuid, text, text, timestamptz, timestamptz, boolean, integer[]
+) from public, anon, authenticated;
+
 -- ============================================================
 -- update_event_with_reminders
 -- p_reminder_minutes = NULL  → reminders unchanged
@@ -65,6 +72,7 @@ create or replace function update_event_with_reminders(
 returns void
 language plpgsql
 security definer
+set search_path = public
 as $$
 begin
   update events
@@ -87,3 +95,9 @@ begin
   end if;
 end;
 $$;
+
+-- 이 함수는 service role(API route)에서만 호출해야 한다.
+-- anon/authenticated 클라이언트가 route 검증을 우회하지 못하도록 실행 권한을 제거한다.
+revoke execute on function update_event_with_reminders(
+  uuid, text, text, timestamptz, timestamptz, boolean, uuid, integer[]
+) from public, anon, authenticated;


### PR DESCRIPTION
## Summary

- `create_event_with_reminders`, `update_event_with_reminders` DB RPC 추가 (migration `20260412000000_atomic_event_save.sql`)
- `POST /api/events`: events INSERT + reminders INSERT를 단일 RPC 호출로 교체
- `PATCH /api/events/[id]`: events UPDATE + reminders DELETE/INSERT를 단일 RPC 호출로 교체
- `src/types/database.ts` Functions 타입에 두 RPC 추가
- post/patch 테스트를 `mockFrom` 체이닝에서 `mockRpc` 방식으로 전면 교체

## Testing

- `npm run test -- --testPathPatterns="src/__tests__/api/events"` 전체 통과 (25개)
- `npx tsc --noEmit` 오류 없음

## 수동 확인 항목

- [ ] 이벤트 생성 후 리마인더가 함께 저장되는지 확인
- [ ] 이벤트 수정 시 리마인더가 교체되는지 확인
- [ ] 리마인더 없이 이벤트만 생성/수정 시 정상 동작 확인
- [ ] Supabase migration 적용 후 기존 이벤트 조회 정상 여부 확인

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)