### PR TITLE
chore: add per-step timing logs to event API routes

### DIFF
--- a/src/app/api/events/[id]/route.ts
+++ b/src/app/api/events/[id]/route.ts
@@ -24,7 +24,9 @@ async function canWriteEvent(
 }
 
 export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const t0 = Date.now()
   const actorUserId = await getAuthenticatedUserId(req)
+  console.log(`[perf] PATCH /api/events/[id] auth: ${Date.now() - t0}ms`)
   if (!actorUserId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
@@ -32,19 +34,23 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
   const { id: eventId } = await params
   const body = (await req.json()) as UpdateEventRequest
 
+  const t1 = Date.now()
   const { data: existing, error: fetchError } = await supabaseAdmin
     .from('events')
     .select('id, title, start_at, end_at, description, calendar_id, is_all_day, family_id')
     .eq('id', eventId)
     .maybeSingle()
+  console.log(`[perf] PATCH /api/events/[id] event fetch: ${Date.now() - t1}ms`)
 
   if (fetchError || !existing) {
     return NextResponse.json({ error: 'Event not found' }, { status: 404 })
   }
 
+  const t2 = Date.now()
   if (!(await canWriteEvent(existing, actorUserId))) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
   }
+  console.log(`[perf] PATCH /api/events/[id] access check: ${Date.now() - t2}ms`)
 
   // 대상 캘린더가 바뀌는 경우 target 캘린더 접근 권한도 검증
   if (body.calendarId !== undefined && body.calendarId !== null && body.calendarId !== existing.calendar_id) {
@@ -69,6 +75,7 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
     newIsAllDay !== existing.is_all_day ||
     newCalendarId !== existing.calendar_id
 
+  const t3 = Date.now()
   const { error: rpcError } = await supabaseAdmin.rpc('update_event_with_reminders', {
     p_event_id: eventId,
     p_title: newTitle,
@@ -79,6 +86,7 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
     p_calendar_id: newCalendarId,
     p_reminder_minutes: body.reminderMinutes ?? null,
   })
+  console.log(`[perf] PATCH /api/events/[id] RPC: ${Date.now() - t3}ms | total: ${Date.now() - t0}ms`)
 
   if (rpcError) {
     return NextResponse.json({ error: 'Failed to update event' }, { status: 500 })
@@ -101,31 +109,39 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
 }
 
 export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const t0 = Date.now()
   const actorUserId = await getAuthenticatedUserId(req)
+  console.log(`[perf] DELETE /api/events/[id] auth: ${Date.now() - t0}ms`)
   if (!actorUserId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
   const { id: eventId } = await params
 
+  const t1 = Date.now()
   const { data: existing, error: fetchError } = await supabaseAdmin
     .from('events')
     .select('id, title, start_at, calendar_id, family_id')
     .eq('id', eventId)
     .maybeSingle()
+  console.log(`[perf] DELETE /api/events/[id] event fetch: ${Date.now() - t1}ms`)
 
   if (fetchError || !existing) {
     return NextResponse.json({ error: 'Event not found' }, { status: 404 })
   }
 
+  const t2 = Date.now()
   if (!(await canWriteEvent(existing, actorUserId))) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
   }
+  console.log(`[perf] DELETE /api/events/[id] access check: ${Date.now() - t2}ms`)
 
+  const t3 = Date.now()
   const { error: deleteError } = await supabaseAdmin
     .from('events')
     .delete()
     .eq('id', eventId)
+  console.log(`[perf] DELETE /api/events/[id] delete: ${Date.now() - t3}ms | total: ${Date.now() - t0}ms`)
 
   if (deleteError) {
     return NextResponse.json({ error: 'Failed to delete event' }, { status: 500 })

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -14,7 +14,9 @@ interface CreateEventRequest {
 }
 
 export async function POST(req: NextRequest) {
+  const t0 = Date.now()
   const actorUserId = await getAuthenticatedUserId(req)
+  console.log(`[perf] POST /api/events auth: ${Date.now() - t0}ms`)
   if (!actorUserId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
@@ -26,23 +28,28 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Missing required fields' }, { status: 400 })
   }
 
+  const t1 = Date.now()
   const { data: member } = await supabaseAdmin
     .from('family_members')
     .select('family_id')
     .eq('user_id', actorUserId)
     .maybeSingle()
+  console.log(`[perf] POST /api/events family lookup: ${Date.now() - t1}ms`)
 
   if (!member) {
     return NextResponse.json({ error: 'Family not found' }, { status: 403 })
   }
 
   if (calendarId) {
+    const t2 = Date.now()
     const hasAccess = await assertCalendarWriteAccess(member.family_id, calendarId, actorUserId)
+    console.log(`[perf] POST /api/events calendar access check: ${Date.now() - t2}ms`)
     if (!hasAccess) {
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
     }
   }
 
+  const t3 = Date.now()
   const { data: events, error: rpcError } = await supabaseAdmin.rpc(
     'create_event_with_reminders',
     {
@@ -57,6 +64,7 @@ export async function POST(req: NextRequest) {
       p_reminder_minutes: reminderMinutes,
     }
   )
+  console.log(`[perf] POST /api/events RPC: ${Date.now() - t3}ms | total: ${Date.now() - t0}ms`)
 
   if (rpcError || !events?.length) {
     return NextResponse.json({ error: 'Failed to create event' }, { status: 500 })


### PR DESCRIPTION
## Summary
- 일정 생성(POST), 수정(PATCH), 삭제(DELETE) API route의 각 단계별 실행 시간을 `[perf]` 태그로 로깅
- 측정 항목: auth, family lookup / event fetch, access check, RPC/delete, total

## Testing
- `npx tsc --noEmit` 통과
- Vercel 로그에서 `[perf]` 검색으로 각 단계 ms 확인

## Note
병목 확인 후 제거 예정인 임시 측정 코드입니다.