### PR TITLE
docs: refine readme logo header layout

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,6 +1,4 @@
-<img src="public/logo.webp" alt="Koko ロゴ" width="72" />
-
-# Koko — ファミリーハブ
+<h1><img src="public/logo.webp" alt="Koko ロゴ" width="40" /> Koko — ファミリーハブ</h1>
 
 [한국어](README.ko.md) | **[日本語]** | [English](README.md)
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,6 +1,4 @@
-<img src="public/logo.webp" alt="Koko 로고" width="72" />
-
-# Koko — 패밀리 허브
+<h1><img src="public/logo.webp" alt="Koko 로고" width="40" /> Koko — 패밀리 허브</h1>
 
 **[한국어]** | [日本語](README.ja.md) | [English](README.md)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-<img src="public/logo.webp" alt="Koko logo" width="72" />
-
-# Koko — Family Hub
+<h1><img src="public/logo.webp" alt="Koko logo" width="40" /> Koko — Family Hub</h1>
 
 [한국어](README.ko.md) | [日本語](README.ja.md) | **[English]**
 


### PR DESCRIPTION
## Summary
- replace the stacked README logo/title header with a single-line logo header in the English, Korean, and Japanese READMEs
- keep the current logo asset while making the top section render more cleanly in GitHub markdown

## Testing
- Tests not run (docs-only changes)