### PR TITLE
fix: stabilize mobile event push delivery

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -3,8 +3,8 @@ self.addEventListener('push', (event) => {
   event.waitUntil(
     self.registration.showNotification(data.title ?? 'Koko', {
       body: data.body ?? '',
-      icon: '/icons/icon-192x192.png',
-      badge: '/icons/icon-72x72.png',
+      icon: '/icons/icon-192.png',
+      badge: '/icons/icon-192.png',
       tag: data.tag ?? 'koko-reminder',
       data: { url: data.url ?? '/' },
     })

--- a/src/__tests__/api/events/delete.test.ts
+++ b/src/__tests__/api/events/delete.test.ts
@@ -1,13 +1,21 @@
 /**
  * @jest-environment node
  */
+jest.mock('next/server', () => {
+  const actual = jest.requireActual('next/server')
+  return {
+    ...actual,
+    after: (callback: () => unknown) => callback(),
+  }
+})
+
 import { DELETE } from '@/app/api/events/[id]/route'
 import { NextRequest } from 'next/server'
 
 const mockSendEventNotification = jest.fn()
 
 jest.mock('@/lib/push-utils', () => ({
-  fireEventNotification: (...args: unknown[]) => mockSendEventNotification(...args),
+  sendEventNotification: (...args: unknown[]) => mockSendEventNotification(...args),
 }))
 
 const mockGetUser = jest.fn()

--- a/src/__tests__/api/events/patch.test.ts
+++ b/src/__tests__/api/events/patch.test.ts
@@ -1,13 +1,21 @@
 /**
  * @jest-environment node
  */
+jest.mock('next/server', () => {
+  const actual = jest.requireActual('next/server')
+  return {
+    ...actual,
+    after: (callback: () => unknown) => callback(),
+  }
+})
+
 import { PATCH } from '@/app/api/events/[id]/route'
 import { NextRequest } from 'next/server'
 
 const mockSendEventNotification = jest.fn()
 
 jest.mock('@/lib/push-utils', () => ({
-  fireEventNotification: (...args: unknown[]) => mockSendEventNotification(...args),
+  sendEventNotification: (...args: unknown[]) => mockSendEventNotification(...args),
 }))
 
 const mockGetUser = jest.fn()
@@ -145,6 +153,7 @@ describe('PATCH /api/events/[id]', () => {
   it('변경사항 있으면 204를 반환하고 알림을 보낸다', async () => {
     mockEventFetch()
     mockCalendarAccess()
+    mockSendEventNotification.mockResolvedValue(undefined)
     const res = await PATCH(makeRequest({ title: '새 제목' }), makeParams())
     expect(res.status).toBe(204)
     expect(mockSendEventNotification).toHaveBeenCalledWith(

--- a/src/__tests__/api/events/post.test.ts
+++ b/src/__tests__/api/events/post.test.ts
@@ -1,13 +1,21 @@
 /**
  * @jest-environment node
  */
+jest.mock('next/server', () => {
+  const actual = jest.requireActual('next/server')
+  return {
+    ...actual,
+    after: (callback: () => unknown) => callback(),
+  }
+})
+
 import { POST } from '@/app/api/events/route'
 import { NextRequest } from 'next/server'
 
 const mockSendEventNotification = jest.fn()
 
 jest.mock('@/lib/push-utils', () => ({
-  fireEventNotification: (...args: unknown[]) => mockSendEventNotification(...args),
+  sendEventNotification: (...args: unknown[]) => mockSendEventNotification(...args),
 }))
 
 const mockGetUser = jest.fn()
@@ -127,6 +135,7 @@ describe('POST /api/events', () => {
     mockFamilyMember()
     mockCalendarAccess()
     mockRpcSuccess()
+    mockSendEventNotification.mockResolvedValue(undefined)
 
     const res = await POST(makeRequest(baseBody))
     expect(res.status).toBe(201)
@@ -149,6 +158,7 @@ describe('POST /api/events', () => {
   it('calendarId가 null이면 캘린더 검증을 건너뛴다', async () => {
     mockFamilyMember()
     mockRpcSuccess()
+    mockSendEventNotification.mockResolvedValue(undefined)
 
     const res = await POST(makeRequest({ ...baseBody, calendarId: null }))
     expect(res.status).toBe(201)

--- a/src/app/api/events/[id]/route.ts
+++ b/src/app/api/events/[id]/route.ts
@@ -1,7 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { after, NextRequest, NextResponse } from 'next/server'
 import { getAuthenticatedUserId, isFamilyMember, assertCalendarWriteAccess } from '@/lib/api-auth'
 import { supabaseAdmin } from '@/lib/supabase-admin'
-import { fireEventNotification } from '@/lib/push-utils'
+import { sendEventNotification } from '@/lib/push-utils'
 
 interface UpdateEventRequest {
   calendarId?: string | null
@@ -85,13 +85,15 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
   }
 
   if (changed) {
-    fireEventNotification({
-      familyId: existing.family_id,
-      calendarId: newCalendarId,
-      actorUserId,
-      action: 'updated',
-      eventTitle: newTitle,
-      eventStartAt: newStartAt,
+    after(async () => {
+      await sendEventNotification({
+        familyId: existing.family_id,
+        calendarId: newCalendarId,
+        actorUserId,
+        action: 'updated',
+        eventTitle: newTitle,
+        eventStartAt: newStartAt,
+      })
     })
   }
 
@@ -129,13 +131,15 @@ export async function DELETE(req: NextRequest, { params }: { params: Promise<{ i
     return NextResponse.json({ error: 'Failed to delete event' }, { status: 500 })
   }
 
-  fireEventNotification({
-    familyId: existing.family_id,
-    calendarId: existing.calendar_id,
-    actorUserId,
-    action: 'deleted',
-    eventTitle: existing.title,
-    eventStartAt: existing.start_at,
+  after(async () => {
+    await sendEventNotification({
+      familyId: existing.family_id,
+      calendarId: existing.calendar_id,
+      actorUserId,
+      action: 'deleted',
+      eventTitle: existing.title,
+      eventStartAt: existing.start_at,
+    })
   })
 
   return new NextResponse(null, { status: 204 })

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -1,7 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { after, NextRequest, NextResponse } from 'next/server'
 import { getAuthenticatedUserId, assertCalendarWriteAccess } from '@/lib/api-auth'
 import { supabaseAdmin } from '@/lib/supabase-admin'
-import { fireEventNotification } from '@/lib/push-utils'
+import { sendEventNotification } from '@/lib/push-utils'
 
 interface CreateEventRequest {
   calendarId: string | null
@@ -62,13 +62,15 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Failed to create event' }, { status: 500 })
   }
 
-  fireEventNotification({
-    familyId: member.family_id,
-    calendarId,
-    actorUserId,
-    action: 'created',
-    eventTitle: title,
-    eventStartAt: startAt,
+  after(async () => {
+    await sendEventNotification({
+      familyId: member.family_id,
+      calendarId,
+      actorUserId,
+      action: 'created',
+      eventTitle: title,
+      eventStartAt: startAt,
+    })
   })
 
   return NextResponse.json(events[0], { status: 201 })

--- a/src/lib/push-utils.ts
+++ b/src/lib/push-utils.ts
@@ -21,8 +21,21 @@ export async function dispatchPushNotifications(
         )
         successIds.push(sub.id)
       } catch (err: unknown) {
-        const status = (err as { statusCode?: number }).statusCode
+        const error = err as {
+          statusCode?: number
+          body?: string
+          message?: string
+        }
+        const status = error.statusCode
         if (status === 404 || status === 410) staleIds.push(sub.id)
+
+        console.error('[push-utils] sendNotification failed:', {
+          subscriptionId: sub.id,
+          endpointHost: getEndpointHost(sub.endpoint),
+          statusCode: status ?? null,
+          message: error.message ?? 'unknown error',
+          body: error.body ?? null,
+        })
       }
     })
   )
@@ -98,6 +111,14 @@ export function fireEventNotification(params: EventNotificationParams): void {
   void sendEventNotification(params).catch((err) =>
     console.error('[push-utils] sendEventNotification failed:', err)
   )
+}
+
+function getEndpointHost(endpoint: string): string {
+  try {
+    return new URL(endpoint).host
+  } catch {
+    return 'invalid-endpoint'
+  }
 }
 
 function buildEventNotificationTitle(action: EventAction): string {


### PR DESCRIPTION
## Summary
- move event create, update, and delete push fan-out into Next.js after() so delivery work stays attached to the route lifecycle after the response is sent
- add endpoint-level web-push failure logging so mobile delivery issues surface in server logs instead of failing silently
- fix service-worker notification asset paths to use the actual shipped icon files and update the event API tests for the new async delivery path

## Testing
- npx jest src/__tests__/api/events/post.test.ts src/__tests__/api/events/patch.test.ts src/__tests__/api/events/delete.test.ts
- npx tsc --noEmit

## Review Notes
- No new privilege-escalation or auth-bypass issue was found in this change; the event routes still gate delivery by authenticated user plus family or calendar write access before enqueueing notifications.
- The remaining operational risk is subscription quality on real devices. If a device still misses notifications after this PR, the next source of truth is the new push-utils sendNotification failed server log with status code and endpoint host.