### PR TITLE
docs: refresh project guides for current codebase

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,4 +1,6 @@
-# 🏠 Koko — ファミリーハブ
+<img src="public/logo.webp" alt="Koko ロゴ" width="72" />
+
+# Koko — ファミリーハブ
 
 [한국어](README.ko.md) | **[日本語]** | [English](README.md)
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,4 +1,6 @@
-# 🏠 Koko — 패밀리 허브
+<img src="public/logo.webp" alt="Koko 로고" width="72" />
+
+# Koko — 패밀리 허브
 
 **[한국어]** | [日本語](README.ja.md) | [English](README.md)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# 🏠 Koko — Family Hub
+<img src="public/logo.webp" alt="Koko logo" width="72" />
+
+# Koko — Family Hub
 
 [한국어](README.ko.md) | [日本語](README.ja.md) | **[English]**
 

--- a/docs/CHALLENGES.md
+++ b/docs/CHALLENGES.md
@@ -1,207 +1,247 @@
 # 개발 과제 & 해결 기록
 
-Koko 개발 과정에서 마주친 기술적 과제와 해결 방법을 기록합니다.
+Koko 개발 과정에서 실제로 문제를 만들었거나, 다시 깨질 가능성이 높은 기술 이슈와 해결 방식을 기록한다.
+새 작업이 아래 주제와 닿아 있으면 구현 전에 먼저 읽는다.
 
 ---
 
-## 1. 브라우저 탭 간 실시간 동기화
+## 1. 브라우저 탭과 기기 간 실시간 동기화
 
 ### 과제
-장바구니 아이템을 추가/삭제할 때, 같은 브라우저에서 열린 다른 탭에 변경사항이 즉시 반영되지 않았다. 처음에는 Supabase Realtime의 `postgres_changes` 이벤트를 사용했지만, DELETE 이벤트의 `payload.old`에 `list_id` 같은 외래키 필드가 누락되어 있어 어느 목록의 아이템인지 식별이 불가능했다.
+
+같은 브라우저의 다른 탭, 또는 다른 기기에서 장보기와 캘린더 변경이 즉시 반영되지 않았다.
+초기에는 `postgres_changes`를 검토했지만, 삭제 payload 정보가 충분하지 않거나 UI 단위 refresh 경계와 잘 맞지 않았다.
 
 ### 해결
-두 레이어의 동기화 전략을 조합했다.
 
-- **같은 브라우저 내 탭 간**: Web API인 `BroadcastChannel`을 사용. WebSocket 연결 없이 동기적으로 메시지가 전달되어 지연이 없다.
-- **다른 기기 간**: Supabase Realtime의 Broadcast 채널을 사용. `postgres_changes` 대신 수동으로 `send()`를 호출해 refresh 이벤트를 전파한다.
+Supabase Realtime Broadcast 기반으로 단순화했다.
 
-또한 채널이 SUBSCRIBED 상태가 되기 전에 `send()`를 호출하면 REST API로 폴백되며 경고가 발생하는 문제가 있었다. `channelReadyRef`로 구독 완료 여부를 추적해 SUBSCRIBED 이후에만 broadcast를 전송하도록 개선했다.
+- mutation 성공 뒤 필요한 로컬 refresh를 수행한다.
+- 이어서 `refresh` broadcast를 수동 전송한다.
+- 수신 측은 같은 범위의 데이터를 다시 읽는다.
 
-```
-BroadcastChannel (same browser) ─── 즉시 동기화
-Supabase Realtime Broadcast     ─── 다른 기기 동기화
-```
+또한 채널이 `SUBSCRIBED` 되기 전에 `send()`를 호출하면 REST fallback 경고가 발생하고 메시지 누락 가능성이 있었다.
+그래서 `useRealtimeSync`에서 `channelReadyRef`를 두고, `SUBSCRIBED` 이후에만 broadcast를 보낸다.
+
+### 남은 규칙
+
+- 자동 전파를 기대하지 않는다.
+- 데이터 범위와 채널 범위를 맞춘다.
+- `channel.send()`를 직접 흩뿌리지 말고 `useRealtimeSync` 패턴을 재사용한다.
 
 ---
 
-## 2. Optimistic UI의 UUID 불일치로 인한 아이템 부활 현상
+## 2. Optimistic UI 임시 UUID로 인한 데이터 부활
 
 ### 과제
-빠른 UI 반응을 위해 서버 응답 전에 임시 UUID로 아이템을 화면에 먼저 표시(Optimistic UI)했다. 이때 다른 탭에서 Realtime으로 목록을 새로고침하면 서버의 실제 UUID로 아이템이 들어온다. 이후 Optimistic 아이템을 삭제해도 DB에는 가짜 UUID로 삭제 요청이 가서 아무것도 삭제되지 않고, 다음 새로고침 시 아이템이 다시 나타나는 "부활" 현상이 발생했다.
+
+장보기 아이템/목록을 optimistic UUID로 먼저 렌더링한 뒤, 그 임시 ID를 그대로 삭제/수정/정렬에 사용하면 서버 row와 ID가 맞지 않아 아이템이 "삭제된 것처럼 보였다가 다시 살아나는" 문제가 생겼다.
 
 ### 해결
-서버로부터 실제 응답을 받은 즉시 Optimistic 아이템을 실제 아이템으로 교체했다.
+
+서버 응답을 받는 즉시 optimistic row를 실제 DB row로 치환했다.
 
 ```typescript
-// 임시 ID로 먼저 렌더링
 setItems((prev) => [...prev, optimisticItem])
 
-// 서버 응답 후 실제 ID로 교체
 const realItem = await addShoppingItem(...)
-setItems((prev) => prev.map((i) => i.id === optimisticItem.id ? realItem : i))
+setItems((prev) =>
+  prev.map((item) => item.id === optimisticItem.id ? realItem : item)
+)
 ```
 
-이후 삭제/수정 시에는 항상 실제 서버 UUID를 사용하게 되어 문제가 해결됐다.
+### 남은 규칙
+
+- optimistic ID를 후속 mutation key로 쓰지 않는다.
+- create 계열 optimistic UI는 반드시 "실제 row 치환"까지 포함해야 한다.
 
 ---
 
-## 3. Supabase RLS(Row Level Security) 정책 위반
+## 3. Supabase RLS 정책의 재귀와 중첩 권한 실패
 
 ### 과제
-`shopping_items` 테이블의 INSERT/DELETE 시 RLS 정책에서 `42501 permission denied` 오류가 발생했다. 처음 작성한 정책은 `get_my_list_ids()` 함수를 WITH CHECK 절에서 서브쿼리로 사용했는데, RLS 컨텍스트에서 중첩 쿼리가 올바르게 동작하지 않았다.
+
+`family_members`를 직접 서브쿼리하는 RLS 정책과, 자식 테이블 `WITH CHECK`에서 JOIN 기반 검사를 넣은 정책은 예상보다 쉽게 무한 재귀나 `permission denied`를 만들었다.
+특히 `shopping_items`, `calendar_members` 주변에서 이런 문제가 반복됐다.
 
 ### 해결
-`get_my_list_ids()`를 `SECURITY DEFINER`로 정의해 RLS를 우회하는 방식을 사용하되, INSERT/DELETE 정책 자체는 `auth.uid() IS NOT NULL` 조건으로 단순화했다. 어차피 어떤 list에 아이템을 추가할 수 있는지는 애플리케이션 레벨에서 `family_id`로 제어되므로, RLS는 인증 여부만 확인하는 것으로 MVP 범위에서는 충분하다고 판단했다.
+
+- 가족 범위 판정은 `get_my_family_ids()` 같은 helper 함수 기반으로 단순화했다.
+- 복잡한 다중 테이블 권한 검사는 가능하면 API route + service role 쪽으로 이동했다.
+- `calendar_members` bootstrap은 owner 선삽입 패턴을 전제로 맞췄다.
+
+### 남은 규칙
+
+- RLS 안에서 권한 모델을 과도하게 표현하려 하지 않는다.
+- 중첩 정책이 필요한 순간 API route로 경계를 옮기는 편이 더 안전하다.
 
 ---
 
-## 4. 가족 생성 시 레이스 컨디션
+## 4. 가족 생성/합류를 클라이언트 다중 요청으로 처리했을 때의 레이스 컨디션
 
 ### 과제
-로그인 직후 여러 탭이 동시에 열리면, 각 탭이 독립적으로 `/api/family` API를 호출해 가족이 중복 생성되는 문제가 있었다. 두 탭 모두 "내 가족이 없다"고 판단하고 각각 INSERT를 실행하기 때문이다.
+
+로그인 직후 여러 탭이 동시에 열리면 "가족이 없으면 만들기"를 클라이언트 select -> insert 흐름으로 처리할 경우 중복 가족 생성이나 membership 충돌이 발생했다.
+가족 합류도 조회와 업데이트를 분리하면 동시 요청에서 정합성이 깨질 수 있었다.
 
 ### 해결
-애플리케이션 레벨이 아닌 **DB 레벨에서 원자적으로 처리**했다.
 
-1. `family_members` 테이블에 `user_id` 유니크 제약을 추가해 중복 삽입을 차단했다.
-2. PL/pgSQL 함수 `get_or_create_family(p_user_id)`를 작성해, 조회와 생성을 하나의 트랜잭션으로 묶었다. `ON CONFLICT DO NOTHING`으로 동시 요청이 와도 하나만 성공하도록 처리했다.
+가족 생성과 합류를 DB 함수로 옮겨 원자 처리했다.
 
-```sql
-CREATE OR REPLACE FUNCTION get_or_create_family(p_user_id uuid)
-RETURNS uuid AS $$
-DECLARE
-  v_family_id uuid;
-BEGIN
-  -- 기존 가족 조회
-  SELECT family_id INTO v_family_id
-  FROM family_members WHERE user_id = p_user_id;
+- `get_or_create_family(p_user_id)`는 legacy bootstrap 경로를 담당한다.
+- `create_family_with_name(p_user_id, p_name)`는 현재 온보딩의 명시적 가족 생성을 담당한다.
+- `join_family_by_invite_code(...)`는 가족 이동을 원자 처리한다.
 
-  IF v_family_id IS NULL THEN
-    -- 원자적 생성
-    INSERT INTO families (name) VALUES ('우리 가족')
-    RETURNING id INTO v_family_id;
+### 남은 규칙
 
-    INSERT INTO family_members (family_id, user_id, display_name, role)
-    VALUES (v_family_id, p_user_id, 'Member', 'admin')
-    ON CONFLICT (user_id) DO NOTHING;
-  END IF;
-
-  RETURN v_family_id;
-END;
-$$ LANGUAGE plpgsql SECURITY DEFINER;
-```
+- 가족 생성/합류는 클라이언트에서 select 후 insert로 구현하지 않는다.
+- 온보딩 접근 여부와 가족 존재 여부를 분리해서 본다.
 
 ---
 
-## 5. 모달 하단 버튼이 네비게이션 바에 가려지는 문제
+## 5. OAuth 자동 세션 교환으로 허용 목록 검사가 우회된 문제
 
 ### 과제
-PWA로 설치한 스마트폰에서 "새 장바구니" 모달을 열면 "만들기" 버튼이 잘려서 보이지 않았다. `max-h-[90vh]`와 `overflow-y-auto`로 스크롤을 추가하는 방식으로 한 번 수정했으나 문제가 재현됐다.
 
-### 원인
-모달 컨테이너(`fixed inset-0 flex items-end`)와 하단 네비게이션 바(`fixed bottom-0`)가 동일한 `z-50`를 사용하고 있었다. `items-end`는 모달 시트를 화면 최하단에 붙이는데, 네비게이션 바(약 64px)가 그 위를 덮어 버튼이 보이지 않는 구조였다. `max-h`로 높이를 제한해도 모달이 네비게이션 바 뒤에서 시작하기 때문에 근본 해결이 안 됐다.
+초기에는 callback 페이지에서 `exchangeCodeForSession`을 수동 호출한 뒤 `allowed_emails`를 검사했다.
+하지만 Supabase가 URL의 code를 먼저 자동 교환해 세션을 저장해버려, 수동 교환은 실패하고 이메일 검사가 우회되는 케이스가 생겼다.
 
 ### 해결
-모달 외부 컨테이너에 `pb-16 sm:pb-0`을 추가했다. `flex items-end`는 패딩을 존중하므로, 모바일에서 모달 시트가 네비게이션 바 높이만큼 위로 올라가 버튼이 온전히 노출된다. 태블릿/데스크탑(`sm` 이상)에서는 패딩 없이 중앙 정렬이 유지된다.
 
-```tsx
-// 수정 전
-<div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center">
+- `exchangeCodeForSession`을 제거했다.
+- `getSession()`과 `onAuthStateChange()`를 함께 사용해 세션 확보 시점을 잡았다.
+- 세션이 생긴 직후 `/api/auth/check-allowed`를 호출해 허용 여부를 최종 판정한다.
 
-// 수정 후
-<div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center pb-16 sm:pb-0">
-```
+### 남은 규칙
+
+- callback에서 세션 교환을 직접 다시 시도하지 않는다.
+- callback 검증은 "세션 생성 이후 판정" 모델로 유지한다.
 
 ---
 
-## 6. 탭 전환 시 로딩 스피너 발생
+## 6. 앱 초대 코드 소비를 분리 처리했을 때의 중복 사용 문제
 
 ### 과제
-캘린더, 장바구니, 설정 탭을 이동할 때마다 스피너가 표시되며 로딩이 발생했다. 각 탭이 별도의 Next.js 라우트 페이지로 구성되어 있어, 탭 이동 시 컴포넌트가 언마운트 → 재마운트되고 Supabase 데이터를 새로 fetch하기 때문이다. 네이티브 앱처럼 로딩 없이 즉각적인 탭 전환이 필요했다.
+
+앱 초대 코드를 "조회 -> 사용 처리 -> allowlist insert"로 나누면, 거의 동시에 두 요청이 들어왔을 때 같은 코드가 중복 소비될 수 있었다.
+또 앱 초대와 가족 초대의 의미가 섞이면 허용 목록 추가, 온보딩 이동, 가족 합류 경계가 무너지기 쉬웠다.
 
 ### 해결
-모든 탭 콘텐츠를 항상 마운트된 상태로 유지하고 CSS `display: none`으로 숨기는 방식(CSS Keep-Alive 패턴)을 적용했다.
 
-- 각 페이지(`calendar/page.tsx`, `shopping/page.tsx`, `settings/page.tsx`)의 내용을 탭 컴포넌트(`CalendarTab`, `ShoppingTab`, `SettingsTab`)로 추출
-- `TabsShell` 컴포넌트에서 세 탭을 동시에 렌더링하고 `display: contents` / `display: none`으로 가시성 제어
-- `BottomNav`를 라우팅 모드(Link)와 콜백 모드(button + onTabChange) 둘 다 지원하도록 수정
-- `/calendar`가 단일 진입점이 되고, `/shopping`과 `/settings`는 `/calendar`로 리다이렉트
+- 앱 초대는 `consume_app_invite(code, email)` RPC 한 번으로 소비한다.
+- callback 응답에 `needsOnboarding`를 포함해, 앱 접근 허용과 가족 생성 여부를 분리했다.
+- 가족 초대는 allowlist 허용만 수행하고 실제 가족 합류는 `/join`에서 처리한다.
 
-Supabase Realtime 구독이 이미 각 탭에 구현되어 있어, 탭이 항상 마운트된 상태에서도 가족 구성원의 변경이 즉시 반영된다.
+### 남은 규칙
 
-```
-변경 전: 탭 클릭 → 페이지 라우팅 → 컴포넌트 마운트 → 데이터 fetch → 스피너 표시
-변경 후: 탭 클릭 → activeTab 상태 변경 → display: none → display: contents (즉각 전환)
-```
-
-### 트레이드오프
-- URL이 항상 `/calendar`로 고정됨 (내부 가족 앱이므로 실질적 문제 없음)
-- 앱 초기 로딩 시 세 탭 데이터를 동시에 fetch함 (탭 수가 적고 데이터가 가벼워 영향 미미)
+- 앱 초대와 가족 초대는 서로 다른 목적의 링크로 유지한다.
+- 앱 초대 소비는 반드시 원자 RPC로 처리한다.
 
 ---
 
-## 7. Supabase OAuth 자동 세션 교환으로 이메일 허용 목록 우회
+## 7. 모달 CTA가 하단 네비게이션 바에 가려진 문제
 
 ### 과제
-가족 전용 앱이므로 허용된 이메일만 로그인할 수 있도록 제한하는 기능을 구현했다. OAuth 콜백 페이지에서 `exchangeCodeForSession`으로 코드를 교환한 뒤 이메일을 검사하고, 허용 목록에 없으면 즉시 로그아웃하는 방식이었다. 그러나 실제 테스트에서 허용 목록에 없는 이메일도 로그인이 가능했다.
 
-### 원인
-`@supabase/supabase-js` v2는 기본적으로 `detectSessionInUrl: true`가 설정되어 있다. OAuth 콜백 URL(`?code=xxx`)이 로드되는 순간 Supabase 클라이언트가 **React 렌더링보다 먼저** 코드 교환을 자동 완료하고 세션을 저장한다. 이후 `useEffect`에서 수동으로 `exchangeCodeForSession`을 호출하면 코드가 이미 소진된 상태라 에러가 발생하고, 에러 핸들러가 `/login`으로 리다이렉트한다. 그런데 Supabase가 이미 세션을 설정해둔 상태이므로 로그인 페이지가 자동으로 `/shopping`으로 튕겨버려 이메일 체크가 완전히 우회됐다.
-
-`detectSessionInUrl: false`로 자동 교환을 비활성화하면 이번엔 PKCE 코드 검증자(code verifier) 처리에 문제가 생겨 `exchangeCodeForSession` 자체가 실패했다.
+모바일 PWA에서 하단에서 올라오는 모달의 CTA가 고정 BottomNav 뒤로 가려졌다.
+단순 `max-h`나 내부 스크롤 추가만으로는 구조적으로 해결되지 않았다.
 
 ### 해결
-`exchangeCodeForSession`을 버리고 `onAuthStateChange`로 전략을 바꿨다. Supabase가 알아서 코드를 교환한 직후 `SIGNED_IN` 이벤트가 발생하는데, 이 시점에 이메일 허용 목록 체크를 수행한다. `getSession`과 `onAuthStateChange`를 함께 사용해 이벤트가 `useEffect` 등록 전에 발생하는 레이스 컨디션도 방지했다.
 
-```
-기존: 코드 교환(수동) → 이메일 체크 → 리다이렉트
-       ↑ Supabase가 먼저 교환해버려 우회됨
+모달 외부 컨테이너에 `pb-16 sm:pb-0`을 추가했다.
+`flex items-end` 컨테이너가 패딩을 존중하므로, 모바일에서는 시트가 네비게이션 바 높이만큼 위로 올라간다.
 
-변경: Supabase 자동 교환 → SIGNED_IN 이벤트 → 이메일 체크 → 허용/차단
-```
+### 남은 규칙
 
-허용 목록은 Supabase `allowed_emails` 테이블로 관리하며, 유효한 초대 코드를 통해 처음 로그인하는 사용자는 자동으로 테이블에 추가된다. 환경변수 방식은 Vercel 재배포 없이 멤버를 추가/제거할 수 없어 DB 방식으로 전환했다.
+- BottomNav와 같은 레벨에서 뜨는 일반 모달은 기본적으로 `pb-16 sm:pb-0`을 둔다.
 
 ---
 
-## 8. iOS Safari에서 캘린더 화면 상하 스크롤이 차단되지 않는 문제
+## 8. 탭 전환마다 스피너가 발생하던 문제
 
 ### 과제
-캘린더 화면은 `height: 100dvh`로 뷰포트 전체를 채우며, 세로 스크롤이 필요 없는 구조다. 그러나 모바일에서 화면을 위아래로 드래그하면 페이지가 따라서 움직였다.
 
-### 시도 1 — 컨테이너에 touchmove 이벤트 방지 (실패)
+캘린더, 장보기, 설정을 각각 별도 페이지로 운용할 때 탭 전환 시 언마운트/재마운트가 발생해 fetch와 스피너가 반복됐다.
+모바일 앱 같은 연속성이 깨졌다.
 
-```typescript
-el.addEventListener('touchmove', (e) => {
-  if (!isModalOpen) e.preventDefault()
-}, { passive: false })
-```
+### 해결
 
-iOS Safari에서는 `body`가 스크롤 가능한 상태이면 자식 엘리먼트에서 `e.preventDefault()`를 호출해도 body 레벨 스크롤이 막히지 않았다.
+- `/calendar`를 단일 live entry로 고정했다.
+- `TabsShell`이 세 탭을 모두 마운트한 상태로 유지하고 `display`만 전환한다.
+- 장보기 상세도 메인 흐름에서는 search param 기반으로 유지한다.
 
-### 시도 2 — document 레벨로 이벤트 이동 (실패)
+### 남은 규칙
 
-```typescript
-document.addEventListener('touchmove', (e) => {
-  if (!isModalOpen && el.contains(e.target as Node)) e.preventDefault()
-}, { passive: false })
-```
+- 탭을 다시 개별 route page로 쪼개지 않는다.
+- 독립 route가 필요하면 bridge 또는 외부 링크 호환 목적이 분명해야 한다.
 
-`body`에 `min-h-full`이 설정되어 있어 스크롤 가능한 상태인 점은 동일했다. Shopping 탭은 body 스크롤을 사용하므로 `overflow: hidden`을 전역으로 추가할 수도 없었다. 결과적으로 iOS Safari에서 여전히 스크롤이 발생했다.
+---
 
-### 해결 — CSS `touch-action: none`
+## 9. iOS Safari에서 캘린더 세로 스크롤이 막히지 않던 문제
 
-```tsx
-<div
-  style={{ height: '100dvh', touchAction: isModalOpen ? 'auto' : 'none' }}
->
-```
+### 과제
 
-JavaScript 이벤트 핸들러 방식은 iOS Safari에서 body 스크롤을 신뢰성 있게 막지 못한다. CSS `touch-action: none`은 브라우저에게 "이 요소에서 터치 기반 스크롤/줌 제스처를 처리하지 말 것"을 직접 지시하므로 JavaScript보다 앞선 레이어에서 동작한다.
+캘린더는 `100dvh` 고정 화면인데, iOS Safari에서는 `touchmove`를 막아도 body 레벨 스크롤이 계속 살아 있었다.
 
-모달이 열렸을 때(`isModalOpen: true`)는 `auto`로 복원해 모달 내부의 `overflow-y-auto` 스크롤 영역이 정상 동작하게 했다. 좌우 스와이프 월 이동은 JavaScript `touchstart`/`touchend` 이벤트로 구현되어 있어 `touch-action`의 영향을 받지 않는다.
+### 해결
 
-```
-실패: JS e.preventDefault() → iOS Safari body 스크롤 레이어에서 무시됨
-해결: CSS touch-action: none → 브라우저가 스크롤 시도 자체를 하지 않음
-```
+JS `preventDefault()` 대신 CSS `touch-action: none`을 사용했다.
+모달이 열렸을 때만 `auto`로 되돌려 모달 내부 스크롤을 허용한다.
+
+### 남은 규칙
+
+- iOS 터치 스크롤 제어는 JS 이벤트보다 CSS `touch-action`을 우선한다.
+
+---
+
+## 10. 이벤트와 리마인더를 순차 저장했을 때의 부분 실패 문제
+
+### 과제
+
+이벤트 row 저장과 `event_reminders` 저장을 클라이언트 또는 API에서 순차 처리하면, 앞 단계만 성공하고 뒤 단계가 실패하는 부분 저장 상태가 생길 수 있었다.
+또 클라이언트 direct mutation은 캘린더 write 권한과 family membership 권한 검증을 우회하기 쉬웠다.
+
+### 해결
+
+- 이벤트 생성/수정을 API route로 이동했다.
+- create/update는 각각 `create_event_with_reminders`, `update_event_with_reminders` RPC로 묶었다.
+- 해당 RPC의 anon/authenticated execute 권한을 제거해 route를 우회하지 못하게 했다.
+
+### 남은 규칙
+
+- 이벤트 생성/수정은 반드시 `/api/events` 계열 route를 통한다.
+- event와 reminder는 분리 저장하지 않는다.
+
+---
+
+## 11. 이벤트 변경 알림 fan-out을 클라이언트에서 처리할 수 없던 문제
+
+### 과제
+
+일정 생성/수정/삭제 후 관련 가족 또는 캘린더 멤버에게 push notification을 보내려면 actor 제외, 캘린더 멤버 조회, 구독 조회, 만료 구독 정리가 필요했다.
+이 흐름은 클라이언트에서 안전하게 수행할 수 없었다.
+
+### 해결
+
+- 이벤트 변경 push는 API route에서 비동기로 발송한다.
+- 캘린더 일정이면 `calendar_members`, 가족 전체 일정이면 `family_members`를 기준으로 대상을 결정한다.
+- actor 본인은 제외한다.
+- 404/410 구독은 즉시 정리한다.
+
+### 남은 규칙
+
+- cross-user notification fan-out은 클라이언트에 두지 않는다.
+- 발송 실패가 사용자 mutation 자체를 실패시키지 않도록 비동기로 분리한다.
+
+---
+
+## 언제 먼저 읽어야 하나
+
+아래 변경은 구현 전에 이 문서를 먼저 본다.
+
+- realtime 채널 구조를 바꿀 때
+- RLS 정책이나 migration을 수정할 때
+- OAuth callback, allowlist, 앱 초대 흐름을 손볼 때
+- 가족 생성/합류 로직을 바꿀 때
+- 이벤트 저장/리마인더/API route를 수정할 때
+- 탭 셸, 모달, 모바일 터치 동작을 바꿀 때

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -2,8 +2,8 @@
 
 # Koko Implementation Patterns
 
-이 문서는 "현재 코드베이스에서 반복적으로 검증된 구현 방식"만 정리한다.
-기능 소개나 파일 목록은 `docs/PROJECT_MAP.md`를 보고, 과거 버그의 배경은 `docs/CHALLENGES.md`를 본다.
+이 문서는 현재 코드베이스에서 반복적으로 검증된 구현 방식만 정리한다.
+기능 소개와 파일 지도는 `docs/PROJECT_MAP.md`, 과거 버그 배경은 `docs/CHALLENGES.md`를 본다.
 
 ## 1. Layer Rules
 
@@ -12,85 +12,102 @@ DB migration -> src/types/database.ts -> src/lib/* -> src/hooks/* -> src/app/* -
 ```
 
 - 각 레이어는 바로 아래 레이어에만 의존한다.
-- `src/lib/*`는 Supabase CRUD, API 호출, 순수 유틸만 둔다.
-- `src/hooks/*`는 여러 화면에서 재사용할 상태 로직만 둔다.
-- `src/app/*`는 라우트 진입점과 API route만 둔다.
-- `src/components/*`는 UI 조합과 로컬 인터랙션만 담당한다.
-- Realtime 구독 소유권은 탭 컨테이너나 페이지에 둔다. 하위 leaf 컴포넌트에 두지 않는다.
+- `src/lib/*`에는 Supabase 접근, API client helper, 순수 유틸만 둔다.
+- `src/hooks/*`에는 여러 화면에서 재사용할 상태 로직만 둔다.
+- `src/app/*`에는 route entry와 API route만 둔다.
+- `src/components/*`는 UI 조합과 로컬 인터랙션 상태를 담당한다.
+- Realtime 구독 소유권은 탭 컨테이너나 페이지에 둔다. leaf 컴포넌트에 두지 않는다.
 
 ## 2. App Shell And Routing
 
 - `/calendar`가 가족 앱의 단일 live entry point다.
-- `/shopping`과 `/settings`는 독립 화면이 아니라 `/calendar`로 리다이렉트한다.
-- 실제 탭 상태는 URL path가 아니라 `/calendar?tab=shopping` 같은 search param으로 제어한다.
-- `TabsShell`은 `CalendarTab`, `ShoppingTab`, `SettingsTab`를 항상 마운트하고 `display: none` 또는 `display: contents`로 가시성만 바꾼다.
-- 탭 전환 시 기존 상태를 유지해야 하므로, "탭마다 별도 페이지 라우팅 후 재마운트" 패턴을 다시 도입하지 않는다.
-- 예외적으로 장보기 상세는 [`src/app/shopping/[id]/page.tsx`](/Users/codingclef/workspace/koko/src/app/shopping/[id]/page.tsx)처럼 별도 라우트로 유지한다.
+- `/shopping`, `/settings`는 독립 화면이 아니라 `/calendar` 탭 셸로 리다이렉트한다.
+- 실제 탭 상태는 route path가 아니라 `/calendar?tab=shopping` 같은 search param으로 제어한다.
+- `TabsShell`은 `CalendarTab`, `ShoppingTab`, `SettingsTab`를 항상 마운트하고 `display`만 바꾼다.
+- 탭 상태 유지가 목적이므로 탭별 개별 route로 다시 분리하지 않는다.
+- 장보기 상세도 메인 흐름에서는 `/calendar?tab=shopping&list=<id>` search param으로 연다.
+- `src/app/shopping/[id]/page.tsx`는 canonical page가 아니라 구형 링크용 bridge route다.
 
 ## 3. Data And API Boundaries
 
-- 클라이언트 컴포넌트는 Supabase anon client로 직접 읽고 쓸 수 있는 데이터만 `src/lib/*`를 통해 접근한다.
-- 서비스 롤 키가 필요한 작업은 반드시 API route로 감싼다.
-- 클라이언트에서 `SUPABASE_SERVICE_ROLE_KEY`를 직접 사용하지 않는다.
-- 인증이 필요한 API route는 [`src/lib/api-auth.ts`](/Users/codingclef/workspace/koko/src/lib/api-auth.ts)의 `getAuthenticatedUserId()` 패턴을 사용한다.
-- 클라이언트에서 API route를 호출할 때는 [`src/lib/api-client.ts`](/Users/codingclef/workspace/koko/src/lib/api-client.ts)의 `getAuthHeaders()`로 access token을 붙인다.
-- 가족 생성, 가족 합류, 이메일 허용 목록 판정처럼 원자성이 중요한 로직은 DB 함수와 admin client로 처리한다.
+- 클라이언트는 anon Supabase client로 직접 접근 가능한 데이터만 `src/lib/*`를 통해 읽고 쓴다.
+- service role key가 필요한 작업은 반드시 API route로 감싼다.
+- 클라이언트 코드에서 `SUPABASE_SERVICE_ROLE_KEY`를 사용하지 않는다.
+- 인증이 필요한 API route는 `src/lib/api-auth.ts`의 helper를 사용해 사용자 식별을 처리한다.
+- 클라이언트에서 API route를 호출할 때는 `src/lib/api-client.ts`의 auth helper로 bearer token을 붙인다.
+- 권한 검증, 원자 저장, cross-table mutation, push fan-out이 필요한 로직은 API route + admin client + DB RPC 조합을 우선한다.
 
-## 4. Auth And Family Flow
+## 4. Auth And Onboarding Flow
 
 - 로그인은 Google OAuth만 사용한다.
 - OAuth callback에서는 `exchangeCodeForSession`을 호출하지 않는다.
-- Supabase 자동 세션 교환 후 `getSession()` 또는 `onAuthStateChange()`에서 이메일 허용 목록을 검사한다.
-- 허용 목록은 `allowed_emails` 테이블이 source of truth다.
-- 초대 코드로 진입한 신규 사용자는 `/api/auth/check-allowed`에서 허용 목록에 추가될 수 있다.
-- 로그인 직후 가족 조회는 `/api/family/me` -> `get_my_family` RPC(조회 전용)로 처리한다.
-- 가족 합류는 `/api/family/join` -> `join_family_by_invite_code` RPC 흐름으로 처리한다.
-- 가족 직접 생성은 `/api/family/create` -> `create_family_with_name` RPC로 처리한다.
-- "가족이 없으면 클라이언트에서 select 후 insert" 같은 다중 요청 패턴은 레이스 컨디션을 만든다. 사용하지 않는다.
-- 앱 초대 코드 소비는 `consume_app_invite(code, email)` RPC 한 번으로 원자 처리한다. 조회 → insert → update를 분리하면 동시 요청 시 코드가 두 번 소비된다.
-- **온보딩 접근 정책**: 가족이 없는 allowed user는 초대 경로(앱 초대 vs 가족 초대)와 무관하게 `/onboarding`에서 가족을 생성할 수 있다. 앱 초대는 이 상태에 도달하는 대표 경로일 뿐, 온보딩 접근의 유일한 자격 조건은 아니다.
+- Supabase 자동 세션 교환 후 `getSession()`과 `onAuthStateChange()`로 callback를 처리한다.
+- 앱 접근 허용의 source of truth는 `allowed_emails`다.
+- `allowed_emails.app_role`은 앱 관리자 권한을 나타낸다.
+- 앱 초대 링크는 `/join-app?code=...`, 가족 초대 링크는 `/join?code=...`로 구분한다.
+- 앱 초대 소비는 `/api/auth/check-allowed` -> `consume_app_invite(code, email)` RPC로 원자 처리한다.
+- 가족 초대 링크 진입 시 allowlist 추가와 실제 가족 합류는 분리한다.
+- allowed user이지만 `familyId === null`인 사용자는 `TabsShell`에서 `/onboarding`으로 보낸다.
+- 가족 생성은 `/api/family/create` -> `create_family_with_name` RPC로 명시적 처리한다.
+- 가족 합류는 `/api/family/join` -> `join_family_by_invite_code` RPC로 처리한다.
+- 가족 조회에는 `/api/family/me` -> `get_my_family` RPC를 사용한다.
+- 클라이언트에서 select 후 insert로 가족 생성/합류를 흉내 내지 않는다.
 
 ## 5. Realtime Pattern
 
 - Supabase Realtime은 `postgres_changes`가 아니라 Broadcast 채널만 사용한다.
-- 변경 후 자동 전파를 기대하지 말고, mutation 성공 뒤 수동 `broadcast()`를 호출한다.
-- `broadcast()`는 채널이 `SUBSCRIBED` 상태일 때만 보내야 한다.
+- 변경 후 자동 반영을 기대하지 말고 mutation 성공 뒤 수동 `broadcast()`를 호출한다.
+- `broadcast()`는 채널이 `SUBSCRIBED` 상태일 때만 보낸다.
 - `channelReadyRef` 없이 `channel.send()`를 호출하지 않는다.
-- 구독 훅은 [`src/hooks/useRealtimeSync.ts`](/Users/codingclef/workspace/koko/src/hooks/useRealtimeSync.ts) 패턴을 재사용한다.
+- 구독 훅은 `src/hooks/useRealtimeSync.ts` 패턴을 재사용한다.
 - 채널명은 기능 경계가 드러나야 한다.
-- 가족 범위 데이터는 `family_*_${familyId}` 형태를 우선한다.
-- 상세 화면 단위 데이터는 `list_items_${listId}`처럼 더 좁은 범위를 사용한다.
+- 가족 범위 데이터는 `family_*_${familyId}` 형식을 우선한다.
+- 월별 이벤트는 `family_events_${familyId}_${year}_${month}`처럼 조회 범위와 맞춘다.
+- 상세/부분 범위 데이터는 `list_items_${listId}`처럼 더 좁은 범위를 사용한다.
 
 ## 6. Calendar Patterns
 
-- 월별 이벤트 조회는 `getEventsByMonth(familyId, year, month)`처럼 month window 단위로 제한한다.
-- `events.calendar_id = null`은 가족 전체 일정이다. 캘린더 미지정 오류로 취급하지 않는다.
-- 캘린더 생성 시 owner 멤버를 먼저 insert하고, 그 다음 일반 멤버를 넣는다.
-- 이 순서는 `calendar_members` 부트스트랩 RLS를 통과하기 위한 전제다.
-- 캘린더 멤버 수정은 "전체 교체" 방식으로 다룬다. owner는 항상 유지한다.
-- 이벤트 저장 시 reminder도 함께 맞춘다. 이벤트만 저장하고 reminder를 방치하지 않는다.
+- 월 이벤트 조회는 `getEventsByMonth(familyId, year, month)`처럼 month window 단위로 제한한다.
+- 현재 월 외에도 인접 월 prefetch를 허용하지만, cache는 유한 크기로 유지한다.
+- `events.calendar_id = null`은 가족 전체 일정이다.
+- 캘린더 생성 시 owner 멤버를 먼저 insert하고 일반 멤버를 그 다음에 넣는다.
+- 캘린더 멤버 수정은 "owner 유지 + 나머지 전체 교체" 패턴으로 다룬다.
+- 이벤트 생성/수정은 클라이언트에서 테이블을 직접 건드리지 않고 `/api/events` 계열 route를 사용한다.
+- 이벤트 생성/수정 시 reminder도 함께 저장한다. event와 reminder를 분리 저장하지 않는다.
+- reminder 원자 저장은 `create_event_with_reminders`, `update_event_with_reminders` RPC에 맡긴다.
+- 이 RPC들은 service role route에서만 호출한다. 클라이언트 실행 권한을 다시 열지 않는다.
+- 이벤트 저장 후에는 현재 가족 월 cache를 비우고 refresh + broadcast 순서로 정합성을 맞춘다.
 - 캘린더 메인 화면은 `height: 100dvh`와 `touchAction` 제어를 사용한다.
-- 캘린더에서 세로 스크롤 차단이 필요하면 JS `preventDefault()`보다 CSS `touch-action`을 우선한다.
+- 세로 스크롤 차단이 필요하면 JS `preventDefault()`보다 CSS `touch-action`을 우선한다.
 
 ## 7. Shopping Patterns
 
 - 장보기 목록과 아이템 생성은 optimistic UI를 허용한다.
-- 단, optimistic UUID는 서버 응답을 받는 즉시 실제 DB row로 치환해야 한다.
-- optimistic UUID를 그대로 수정, 삭제, 정렬 mutation에 사용하지 않는다.
+- optimistic UUID는 서버 응답을 받는 즉시 실제 DB row로 치환해야 한다.
+- optimistic UUID를 후속 수정/삭제/정렬 mutation의 기준 ID로 쓰지 않는다.
 - 목록 정렬과 아이템 정렬은 `sort_order`를 명시적으로 저장한다.
-- 재정렬 시 UI를 먼저 갱신하되, 실제 `sort_order` 업데이트도 즉시 보낸다.
-- 장보기 탭은 keep-alive 탭 전환을 위해 module-level session cache(`lastKnownLists`)를 사용한다.
-- 비슷한 캐시는 "탭 언마운트 방지와 초기 스피너 최소화"가 분명할 때만 추가한다.
+- 재정렬 시 UI를 먼저 갱신하되, 실제 `sort_order` mutation도 즉시 보낸다.
+- 장보기 탭은 keep-alive 탭 전환과 상세 진입 복귀를 위해 가족별 module-level cache를 사용한다.
+- 이런 캐시는 탭 전환 성능과 초기 스피너 감소가 명확할 때만 추가한다.
 
 ## 8. Preferences And Theme
 
 - 사용자 설정은 `user_preferences` 한 테이블로 모은다.
 - 테마는 DB와 클라이언트 저장소를 함께 사용한다.
 - `persistTheme()`는 `localStorage`와 cookie를 같이 갱신해야 한다.
-- SSR 초기 페인트 전 테마 적용은 [`src/app/layout.tsx`](/Users/codingclef/workspace/koko/src/app/layout.tsx)의 inline head script가 담당한다.
+- SSR 첫 페인트 전 테마 적용은 `src/app/layout.tsx`의 inline head script가 담당한다.
 - 클라이언트에서만 테마를 바꾸고 SSR fallback을 빼면 FOUC가 다시 생긴다.
 
-## 9. Modal And Mobile Layout Rules
+## 9. Push And Notification Pattern
+
+- push subscription 등록은 API route를 통해 저장한다.
+- reminder 발송과 이벤트 변경 알림은 서로 다른 목적이다.
+- reminder는 cron route가 `event_reminders`를 기준으로 보낸다.
+- 이벤트 변경 알림은 이벤트 create/update/delete API route가 비동기로 발송한다.
+- actor 본인에게는 이벤트 변경 push를 보내지 않는다.
+- 404/410으로 만료된 구독은 발송 시점에 정리한다.
+
+## 10. Modal And Mobile Layout Rules
 
 - 하단 네비게이션이 있는 일반 모달 컨테이너에는 `pb-16 sm:pb-0`를 넣는다.
 - 이 패딩이 없으면 PWA 모바일에서 CTA가 하단 탭 바 뒤로 가려질 수 있다.
@@ -103,14 +120,15 @@ DB migration -> src/types/database.ts -> src/lib/* -> src/hooks/* -> src/app/* -
 | 삭제 확인 다이얼로그 | `z-[60]` |
 | 최상위 모달 또는 중첩 시트 | `z-[70]` |
 
-## 10. Testing Expectations
+## 11. Testing Expectations
 
 - 코드 변경 시 관련 테스트를 같이 갱신한다.
 - 우선 위치는 `src/__tests__/lib`, `src/__tests__/hooks`, `src/__tests__/api`, `src/__tests__/components`, `src/__tests__/shopping`, `src/__tests__/settings`다.
+- API route를 추가하거나 권한 로직을 바꾸면 route 테스트를 먼저 보강한다.
 - 회귀 위험이 큰 변경은 "lib 테스트 + 화면/훅 테스트"를 함께 추가하는 쪽을 우선한다.
-- 작업 마무리 전 `npx tsc --noEmit`를 실행한다.
+- 코드 작업 마무리 전 `npx tsc --noEmit`를 실행한다.
 
-## 11. Forbidden Patterns
+## 12. Forbidden Patterns
 
 | Forbidden | Why |
 | --- | --- |
@@ -119,15 +137,18 @@ DB migration -> src/types/database.ts -> src/lib/* -> src/hooks/* -> src/app/* -
 | `channelReadyRef` 없이 realtime broadcast 전송 | `SUBSCRIBED` 전 호출 시 REST fallback 경고와 누락 가능성 |
 | optimistic 임시 UUID로 후속 mutation 실행 | 삭제, 수정, 정렬 후 데이터 부활 버그 |
 | OAuth callback에서 `exchangeCodeForSession` 호출 | Supabase 자동 코드 교환과 충돌 |
+| 앱 초대 consume을 select -> insert -> update로 분리 | 동시 요청 시 코드가 중복 소비될 수 있음 |
+| 이벤트 생성/수정을 클라이언트 direct table mutation으로 처리 | 권한 검증과 reminder 원자 저장이 깨진다 |
 | 클라이언트 코드에서 service role key 사용 | 비밀키 노출 |
-| 탭을 별도 route page로 재분리 | 탭 전환 시 상태 손실과 로딩 스피너 회귀 |
+| 탭을 다시 개별 route page로 분리 | 탭 전환 시 상태 손실과 스피너 회귀 |
 | 수동 테마 저장 시 cookie 갱신 생략 | SSR 초기 렌더와 hydration 사이 FOUC 재발 |
 
-## 12. When To Read Challenges
+## 13. When To Read Challenges
 
-- Realtime을 수정할 때
+- realtime 흐름을 수정할 때
 - RLS 정책이나 migration을 수정할 때
+- 앱 초대, 이메일 허용 목록, OAuth callback 흐름을 바꿀 때
+- 이벤트 API route 또는 reminder 저장 방식을 바꿀 때
 - 모달, 탭 셸, 모바일 터치 동작을 바꿀 때
-- OAuth callback이나 이메일 허용 목록 흐름을 바꿀 때
 
 위 경우는 먼저 `docs/CHALLENGES.md`를 읽고 같은 버그를 재도입하지 않는지 확인한다.

--- a/docs/PROJECT_MAP.md
+++ b/docs/PROJECT_MAP.md
@@ -2,77 +2,118 @@
 
 # Koko Project Map
 
-This document is a fast orientation guide for understanding the current codebase.
-It summarizes implemented features, file ownership, data relationships, and the main runtime flows.
+이 문서는 현재 코드베이스를 빠르게 파악하기 위한 안내서다.
+구현된 기능 범위, 주요 파일 책임, 데이터 관계, 런타임 흐름을 현재 `main` 기준으로 요약한다.
 
 ## 1. Product Scope
 
-Koko is a family collaboration PWA centered on one shared app shell.
+Koko는 가족 단위로 일정을 공유하고 장보기와 설정을 함께 관리하는 PWA다.
+앱의 실제 진입점은 `/calendar` 하나이며, 내부에서 탭 셸이 살아 있는 상태로 캘린더, 장보기, 설정을 전환한다.
 
 ### Implemented
 
-- Family login with Google OAuth and email allowlist
-- Automatic family creation and family join by invite code
-- Calendar with family-scoped and calendar-scoped visibility
-- Shopping lists with realtime sync and drag-and-drop sorting
-- User preferences: holiday countries, app theme, lunar display
-- PWA installation and Web Push reminder delivery
+- Google OAuth 로그인 + 이메일 허용 목록 기반 접근 제어
+- 앱 초대 코드와 가족 초대 코드를 분리한 온보딩/합류 흐름
+- 가족 생성, 가족 이름 수정, 가족 초대 코드 공유, 다른 가족으로 합류
+- 가족 단위/캘린더 단위 가시성을 모두 지원하는 캘린더
+- 일정 생성, 수정, 삭제 API route와 reminder 원자 저장 RPC
+- 일정 변경 시 가족/캘린더 멤버 대상 push notification 전송
+- 장보기 목록/아이템 관리, 실시간 동기화, 드래그 정렬
+- 사용자 설정: holiday countries, app theme, lunar display
+- PWA 설치, service worker, reminder cron 기반 Web Push
+- OAuth 심사 대응용 privacy / terms 페이지
 
-### Present in Schema but Not Implemented in UI
+### Present In Schema But Not Implemented In UI
 
 - `memos`
 - `event_votes`
 
-These appear in the database schema and generated types, but there is no active frontend or `lib/*` implementation for them.
+이 두 테이블은 스키마와 generated types에는 존재하지만 현재 `src/lib/*`, `src/app/*`, `src/components/*`에서 활성 기능으로 연결되어 있지 않다.
 
 ## 2. App Structure
 
 ### Top-Level Runtime Shape
 
 - `src/app/layout.tsx`
-  - Global metadata, font loading, SSR-safe theme bootstrapping
+  - 글로벌 메타데이터, 폰트, SSR-safe theme bootstrap
 - `src/app/page.tsx`
-  - Redirects to `/calendar`
+  - `/calendar`로 리다이렉트
 - `src/app/calendar/page.tsx`
-  - Single mounted app entry point
+  - 가족 앱의 단일 live entry point
 - `src/components/TabsShell.tsx`
-  - Keep-alive shell for calendar, shopping, settings
+  - auth/family/preferences/calendars 초기화 후 탭을 keep-alive 상태로 렌더링
+
+### Auxiliary Routes
+
+- `src/app/login/page.tsx`
+  - Google OAuth 시작
+- `src/app/auth/callback/page.tsx`
+  - Supabase 자동 세션 교환 후 allowlist/app invite/family invite 판정
+- `src/app/onboarding/page.tsx`
+  - allowed user이지만 아직 가족이 없는 사용자의 가족 생성
+- `src/app/join/page.tsx`
+  - 가족 초대 코드로 기존 가족에 합류
+- `src/app/join-app/page.tsx`
+  - 앱 초대 링크 진입점. 로그인 후 callback 판정으로 이어짐
+- `src/app/shopping/[id]/page.tsx`
+  - 구형 상세 링크를 `?tab=shopping&list=...` 형태로 브리지
+- `src/app/privacy/page.tsx`
+- `src/app/terms/page.tsx`
 
 ### Redirect Routes
 
-- `src/app/shopping/page.tsx`
 - `src/app/settings/page.tsx`
+- `src/app/shopping/page.tsx`
 
-These redirect to `/calendar` because the real app state is hosted inside `TabsShell`.
+이 두 route는 독립 화면을 렌더링하지 않고 `/calendar` 기반 탭 셸로 리다이렉트한다.
 
 ## 3. Feature Map
 
-### Auth and Access
+### Auth And Access
 
 - Login page: `src/app/login/page.tsx`
 - OAuth callback: `src/app/auth/callback/page.tsx`
 - Allowlist check API: `src/app/api/auth/check-allowed/route.ts`
-- Invite code parsing: `src/lib/auth.ts`
+- Invite parsing helper: `src/lib/auth.ts`
+- Auth hook: `src/hooks/useAuth.ts`
 
 Flow:
-- User signs in with Google
-- Supabase auto-creates the session
-- Callback checks `allowed_emails`
-- A valid invite code can auto-allow a first-time user
-- Unauthorized users are signed out and redirected to login
+- 사용자는 Google OAuth로 로그인한다.
+- Supabase가 callback URL에서 세션을 자동 교환한다.
+- callback 페이지는 `getSession()` + `onAuthStateChange()`로 세션 확보를 기다린다.
+- `/api/auth/check-allowed`가 `allowed_emails`, 앱 초대 코드, 가족 초대 코드를 판정한다.
+- 앱 초대 코드가 소비되면 `needsOnboarding: true`가 반환되고 `/onboarding`으로 이동한다.
+- 허용되지 않은 사용자는 즉시 sign out 후 `/login?error=unauthorized`로 보낸다.
 
-### Family
+### Family And Onboarding
 
-- Family bootstrap API: `src/app/api/family/route.ts`
+- Family lookup API: `src/app/api/family/me/route.ts`
+- Legacy get-or-create API: `src/app/api/family/route.ts`
+- Explicit family create API: `src/app/api/family/create/route.ts`
 - Family join API: `src/app/api/family/join/route.ts`
-- Join page: `src/app/join/page.tsx`
+- Family rename API: `src/app/api/family/name/route.ts`
 - Family helpers: `src/lib/family.ts`
 - Family hook: `src/hooks/useFamily.ts`
 
-Flow:
-- After auth, the app resolves the user's family via `get_or_create_family`
-- Users can move into another family by invite code
-- The active family is the tenant boundary for most data
+Current behavior:
+- `useFamily()`는 `/api/family/me`를 호출해 현재 가족과 `appRole`을 읽는다.
+- 가족이 없는 allowed user는 `TabsShell`에서 `/onboarding`으로 보낸다.
+- `/onboarding`은 `create_family_with_name` RPC로 명시적 가족 생성을 수행한다.
+- 가족 합류는 `join_family_by_invite_code` RPC로 원자 처리된다.
+- 설정 탭에서 가족 이름을 수정할 수 있다.
+- `allowed_emails.app_role`이 `admin`이면 앱 초대 생성 권한을 가진다.
+
+### App Invite Administration
+
+- App invite API: `src/app/api/app-invite/route.ts`
+- App invite UI: `src/components/tabs/SettingsTab.tsx`
+- Schema support: `app_invites`, `allowed_emails.app_role`
+
+Current behavior:
+- 앱 관리자만 새 앱 초대를 생성할 수 있다.
+- 앱 초대 링크는 `/join-app?code=...` 형식이다.
+- 앱 초대는 1회용이며 만료 시간이 있다.
+- 초대 소비는 `consume_app_invite(code, email)` RPC로 원자 처리된다.
 
 ### Calendar
 
@@ -81,143 +122,168 @@ Flow:
 - Calendar hook: `src/hooks/useCalendars.ts`
 - Holiday hook: `src/hooks/useHolidays.ts`
 - Swipe hook: `src/hooks/useSwipe.ts`
-- UI:
+- Event APIs:
+  - `src/app/api/events/route.ts`
+  - `src/app/api/events/[id]/route.ts`
+- Key UI:
   - `src/components/calendar/CalendarGrid.tsx`
   - `src/components/calendar/CalendarFilter.tsx`
   - `src/components/calendar/CalendarListSheet.tsx`
+  - `src/components/calendar/CalendarDetailScreen.tsx`
   - `src/components/calendar/DayEventsSheet.tsx`
   - `src/components/calendar/EventDetailSheet.tsx`
   - `src/components/calendar/EventFormModal.tsx`
   - `src/components/calendar/CalendarFormModal.tsx`
   - `src/components/calendar/TimeWheelPicker.tsx`
+  - `src/components/calendar/YearMonthPickerSheet.tsx`
 
 Current behavior:
-- Month-based event loading
-- Calendar filter chips
-- Family-wide events and calendar-specific events
-- Calendar membership management
-- Reminder settings per event
-- Holiday overlays and optional lunar date display
+- 월 단위로 이벤트를 로드하고 인접 월을 prefetch한다.
+- 월 이벤트 캐시는 최대 12개월까지 유지된다.
+- 가족 전체 일정과 캘린더 전용 일정을 함께 지원한다.
+- 캘린더 생성/수정/삭제와 멤버 관리가 가능하다.
+- 이벤트 생성/수정은 API route 뒤의 `create_event_with_reminders`, `update_event_with_reminders` RPC로 원자 저장한다.
+- 이벤트 삭제는 API route에서 권한 검증 후 수행한다.
+- 이벤트 생성/수정/삭제 시 관련 멤버에게 push notification을 보낼 수 있다.
+- holiday overlay, lunar display, year-month picker, swipe month navigation을 제공한다.
 
 ### Shopping
 
 - Tab container: `src/components/tabs/ShoppingTab.tsx`
-- Detail page: `src/app/shopping/[id]/page.tsx`
+- Detail view: `src/components/shopping/ShoppingDetailView.tsx`
+- Bridge route: `src/app/shopping/[id]/page.tsx`
 - Data layer: `src/lib/shopping.ts`
-- UI:
+- Key UI:
   - `src/components/shopping/ShoppingListCard.tsx`
   - `src/components/shopping/CreateListModal.tsx`
   - `src/components/shopping/ShoppingItem.tsx`
   - `src/components/shopping/AddItemInput.tsx`
 
 Current behavior:
-- Shopping list creation, rename, delete
-- Two list types: `strikethrough` and `delete`
-- Item add/check/delete/rename
-- Drag-and-drop list and item ordering
-- Optimistic UI for create operations
+- 장보기 목록 생성, 이름 변경, 삭제
+- 두 가지 목록 타입: `strikethrough`, `delete`
+- 아이템 추가/체크/삭제/이름 변경
+- 목록/아이템 drag-and-drop 정렬
+- 생성 계열 optimistic UI + 서버 row 치환
+- 가족별 module-level cache로 탭 전환과 상세 진입 시 초기 스피너를 최소화
+- 상세 상태는 별도 페이지가 아니라 `/calendar?tab=shopping&list=<id>` search param으로 유지한다
 
-### Settings and Preferences
+### Settings And Preferences
 
 - Tab container: `src/components/tabs/SettingsTab.tsx`
 - Preferences helpers: `src/lib/preferences.ts`
 - Preferences hook: `src/hooks/useUserPreferences.ts`
+- Push registration: `src/lib/push.ts`
 
 Current behavior:
-- View account email
-- Edit display name
-- Share family invite code
-- Join a family by code
-- Enable push notifications
-- Configure holiday countries
-- Toggle lunar display
-- Change app theme
+- 계정 이메일 표시
+- 내 display name 수정
+- 가족 이름 수정
+- 가족 초대 코드 공유
+- 가족 초대 코드로 다른 가족 합류
+- 앱 관리자용 앱 초대 생성/공유
+- push notification 권한 요청 및 구독 등록
+- holiday countries 변경
+- lunar display toggle
+- app theme 변경
 
-### Realtime and Push
+### Realtime And Push
 
 - Realtime hook: `src/hooks/useRealtimeSync.ts`
-- Push registration: `src/lib/push.ts`
+- Push notification helpers: `src/lib/push-utils.ts`
 - Web Push sender: `src/lib/webpush.ts`
 - Push subscription API: `src/app/api/push/subscribe/route.ts`
 - Push test API: `src/app/api/push/test/route.ts`
 - Reminder cron API: `src/app/api/cron/send-reminders/route.ts`
 - Service worker: `public/sw.js`
-- PWA manifest: `public/manifest.json`
+- Manifest: `public/manifest.json`
+
+Current behavior:
+- Supabase Realtime Broadcast를 사용해 가족 범위 변경사항을 동기화한다.
+- 이벤트 mutation API는 일정 변경 push를 비동기로 발송한다.
+- reminder cron은 `event_reminders`를 기준으로 예정 알림을 발송한다.
+- 만료된 push subscription은 발송 실패 시 정리된다.
 
 ## 4. File Responsibility Map
 
 ### `src/app/*`
 
-- Route entry points, redirects, and server APIs
-- Minimal orchestration only
+- 라우트 진입점, redirect, API route
+- 서버 권한 검증과 orchestration
 
 ### `src/components/*`
 
-- UI composition and local interaction state
-- Tab-level containers own feature-level fetch and realtime subscription wiring
+- UI composition과 feature-level interaction state
+- 탭 컨테이너가 feature fetch, mutation trigger, realtime wiring을 보유
 
 ### `src/lib/*`
 
-- Supabase clients
-- Typed CRUD and feature utilities
-- No view logic
+- Supabase client
+- typed CRUD, API client helper, feature utility
+- 서버/클라이언트 공용 비즈니스 접근 함수
 
 ### `src/hooks/*`
 
-- Shared stateful client hooks
-- Reusable auth, family, preferences, holidays, swipe, realtime logic
+- 여러 화면에서 재사용하는 client state 로직
+- auth, family, preferences, holidays, swipe, realtime, async data 관리
 
 ### `src/types/*`
 
-- Generated database contract and shared UI types
+- generated DB contract
+- tab / push 등 앱 공용 타입
 
 ### `supabase/migrations/*`
 
-- Source of truth for database schema, RLS, helper functions, and operational fixes
+- DB schema, RLS, helper RPC, 운영 fix의 source of truth
 
 ### `src/__tests__/*`
 
-- Regression coverage across API routes, hooks, lib functions, and major UI pieces
+- API route, lib, hook, major component 회귀 테스트
 
 ## 5. Data Model Summary
 
 ### Core Entities
 
 - `families`
-  - Top-level tenant for shared family data
+  - 가족 tenant와 가족 초대 코드
 - `family_members`
-  - Membership records for users inside a family
+  - 사용자와 가족의 membership
 - `allowed_emails`
-  - Login allowlist for authorized users
+  - 앱 접근 허용 이메일 + `app_role`
+- `app_invites`
+  - 앱 접근용 1회성 초대 코드
 - `user_preferences`
-  - Per-user UI and calendar display preferences
+  - 사용자별 UI/캘린더 설정
 
 ### Calendar Domain
 
 - `calendars`
-  - Named calendars belonging to a family
+  - 가족 소속 캘린더
 - `calendar_members`
-  - Per-calendar access control
+  - 캘린더별 접근 제어
 - `events`
-  - Calendar events, optionally assigned to a specific calendar
+  - 가족 또는 캘린더 범위 일정
 - `event_reminders`
-  - Reminder offsets attached to events
+  - 일정별 reminder offset
 - `event_votes`
-  - Exists in schema only at the moment
+  - 현재 UI 미구현
 
 ### Shopping Domain
 
 - `shopping_lists`
-  - Family-owned lists
+  - 가족 소속 장보기 목록
 - `shopping_items`
-  - Items inside a shopping list
+  - 목록 내 아이템
+
+### Push Domain
+
+- `push_subscriptions`
+  - 브라우저/디바이스별 Web Push endpoint
 
 ### Other Domain Tables
 
 - `memos`
-  - Exists in schema only at the moment
-- `push_subscriptions`
-  - Web Push endpoints per user/device/browser
+  - 현재 UI 미구현
 
 ## 6. ERD-Level Relationship Summary
 
@@ -225,7 +291,11 @@ Current behavior:
 auth.users
   ├─< family_members >─ families
   ├─< user_preferences
-  └─< push_subscriptions
+  ├─< push_subscriptions
+  └─< app_invites(created_by)
+
+allowed_emails
+  └─ app_role
 
 families
   ├─< calendars
@@ -246,54 +316,49 @@ shopping_lists
 ```
 
 Important notes:
-- A user is effectively modeled as belonging to one active family through `family_members.user_id` uniqueness.
-- `events.calendar_id` can be `null`, which means a family-wide event not restricted to a specific calendar.
-- `calendar_members` is the access-control table for calendar visibility.
+- 앱 접근 허용과 가족 소속은 별개다. `allowed_emails`에 있어도 `family_members`에는 없을 수 있다.
+- `family_members.user_id`는 사실상 사용자당 활성 가족 1개 모델을 만든다.
+- `events.calendar_id = null`은 가족 전체 일정이다.
+- `calendar_members`가 캘린더별 읽기/쓰기 권한의 기준이다.
 
 ## 7. Main Runtime Flows
 
-### App Initialization
+### App Startup
 
-1. `useAuth()` resolves the current session
-2. `useFamily()` calls `/api/family`
-3. `TabsShell` mounts all three tabs
-4. Each tab loads its own data
+1. `useAuth()`가 현재 세션을 확인한다.
+2. `useFamily()`가 `/api/family/me`를 호출해 `familyId`와 `appRole`을 가져온다.
+3. `useCalendars()`가 가족 캘린더를 읽는다.
+4. `TabsShell`이 세 탭을 keep-alive 상태로 렌더링한다.
+5. 가족이 없으면 `/onboarding`으로 리다이렉트한다.
 
-### Realtime
+### Login And Access Decision
 
-1. Tab/page subscribes through `useRealtimeSync`
-2. Local mutation updates Supabase
-3. The mutation owner manually broadcasts `refresh`
-4. Other clients receive the event and reload
+1. `/login`에서 Google OAuth를 시작한다.
+2. Supabase가 `/auth/callback`에서 세션을 자동 교환한다.
+3. callback 페이지가 `/api/auth/check-allowed`를 호출한다.
+4. 결과에 따라:
+   - allowed + onboarding 필요 없음 → 원래 `next`로 이동
+   - allowed + onboarding 필요 → `/onboarding`
+   - not allowed → sign out 후 `/login?error=unauthorized`
 
-### Push Reminders
+### Family Creation / Join
 
-1. Client requests notification permission
-2. Browser push subscription is stored in `push_subscriptions`
-3. Scheduled cron hits `/api/cron/send-reminders`
-4. Server fetches due reminders and marks them as sent atomically
-5. Web Push is sent to active subscriptions
+1. allowed user가 가족이 없으면 `/onboarding`으로 이동한다.
+2. 가족 생성은 `/api/family/create` -> `create_family_with_name` RPC로 수행한다.
+3. 기존 가족 합류는 `/api/family/join` -> `join_family_by_invite_code` RPC로 수행한다.
+4. 합류 후 앱의 tenant boundary는 새 `familyId`로 바뀐다.
 
-## 8. Rules to Keep in Mind Before Editing
+### Event Mutation
 
-- Read `docs/PATTERNS.md` before feature work.
-- Read `docs/CHALLENGES.md` when touching auth, realtime, RLS, shopping optimistic UI, or mobile modal behavior.
-- Do not replace the `TabsShell` keep-alive structure with route-per-tab navigation without understanding the tradeoff.
-- Do not switch realtime back to `postgres_changes`.
-- Do not call `exchangeCodeForSession`.
-- Do not use service-role keys on the client.
-- Do not add RLS policies with naive nested `family_members` subqueries when helper functions already exist.
+1. `CalendarTab`이 `/api/events` 또는 `/api/events/[id]`를 호출한다.
+2. API route가 요청 사용자의 가족/캘린더 write 권한을 검증한다.
+3. create/update는 reminder까지 함께 RPC로 원자 저장한다.
+4. 성공 후 현재 월 이벤트를 강제 refresh하고 realtime broadcast를 보낸다.
+5. 이벤트 변경 push notification은 API route에서 비동기로 발송한다.
 
-## 9. Useful Entry Files for Fast Orientation
+### Shopping Sync
 
-- `src/components/TabsShell.tsx`
-- `src/components/tabs/CalendarTab.tsx`
-- `src/components/tabs/ShoppingTab.tsx`
-- `src/components/tabs/SettingsTab.tsx`
-- `src/lib/calendar.ts`
-- `src/lib/shopping.ts`
-- `src/lib/preferences.ts`
-- `src/hooks/useRealtimeSync.ts`
-- `src/types/database.ts`
-- `docs/PATTERNS.md`
-- `docs/CHALLENGES.md`
+1. `ShoppingTab`이 가족별 목록을 읽고 module-level cache에 저장한다.
+2. create/rename/delete/reorder 후 로컬 상태를 즉시 갱신한다.
+3. mutation 성공 시 `family_lists_${familyId}` broadcast를 보낸다.
+4. 다른 탭/기기는 realtime 수신 후 목록을 새로고침한다.


### PR DESCRIPTION
## Summary
- refresh docs/PROJECT_MAP.md to match the current app structure, onboarding flow, event APIs, and push behavior
- refresh docs/PATTERNS.md with the current routing, app invite, realtime, and atomic event-save conventions
- refresh docs/CHALLENGES.md with the main implementation pitfalls and replace README emoji headers with the current logo asset

## Testing
- Tests not run (docs-only changes)