### PR TITLE
fix: set urgency high and TTL 24h for web push delivery

### DIFF
--- a/src/lib/push-utils.ts
+++ b/src/lib/push-utils.ts
@@ -17,7 +17,8 @@ export async function dispatchPushNotifications(
       try {
         await webpush.sendNotification(
           { endpoint: sub.endpoint, keys: { p256dh: sub.p256dh, auth: sub.auth } },
-          payload
+          payload,
+          { TTL: 86400, urgency: 'high' }
         )
         successIds.push(sub.id)
       } catch (err: unknown) {


### PR DESCRIPTION
## Summary
- `webpush.sendNotification` 호출에 `urgency: 'high'` 및 `TTL: 86400` 옵션 추가
- `urgency: 'high'` 없이는 FCM이 Android에서 배터리 절약 큐에 메시지를 보관하다 지연 전달함
- `TTL: 86400` (24시간)으로 기기가 잠시 오프라인이어도 메시지를 유실하지 않음

## Testing
- `/api/push/test`로 Android 기기 발송 후 즉시 수신 여부 확인
- `npx tsc --noEmit` 통과

## Manual Verification
- [ ] Android 기기에서 일정 생성/수정/삭제 시 즉시 알림 수신 확인