### PR TITLE
perf: replace sequential auth+DB calls with authorized RPCs for event API

### DIFF
--- a/src/__tests__/api/events/delete.test.ts
+++ b/src/__tests__/api/events/delete.test.ts
@@ -18,13 +18,13 @@ jest.mock('@/lib/push-utils', () => ({
   sendEventNotification: (...args: unknown[]) => mockSendEventNotification(...args),
 }))
 
-const mockGetUser = jest.fn()
-const mockFrom = jest.fn()
+const mockGetClaims = jest.fn()
+const mockRpc = jest.fn()
 
 jest.mock('@/lib/supabase-admin', () => ({
   supabaseAdmin: {
-    auth: { getUser: (token: unknown) => mockGetUser(token) },
-    from: (table: unknown) => mockFrom(table),
+    auth: { getClaims: (token: unknown) => mockGetClaims(token) },
+    rpc: (fn: unknown, args: unknown) => mockRpc(fn, args),
   },
 }))
 
@@ -33,15 +33,12 @@ const EVENT_ID = 'evt-1'
 const FAMILY_ID = 'fam-1'
 const CALENDAR_ID = 'cal-1'
 
-const mockExisting = {
-  id: EVENT_ID,
+const deletedResult = {
+  family_id: FAMILY_ID,
+  calendar_id: CALENDAR_ID,
   title: '생일 파티',
   start_at: '2026-04-15T09:00:00.000Z',
-  calendar_id: CALENDAR_ID,
-  family_id: FAMILY_ID,
 }
-
-const mockExistingFamilyWide = { ...mockExisting, calendar_id: null }
 
 function makeRequest(token = 'valid-token') {
   return new NextRequest(`http://localhost/api/events/${EVENT_ID}`, {
@@ -59,87 +56,34 @@ beforeEach(() => {
   process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://localhost'
   process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key'
 
-  mockGetUser.mockResolvedValue({
-    data: { user: { id: ACTOR_USER_ID, email: 'actor@test.com' } },
+  mockGetClaims.mockResolvedValue({
+    data: { claims: { sub: ACTOR_USER_ID, email: 'actor@test.com' } },
     error: null,
   })
+  mockRpc.mockResolvedValue({ data: deletedResult, error: null })
 })
-
-function mockEventFetch(existing: Record<string, unknown> | null = mockExisting) {
-  mockFrom.mockImplementationOnce(() => ({
-    select: jest.fn().mockReturnThis(),
-    eq: jest.fn().mockReturnThis(),
-    maybeSingle: jest.fn().mockResolvedValue(existing ? { data: existing } : { data: null }),
-  }))
-}
-
-function mockCalendarAccess(calendarFound = true, isMember = true) {
-  mockFrom.mockImplementationOnce(() => ({
-    select: jest.fn().mockReturnThis(),
-    eq: jest.fn().mockReturnThis(),
-    maybeSingle: jest.fn().mockResolvedValue(
-      calendarFound ? { data: { id: CALENDAR_ID } } : { data: null }
-    ),
-  }))
-  mockFrom.mockImplementationOnce(() => ({
-    select: jest.fn().mockReturnThis(),
-    eq: jest.fn().mockReturnThis(),
-    maybeSingle: jest.fn().mockResolvedValue(
-      isMember ? { data: { user_id: ACTOR_USER_ID } } : { data: null }
-    ),
-  }))
-}
-
-function mockFamilyAccess(isMember = true) {
-  mockFrom.mockImplementationOnce(() => ({
-    select: jest.fn().mockReturnThis(),
-    eq: jest.fn().mockReturnThis(),
-    maybeSingle: jest.fn().mockResolvedValue(
-      isMember ? { data: { user_id: ACTOR_USER_ID } } : { data: null }
-    ),
-  }))
-}
-
-function mockEventDelete(error: unknown = null) {
-  mockFrom.mockImplementationOnce(() => ({
-    delete: jest.fn().mockReturnThis(),
-    eq: jest.fn().mockResolvedValue({ error }),
-  }))
-}
 
 describe('DELETE /api/events/[id]', () => {
   it('인증 토큰 없으면 401을 반환한다', async () => {
-    mockGetUser.mockResolvedValue({ data: { user: null }, error: new Error('unauthorized') })
+    mockGetClaims.mockResolvedValue({ data: null, error: new Error('unauthorized') })
     const res = await DELETE(makeRequest(), makeParams())
     expect(res.status).toBe(401)
   })
 
   it('이벤트가 없으면 404를 반환한다', async () => {
-    mockEventFetch(null)
+    mockRpc.mockResolvedValue({ data: null, error: { message: 'not_found' } })
     const res = await DELETE(makeRequest(), makeParams())
     expect(res.status).toBe(404)
   })
 
-  it('캘린더 미소속이면 403을 반환한다 (캘린더 이벤트)', async () => {
-    mockEventFetch()
-    mockCalendarAccess(true, false)
-    const res = await DELETE(makeRequest(), makeParams())
-    expect(res.status).toBe(403)
-  })
-
-  it('가족 미소속이면 403을 반환한다 (가족 전체 이벤트)', async () => {
-    mockEventFetch(mockExistingFamilyWide)
-    mockFamilyAccess(false)
+  it('접근 불가이면 403을 반환한다', async () => {
+    mockRpc.mockResolvedValue({ data: null, error: { message: 'forbidden' } })
     const res = await DELETE(makeRequest(), makeParams())
     expect(res.status).toBe(403)
   })
 
   it('이벤트를 삭제하고 204를 반환하며 알림을 보낸다', async () => {
-    mockEventFetch()
-    mockCalendarAccess()
-    mockEventDelete()
     mockSendEventNotification.mockResolvedValue(undefined)
-
     const res = await DELETE(makeRequest(), makeParams())
     expect(res.status).toBe(204)
     expect(mockSendEventNotification).toHaveBeenCalledWith(
@@ -147,11 +91,8 @@ describe('DELETE /api/events/[id]', () => {
     )
   })
 
-  it('삭제 실패 시 500을 반환하고 알림을 보내지 않는다', async () => {
-    mockEventFetch()
-    mockCalendarAccess()
-    mockEventDelete({ message: 'DB error' })
-
+  it('RPC 실패 시 500을 반환한다', async () => {
+    mockRpc.mockResolvedValue({ data: null, error: { message: 'rpc error' } })
     const res = await DELETE(makeRequest(), makeParams())
     expect(res.status).toBe(500)
     expect(mockSendEventNotification).not.toHaveBeenCalled()

--- a/src/__tests__/api/events/patch.test.ts
+++ b/src/__tests__/api/events/patch.test.ts
@@ -18,14 +18,12 @@ jest.mock('@/lib/push-utils', () => ({
   sendEventNotification: (...args: unknown[]) => mockSendEventNotification(...args),
 }))
 
-const mockGetUser = jest.fn()
-const mockFrom = jest.fn()
+const mockGetClaims = jest.fn()
 const mockRpc = jest.fn()
 
 jest.mock('@/lib/supabase-admin', () => ({
   supabaseAdmin: {
-    auth: { getUser: (token: unknown) => mockGetUser(token) },
-    from: (table: unknown) => mockFrom(table),
+    auth: { getClaims: (token: unknown) => mockGetClaims(token) },
     rpc: (fn: unknown, args: unknown) => mockRpc(fn, args),
   },
 }))
@@ -35,18 +33,13 @@ const EVENT_ID = 'evt-1'
 const FAMILY_ID = 'fam-1'
 const CALENDAR_ID = 'cal-1'
 
-const mockExisting = {
-  id: EVENT_ID,
-  title: '기존 제목',
-  start_at: '2026-04-15T09:00:00.000Z',
-  end_at: null,
-  description: null,
-  calendar_id: CALENDAR_ID,
-  is_all_day: false,
+const baseResult = {
+  is_changed: false,
   family_id: FAMILY_ID,
+  new_calendar_id: CALENDAR_ID,
+  new_title: '기존 제목',
+  new_start_at: '2026-04-15T09:00:00.000Z',
 }
-
-const mockExistingFamilyWide = { ...mockExisting, calendar_id: null }
 
 function makeRequest(body: Record<string, unknown>, token = 'valid-token') {
   return new NextRequest(`http://localhost/api/events/${EVENT_ID}`, {
@@ -65,94 +58,40 @@ beforeEach(() => {
   process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://localhost'
   process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key'
 
-  mockGetUser.mockResolvedValue({
-    data: { user: { id: ACTOR_USER_ID, email: 'actor@test.com' } },
+  mockGetClaims.mockResolvedValue({
+    data: { claims: { sub: ACTOR_USER_ID, email: 'actor@test.com' } },
     error: null,
   })
-  mockRpc.mockResolvedValue({ error: null })
+  mockRpc.mockResolvedValue({ data: baseResult, error: null })
 })
-
-function mockEventFetch(existing: Record<string, unknown> | null = mockExisting) {
-  mockFrom.mockImplementationOnce(() => ({
-    select: jest.fn().mockReturnThis(),
-    eq: jest.fn().mockReturnThis(),
-    maybeSingle: jest.fn().mockResolvedValue(existing ? { data: existing } : { data: null }),
-  }))
-}
-
-function mockCalendarAccess(calendarFound = true, isMember = true) {
-  mockFrom.mockImplementationOnce(() => ({
-    select: jest.fn().mockReturnThis(),
-    eq: jest.fn().mockReturnThis(),
-    maybeSingle: jest.fn().mockResolvedValue(
-      calendarFound ? { data: { id: CALENDAR_ID } } : { data: null }
-    ),
-  }))
-  mockFrom.mockImplementationOnce(() => ({
-    select: jest.fn().mockReturnThis(),
-    eq: jest.fn().mockReturnThis(),
-    maybeSingle: jest.fn().mockResolvedValue(
-      isMember ? { data: { user_id: ACTOR_USER_ID } } : { data: null }
-    ),
-  }))
-}
-
-function mockFamilyAccess(isMember = true) {
-  mockFrom.mockImplementationOnce(() => ({
-    select: jest.fn().mockReturnThis(),
-    eq: jest.fn().mockReturnThis(),
-    maybeSingle: jest.fn().mockResolvedValue(
-      isMember ? { data: { user_id: ACTOR_USER_ID } } : { data: null }
-    ),
-  }))
-}
 
 describe('PATCH /api/events/[id]', () => {
   it('인증 토큰 없으면 401을 반환한다', async () => {
-    mockGetUser.mockResolvedValue({ data: { user: null }, error: new Error('unauthorized') })
+    mockGetClaims.mockResolvedValue({ data: null, error: new Error('unauthorized') })
     const res = await PATCH(makeRequest({ title: '새 제목' }), makeParams())
     expect(res.status).toBe(401)
   })
 
   it('이벤트가 없으면 404를 반환한다', async () => {
-    mockEventFetch(null)
+    mockRpc.mockResolvedValue({ data: null, error: { message: 'not_found' } })
     const res = await PATCH(makeRequest({ title: '새 제목' }), makeParams())
     expect(res.status).toBe(404)
   })
 
-  it('캘린더 미소속이면 403을 반환한다 (캘린더 이벤트)', async () => {
-    mockEventFetch()
-    mockCalendarAccess(true, false)
+  it('접근 불가이면 403을 반환한다', async () => {
+    mockRpc.mockResolvedValue({ data: null, error: { message: 'forbidden' } })
     const res = await PATCH(makeRequest({ title: '새 제목' }), makeParams())
-    expect(res.status).toBe(403)
-  })
-
-  it('가족 미소속이면 403을 반환한다 (가족 전체 이벤트)', async () => {
-    mockEventFetch(mockExistingFamilyWide)
-    mockFamilyAccess(false)
-    const res = await PATCH(makeRequest({ title: '새 제목' }), makeParams())
-    expect(res.status).toBe(403)
-  })
-
-  it('이동 대상 캘린더 미소속이면 403을 반환한다', async () => {
-    mockEventFetch()
-    mockCalendarAccess()             // 기존 캘린더 접근 OK
-    mockCalendarAccess(true, false)  // 대상 캘린더 멤버 아님
-    const res = await PATCH(makeRequest({ calendarId: 'cal-2' }), makeParams())
     expect(res.status).toBe(403)
   })
 
   it('변경사항 없으면 204를 반환하고 알림을 보내지 않는다', async () => {
-    mockEventFetch()
-    mockCalendarAccess()
-    const res = await PATCH(makeRequest({ title: mockExisting.title }), makeParams())
+    const res = await PATCH(makeRequest({ title: '기존 제목' }), makeParams())
     expect(res.status).toBe(204)
     expect(mockSendEventNotification).not.toHaveBeenCalled()
   })
 
   it('변경사항 있으면 204를 반환하고 알림을 보낸다', async () => {
-    mockEventFetch()
-    mockCalendarAccess()
+    mockRpc.mockResolvedValue({ data: { ...baseResult, is_changed: true, new_title: '새 제목' }, error: null })
     mockSendEventNotification.mockResolvedValue(undefined)
     const res = await PATCH(makeRequest({ title: '새 제목' }), makeParams())
     expect(res.status).toBe(204)
@@ -161,30 +100,24 @@ describe('PATCH /api/events/[id]', () => {
     )
   })
 
-  it('update_event_with_reminders RPC를 호출한다', async () => {
-    mockEventFetch()
-    mockCalendarAccess()
+  it('update_event_authorized RPC를 호출한다', async () => {
     await PATCH(makeRequest({ reminderMinutes: [30] }), makeParams())
     expect(mockRpc).toHaveBeenCalledWith(
-      'update_event_with_reminders',
+      'update_event_authorized',
       expect.objectContaining({ p_reminder_minutes: [30] })
     )
   })
 
   it('reminderMinutes 미제공 시 p_reminder_minutes를 null로 전달한다', async () => {
-    mockEventFetch()
-    mockCalendarAccess()
     await PATCH(makeRequest({ title: '새 제목' }), makeParams())
     expect(mockRpc).toHaveBeenCalledWith(
-      'update_event_with_reminders',
+      'update_event_authorized',
       expect.objectContaining({ p_reminder_minutes: null })
     )
   })
 
   it('RPC 실패 시 500을 반환한다', async () => {
-    mockEventFetch()
-    mockCalendarAccess()
-    mockRpc.mockResolvedValue({ error: { message: 'rpc error' } })
+    mockRpc.mockResolvedValue({ data: null, error: { message: 'rpc error' } })
     const res = await PATCH(makeRequest({ title: '새 제목' }), makeParams())
     expect(res.status).toBe(500)
   })

--- a/src/__tests__/api/events/post.test.ts
+++ b/src/__tests__/api/events/post.test.ts
@@ -18,14 +18,12 @@ jest.mock('@/lib/push-utils', () => ({
   sendEventNotification: (...args: unknown[]) => mockSendEventNotification(...args),
 }))
 
-const mockGetUser = jest.fn()
-const mockFrom = jest.fn()
+const mockGetClaims = jest.fn()
 const mockRpc = jest.fn()
 
 jest.mock('@/lib/supabase-admin', () => ({
   supabaseAdmin: {
-    auth: { getUser: (token: unknown) => mockGetUser(token) },
-    from: (table: unknown) => mockFrom(table),
+    auth: { getClaims: (token: unknown) => mockGetClaims(token) },
     rpc: (fn: unknown, args: unknown) => mockRpc(fn, args),
   },
 }))
@@ -58,50 +56,16 @@ beforeEach(() => {
   process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://localhost'
   process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key'
 
-  mockGetUser.mockResolvedValue({
-    data: { user: { id: ACTOR_USER_ID, email: 'actor@test.com' } },
+  mockGetClaims.mockResolvedValue({
+    data: { claims: { sub: ACTOR_USER_ID, email: 'actor@test.com' } },
     error: null,
   })
+  mockRpc.mockResolvedValue({ data: [CREATED_EVENT], error: null })
 })
-
-function mockFamilyMember(found = true) {
-  mockFrom.mockImplementationOnce(() => ({
-    select: jest.fn().mockReturnThis(),
-    eq: jest.fn().mockReturnThis(),
-    maybeSingle: jest.fn().mockResolvedValue(
-      found ? { data: { family_id: FAMILY_ID } } : { data: null }
-    ),
-  }))
-}
-
-function mockCalendarAccess(calendarFound = true, isMember = true) {
-  mockFrom.mockImplementationOnce(() => ({
-    select: jest.fn().mockReturnThis(),
-    eq: jest.fn().mockReturnThis(),
-    maybeSingle: jest.fn().mockResolvedValue(
-      calendarFound ? { data: { id: CALENDAR_ID } } : { data: null }
-    ),
-  }))
-  mockFrom.mockImplementationOnce(() => ({
-    select: jest.fn().mockReturnThis(),
-    eq: jest.fn().mockReturnThis(),
-    maybeSingle: jest.fn().mockResolvedValue(
-      isMember ? { data: { user_id: ACTOR_USER_ID } } : { data: null }
-    ),
-  }))
-}
-
-function mockRpcSuccess(event = CREATED_EVENT) {
-  mockRpc.mockResolvedValue({ data: [event], error: null })
-}
-
-function mockRpcFailure() {
-  mockRpc.mockResolvedValue({ data: null, error: { message: 'rpc error' } })
-}
 
 describe('POST /api/events', () => {
   it('인증 토큰 없으면 401을 반환한다', async () => {
-    mockGetUser.mockResolvedValue({ data: { user: null }, error: new Error('unauthorized') })
+    mockGetClaims.mockResolvedValue({ data: null, error: new Error('unauthorized') })
     const res = await POST(makeRequest(baseBody))
     expect(res.status).toBe(401)
   })
@@ -112,64 +76,45 @@ describe('POST /api/events', () => {
   })
 
   it('가족 미소속이면 403을 반환한다', async () => {
-    mockFamilyMember(false)
+    mockRpc.mockResolvedValue({ data: null, error: { message: 'no_family' } })
     const res = await POST(makeRequest(baseBody))
     expect(res.status).toBe(403)
   })
 
-  it('캘린더가 해당 가족 소속이 아니면 403을 반환한다', async () => {
-    mockFamilyMember()
-    mockCalendarAccess(false)
-    const res = await POST(makeRequest(baseBody))
-    expect(res.status).toBe(403)
-  })
-
-  it('캘린더 멤버가 아니면 403을 반환한다', async () => {
-    mockFamilyMember()
-    mockCalendarAccess(true, false)
+  it('캘린더 접근 불가이면 403을 반환한다', async () => {
+    mockRpc.mockResolvedValue({ data: null, error: { message: 'forbidden' } })
     const res = await POST(makeRequest(baseBody))
     expect(res.status).toBe(403)
   })
 
   it('이벤트를 생성하고 201을 반환한다', async () => {
-    mockFamilyMember()
-    mockCalendarAccess()
-    mockRpcSuccess()
     mockSendEventNotification.mockResolvedValue(undefined)
-
     const res = await POST(makeRequest(baseBody))
     expect(res.status).toBe(201)
     const json = await res.json() as { id: string }
     expect(json.id).toBe('evt-1')
   })
 
-  it('create_event_with_reminders RPC를 호출한다', async () => {
-    mockFamilyMember()
-    mockCalendarAccess()
-    mockRpcSuccess()
-
+  it('create_event_authorized RPC를 호출한다', async () => {
     await POST(makeRequest({ ...baseBody, reminderMinutes: [30, 60] }))
     expect(mockRpc).toHaveBeenCalledWith(
-      'create_event_with_reminders',
+      'create_event_authorized',
       expect.objectContaining({ p_reminder_minutes: [30, 60] })
     )
   })
 
-  it('calendarId가 null이면 캘린더 검증을 건너뛴다', async () => {
-    mockFamilyMember()
-    mockRpcSuccess()
+  it('calendarId가 null이면 p_calendar_id를 null로 전달한다', async () => {
     mockSendEventNotification.mockResolvedValue(undefined)
-
     const res = await POST(makeRequest({ ...baseBody, calendarId: null }))
     expect(res.status).toBe(201)
-    expect(mockFrom).not.toHaveBeenCalledWith('calendars')
+    expect(mockRpc).toHaveBeenCalledWith(
+      'create_event_authorized',
+      expect.objectContaining({ p_calendar_id: null })
+    )
   })
 
   it('RPC 실패 시 500을 반환한다', async () => {
-    mockFamilyMember()
-    mockCalendarAccess()
-    mockRpcFailure()
-
+    mockRpc.mockResolvedValue({ data: null, error: { message: 'rpc error' } })
     const res = await POST(makeRequest(baseBody))
     expect(res.status).toBe(500)
   })

--- a/src/app/api/events/[id]/route.ts
+++ b/src/app/api/events/[id]/route.ts
@@ -1,5 +1,5 @@
 import { after, NextRequest, NextResponse } from 'next/server'
-import { getAuthenticatedUserId, isFamilyMember, assertCalendarWriteAccess } from '@/lib/api-auth'
+import { getAuthenticatedUserId } from '@/lib/api-auth'
 import { supabaseAdmin } from '@/lib/supabase-admin'
 import { sendEventNotification } from '@/lib/push-utils'
 
@@ -13,20 +13,23 @@ interface UpdateEventRequest {
   reminderMinutes?: number[]
 }
 
-async function canWriteEvent(
-  existing: { calendar_id: string | null; family_id: string },
-  actorUserId: string
-): Promise<boolean> {
-  if (existing.calendar_id) {
-    return assertCalendarWriteAccess(existing.family_id, existing.calendar_id, actorUserId)
-  }
-  return isFamilyMember(existing.family_id, actorUserId)
+type UpdateResult = {
+  is_changed: boolean
+  family_id: string
+  new_calendar_id: string | null
+  new_title: string
+  new_start_at: string
+}
+
+type DeleteResult = {
+  family_id: string
+  calendar_id: string | null
+  title: string
+  start_at: string
 }
 
 export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const t0 = Date.now()
   const actorUserId = await getAuthenticatedUserId(req)
-  console.log(`[perf] PATCH /api/events/[id] auth: ${Date.now() - t0}ms`)
   if (!actorUserId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
@@ -34,73 +37,37 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
   const { id: eventId } = await params
   const body = (await req.json()) as UpdateEventRequest
 
-  const t1 = Date.now()
-  const { data: existing, error: fetchError } = await supabaseAdmin
-    .from('events')
-    .select('id, title, start_at, end_at, description, calendar_id, is_all_day, family_id')
-    .eq('id', eventId)
-    .maybeSingle()
-  console.log(`[perf] PATCH /api/events/[id] event fetch: ${Date.now() - t1}ms`)
-
-  if (fetchError || !existing) {
-    return NextResponse.json({ error: 'Event not found' }, { status: 404 })
-  }
-
-  const t2 = Date.now()
-  if (!(await canWriteEvent(existing, actorUserId))) {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-  }
-  console.log(`[perf] PATCH /api/events/[id] access check: ${Date.now() - t2}ms`)
-
-  // 대상 캘린더가 바뀌는 경우 target 캘린더 접근 권한도 검증
-  if (body.calendarId !== undefined && body.calendarId !== null && body.calendarId !== existing.calendar_id) {
-    const hasTargetAccess = await assertCalendarWriteAccess(existing.family_id, body.calendarId, actorUserId)
-    if (!hasTargetAccess) {
-      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-    }
-  }
-
-  const newTitle = body.title ?? existing.title
-  const newDescription = body.description !== undefined ? body.description : existing.description
-  const newStartAt = body.startAt ?? existing.start_at
-  const newEndAt = body.endAt !== undefined ? body.endAt : existing.end_at
-  const newIsAllDay = body.isAllDay ?? existing.is_all_day
-  const newCalendarId = body.calendarId !== undefined ? body.calendarId : existing.calendar_id
-
-  const changed =
-    newTitle !== existing.title ||
-    newDescription !== existing.description ||
-    newStartAt !== existing.start_at ||
-    newEndAt !== existing.end_at ||
-    newIsAllDay !== existing.is_all_day ||
-    newCalendarId !== existing.calendar_id
-
-  const t3 = Date.now()
-  const { error: rpcError } = await supabaseAdmin.rpc('update_event_with_reminders', {
+  const { data: result, error } = await supabaseAdmin.rpc('update_event_authorized', {
+    p_actor_user_id: actorUserId,
     p_event_id: eventId,
-    p_title: newTitle,
-    p_description: newDescription,
-    p_start_at: newStartAt,
-    p_end_at: newEndAt,
-    p_is_all_day: newIsAllDay,
-    p_calendar_id: newCalendarId,
+    p_title: body.title ?? null,
+    p_description: body.description ?? null,
+    p_has_description: 'description' in body,
+    p_start_at: body.startAt ?? null,
+    p_end_at: body.endAt ?? null,
+    p_has_end_at: 'endAt' in body,
+    p_is_all_day: body.isAllDay ?? null,
+    p_calendar_id: body.calendarId ?? null,
+    p_has_calendar_id: 'calendarId' in body,
     p_reminder_minutes: body.reminderMinutes ?? null,
   })
-  console.log(`[perf] PATCH /api/events/[id] RPC: ${Date.now() - t3}ms | total: ${Date.now() - t0}ms`)
 
-  if (rpcError) {
+  if (error) {
+    if (error.message === 'not_found') return NextResponse.json({ error: 'Event not found' }, { status: 404 })
+    if (error.message === 'forbidden') return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
     return NextResponse.json({ error: 'Failed to update event' }, { status: 500 })
   }
 
-  if (changed) {
+  const { is_changed, family_id, new_calendar_id, new_title, new_start_at } = result as UpdateResult
+  if (is_changed) {
     after(async () => {
       await sendEventNotification({
-        familyId: existing.family_id,
-        calendarId: newCalendarId,
+        familyId: family_id,
+        calendarId: new_calendar_id,
         actorUserId,
         action: 'updated',
-        eventTitle: newTitle,
-        eventStartAt: newStartAt,
+        eventTitle: new_title,
+        eventStartAt: new_start_at,
       })
     })
   }
@@ -109,52 +76,33 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
 }
 
 export async function DELETE(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const t0 = Date.now()
   const actorUserId = await getAuthenticatedUserId(req)
-  console.log(`[perf] DELETE /api/events/[id] auth: ${Date.now() - t0}ms`)
   if (!actorUserId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
   const { id: eventId } = await params
 
-  const t1 = Date.now()
-  const { data: existing, error: fetchError } = await supabaseAdmin
-    .from('events')
-    .select('id, title, start_at, calendar_id, family_id')
-    .eq('id', eventId)
-    .maybeSingle()
-  console.log(`[perf] DELETE /api/events/[id] event fetch: ${Date.now() - t1}ms`)
+  const { data: deleted, error } = await supabaseAdmin.rpc('delete_event_authorized', {
+    p_actor_user_id: actorUserId,
+    p_event_id: eventId,
+  })
 
-  if (fetchError || !existing) {
-    return NextResponse.json({ error: 'Event not found' }, { status: 404 })
-  }
-
-  const t2 = Date.now()
-  if (!(await canWriteEvent(existing, actorUserId))) {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-  }
-  console.log(`[perf] DELETE /api/events/[id] access check: ${Date.now() - t2}ms`)
-
-  const t3 = Date.now()
-  const { error: deleteError } = await supabaseAdmin
-    .from('events')
-    .delete()
-    .eq('id', eventId)
-  console.log(`[perf] DELETE /api/events/[id] delete: ${Date.now() - t3}ms | total: ${Date.now() - t0}ms`)
-
-  if (deleteError) {
+  if (error) {
+    if (error.message === 'not_found') return NextResponse.json({ error: 'Event not found' }, { status: 404 })
+    if (error.message === 'forbidden') return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
     return NextResponse.json({ error: 'Failed to delete event' }, { status: 500 })
   }
 
+  const { family_id, calendar_id, title, start_at } = deleted as DeleteResult
   after(async () => {
     await sendEventNotification({
-      familyId: existing.family_id,
-      calendarId: existing.calendar_id,
+      familyId: family_id,
+      calendarId: calendar_id,
       actorUserId,
       action: 'deleted',
-      eventTitle: existing.title,
-      eventStartAt: existing.start_at,
+      eventTitle: title,
+      eventStartAt: start_at,
     })
   })
 

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -1,5 +1,5 @@
 import { after, NextRequest, NextResponse } from 'next/server'
-import { getAuthenticatedUserId, assertCalendarWriteAccess } from '@/lib/api-auth'
+import { getAuthenticatedUserId } from '@/lib/api-auth'
 import { supabaseAdmin } from '@/lib/supabase-admin'
 import { sendEventNotification } from '@/lib/push-utils'
 
@@ -14,9 +14,7 @@ interface CreateEventRequest {
 }
 
 export async function POST(req: NextRequest) {
-  const t0 = Date.now()
   const actorUserId = await getAuthenticatedUserId(req)
-  console.log(`[perf] POST /api/events auth: ${Date.now() - t0}ms`)
   if (!actorUserId) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
@@ -28,51 +26,30 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Missing required fields' }, { status: 400 })
   }
 
-  const t1 = Date.now()
-  const { data: member } = await supabaseAdmin
-    .from('family_members')
-    .select('family_id')
-    .eq('user_id', actorUserId)
-    .maybeSingle()
-  console.log(`[perf] POST /api/events family lookup: ${Date.now() - t1}ms`)
+  const { data: events, error } = await supabaseAdmin.rpc('create_event_authorized', {
+    p_actor_user_id: actorUserId,
+    p_calendar_id: calendarId,
+    p_title: title,
+    p_description: description,
+    p_start_at: startAt,
+    p_end_at: endAt,
+    p_is_all_day: isAllDay,
+    p_reminder_minutes: reminderMinutes,
+  })
 
-  if (!member) {
-    return NextResponse.json({ error: 'Family not found' }, { status: 403 })
+  if (error) {
+    if (error.message === 'no_family') return NextResponse.json({ error: 'Family not found' }, { status: 403 })
+    if (error.message === 'forbidden') return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    return NextResponse.json({ error: 'Failed to create event' }, { status: 500 })
   }
 
-  if (calendarId) {
-    const t2 = Date.now()
-    const hasAccess = await assertCalendarWriteAccess(member.family_id, calendarId, actorUserId)
-    console.log(`[perf] POST /api/events calendar access check: ${Date.now() - t2}ms`)
-    if (!hasAccess) {
-      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
-    }
-  }
-
-  const t3 = Date.now()
-  const { data: events, error: rpcError } = await supabaseAdmin.rpc(
-    'create_event_with_reminders',
-    {
-      p_family_id: member.family_id,
-      p_created_by: actorUserId,
-      p_calendar_id: calendarId,
-      p_title: title,
-      p_description: description,
-      p_start_at: startAt,
-      p_end_at: endAt,
-      p_is_all_day: isAllDay,
-      p_reminder_minutes: reminderMinutes,
-    }
-  )
-  console.log(`[perf] POST /api/events RPC: ${Date.now() - t3}ms | total: ${Date.now() - t0}ms`)
-
-  if (rpcError || !events?.length) {
+  if (!events?.length) {
     return NextResponse.json({ error: 'Failed to create event' }, { status: 500 })
   }
 
   after(async () => {
     await sendEventNotification({
-      familyId: member.family_id,
+      familyId: events[0].family_id,
       calendarId,
       actorUserId,
       action: 'created',

--- a/src/lib/api-auth.ts
+++ b/src/lib/api-auth.ts
@@ -46,6 +46,9 @@ export async function getAuthenticatedUser(
   const accessToken = authorization.slice('Bearer '.length).trim()
   if (!accessToken) return null
 
+  // getClaims()는 로컬 JWT 검증으로 Auth 서버 왕복을 생략한다.
+  // 삭제/비활성화 사용자 반영이 토큰 만료 시점까지 지연될 수 있으나,
+  // 이 앱의 위협 모델과 짧은 JWT 만료 주기를 고려해 허용된 트레이드오프다.
   const { data, error } = await supabaseAdmin.auth.getClaims(accessToken)
 
   if (error || !data?.claims) return null

--- a/src/lib/api-auth.ts
+++ b/src/lib/api-auth.ts
@@ -46,11 +46,10 @@ export async function getAuthenticatedUser(
   const accessToken = authorization.slice('Bearer '.length).trim()
   if (!accessToken) return null
 
-  const {
-    data: { user },
-    error,
-  } = await supabaseAdmin.auth.getUser(accessToken)
+  const { data, error } = await supabaseAdmin.auth.getClaims(accessToken)
 
-  if (error || !user?.email) return null
-  return { id: user.id, email: user.email }
+  if (error || !data?.claims) return null
+  const { sub: id, email } = data.claims as { sub?: string; email?: string }
+  if (!id || !email) return null
+  return { id, email }
 }

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -579,6 +579,55 @@ export type Database = {
         }
         Returns: undefined
       }
+      create_event_authorized: {
+        Args: {
+          p_actor_user_id: string
+          p_calendar_id: string | null
+          p_title: string
+          p_description: string | null
+          p_start_at: string
+          p_end_at: string | null
+          p_is_all_day: boolean
+          p_reminder_minutes: number[]
+        }
+        Returns: {
+          id: string
+          family_id: string
+          created_by: string
+          calendar_id: string | null
+          title: string
+          description: string | null
+          start_at: string
+          end_at: string | null
+          is_all_day: boolean
+          created_at: string
+          updated_at: string
+        }[]
+      }
+      update_event_authorized: {
+        Args: {
+          p_actor_user_id: string
+          p_event_id: string
+          p_title: string | null
+          p_description: string | null
+          p_has_description: boolean
+          p_start_at: string | null
+          p_end_at: string | null
+          p_has_end_at: boolean
+          p_is_all_day: boolean | null
+          p_calendar_id: string | null
+          p_has_calendar_id: boolean
+          p_reminder_minutes: number[] | null
+        }
+        Returns: Json
+      }
+      delete_event_authorized: {
+        Args: {
+          p_actor_user_id: string
+          p_event_id: string
+        }
+        Returns: Json
+      }
     }
     Enums: {
       [_ in never]: never

--- a/supabase/migrations/20260413000000_event_authorized_rpcs.sql
+++ b/supabase/migrations/20260413000000_event_authorized_rpcs.sql
@@ -1,0 +1,248 @@
+-- ============================================================
+-- Authorized event mutation RPCs
+-- Combines permission check + mutation into a single DB round trip,
+-- replacing the separate family/calendar queries in the API routes.
+-- ============================================================
+
+-- ============================================================
+-- create_event_authorized
+-- Resolves actor's family, checks calendar access if needed,
+-- then creates event + reminders atomically.
+-- Raises: 'no_family' | 'forbidden'
+-- ============================================================
+create or replace function create_event_authorized(
+  p_actor_user_id    uuid,
+  p_calendar_id      uuid,
+  p_title            text,
+  p_description      text,
+  p_start_at         timestamptz,
+  p_end_at           timestamptz,
+  p_is_all_day       boolean,
+  p_reminder_minutes integer[]
+)
+returns setof events
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_family_id uuid;
+  v_event     events;
+begin
+  select family_id into v_family_id
+  from family_members
+  where user_id = p_actor_user_id;
+
+  if not found then
+    raise exception 'no_family';
+  end if;
+
+  if p_calendar_id is not null then
+    if not (
+      exists(select 1 from calendars where id = p_calendar_id and family_id = v_family_id)
+      and
+      exists(select 1 from calendar_members where calendar_id = p_calendar_id and user_id = p_actor_user_id)
+    ) then
+      raise exception 'forbidden';
+    end if;
+  end if;
+
+  insert into events (
+    family_id, created_by, calendar_id,
+    title, description,
+    start_at, end_at, is_all_day
+  )
+  values (
+    v_family_id, p_actor_user_id, p_calendar_id,
+    p_title, p_description,
+    p_start_at, p_end_at, p_is_all_day
+  )
+  returning * into v_event;
+
+  if cardinality(p_reminder_minutes) > 0 then
+    insert into event_reminders (event_id, remind_minutes_before)
+    select v_event.id, unnest(p_reminder_minutes);
+  end if;
+
+  return next v_event;
+end;
+$$;
+
+revoke execute on function create_event_authorized(
+  uuid, uuid, text, text, timestamptz, timestamptz, boolean, integer[]
+) from public, anon, authenticated;
+
+
+-- ============================================================
+-- update_event_authorized
+-- Fetches existing event, checks write access, resolves partial
+-- updates, and returns change metadata for push notifications.
+--
+-- Nullable-field convention:
+--   p_title / p_start_at / p_is_all_day : NULL = keep existing (COALESCE)
+--   p_description / p_end_at / p_calendar_id : paired with
+--     p_has_* sentinel to distinguish "not provided" from "set to null"
+--
+-- Raises: 'not_found' | 'forbidden'
+-- Returns json: { is_changed, family_id, new_calendar_id, new_title, new_start_at }
+-- ============================================================
+create or replace function update_event_authorized(
+  p_actor_user_id   uuid,
+  p_event_id        uuid,
+  p_title           text,
+  p_description     text,
+  p_has_description boolean,
+  p_start_at        timestamptz,
+  p_end_at          timestamptz,
+  p_has_end_at      boolean,
+  p_is_all_day      boolean,
+  p_calendar_id     uuid,
+  p_has_calendar_id boolean,
+  p_reminder_minutes integer[]
+)
+returns json
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_event            events%rowtype;
+  v_has_access       boolean;
+  v_resolved_cal_id  uuid;
+  v_is_changed       boolean;
+begin
+  select * into v_event from events where id = p_event_id;
+  if not found then
+    raise exception 'not_found';
+  end if;
+
+  -- Write access on current event
+  if v_event.calendar_id is not null then
+    select (
+      exists(select 1 from calendars      where id          = v_event.calendar_id and family_id  = v_event.family_id)
+      and
+      exists(select 1 from calendar_members where calendar_id = v_event.calendar_id and user_id = p_actor_user_id)
+    ) into v_has_access;
+  else
+    select exists(
+      select 1 from family_members where family_id = v_event.family_id and user_id = p_actor_user_id
+    ) into v_has_access;
+  end if;
+
+  if not v_has_access then
+    raise exception 'forbidden';
+  end if;
+
+  v_resolved_cal_id := case when p_has_calendar_id then p_calendar_id else v_event.calendar_id end;
+
+  -- Access check when moving to a different calendar
+  if p_has_calendar_id
+     and p_calendar_id is not null
+     and p_calendar_id is distinct from v_event.calendar_id
+  then
+    select (
+      exists(select 1 from calendars        where id          = p_calendar_id and family_id  = v_event.family_id)
+      and
+      exists(select 1 from calendar_members where calendar_id = p_calendar_id and user_id = p_actor_user_id)
+    ) into v_has_access;
+
+    if not v_has_access then
+      raise exception 'forbidden';
+    end if;
+  end if;
+
+  v_is_changed := (
+    (p_title     is not null and p_title     is distinct from v_event.title)     or
+    (p_has_description       and case when p_has_description then p_description else v_event.description end is distinct from v_event.description) or
+    (p_start_at  is not null and p_start_at  is distinct from v_event.start_at)  or
+    (p_has_end_at            and case when p_has_end_at      then p_end_at      else v_event.end_at       end is distinct from v_event.end_at)       or
+    (p_is_all_day is not null and p_is_all_day is distinct from v_event.is_all_day) or
+    (p_has_calendar_id       and v_resolved_cal_id is distinct from v_event.calendar_id)
+  );
+
+  update events set
+    title       = coalesce(p_title,     title),
+    description = case when p_has_description then p_description else description end,
+    start_at    = coalesce(p_start_at,  start_at),
+    end_at      = case when p_has_end_at      then p_end_at      else end_at      end,
+    is_all_day  = coalesce(p_is_all_day, is_all_day),
+    calendar_id = v_resolved_cal_id
+  where id = p_event_id;
+
+  if p_reminder_minutes is not null then
+    delete from event_reminders where event_id = p_event_id;
+    if cardinality(p_reminder_minutes) > 0 then
+      insert into event_reminders (event_id, remind_minutes_before)
+      select p_event_id, unnest(p_reminder_minutes);
+    end if;
+  end if;
+
+  return json_build_object(
+    'is_changed',      v_is_changed,
+    'family_id',       v_event.family_id,
+    'new_calendar_id', v_resolved_cal_id,
+    'new_title',       coalesce(p_title,    v_event.title),
+    'new_start_at',    coalesce(p_start_at, v_event.start_at)
+  );
+end;
+$$;
+
+revoke execute on function update_event_authorized(
+  uuid, uuid, text, text, boolean, timestamptz, timestamptz, boolean, boolean, uuid, boolean, integer[]
+) from public, anon, authenticated;
+
+
+-- ============================================================
+-- delete_event_authorized
+-- Checks write access then deletes, returning metadata needed
+-- for push notifications.
+-- Raises: 'not_found' | 'forbidden'
+-- Returns json: { family_id, calendar_id, title, start_at }
+-- ============================================================
+create or replace function delete_event_authorized(
+  p_actor_user_id uuid,
+  p_event_id      uuid
+)
+returns json
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_event      events%rowtype;
+  v_has_access boolean;
+begin
+  select * into v_event from events where id = p_event_id;
+  if not found then
+    raise exception 'not_found';
+  end if;
+
+  if v_event.calendar_id is not null then
+    select (
+      exists(select 1 from calendars        where id          = v_event.calendar_id and family_id  = v_event.family_id)
+      and
+      exists(select 1 from calendar_members where calendar_id = v_event.calendar_id and user_id = p_actor_user_id)
+    ) into v_has_access;
+  else
+    select exists(
+      select 1 from family_members where family_id = v_event.family_id and user_id = p_actor_user_id
+    ) into v_has_access;
+  end if;
+
+  if not v_has_access then
+    raise exception 'forbidden';
+  end if;
+
+  delete from events where id = p_event_id;
+
+  return json_build_object(
+    'family_id',  v_event.family_id,
+    'calendar_id', v_event.calendar_id,
+    'title',      v_event.title,
+    'start_at',   v_event.start_at
+  );
+end;
+$$;
+
+revoke execute on function delete_event_authorized(uuid, uuid)
+from public, anon, authenticated;


### PR DESCRIPTION
## 변경 내용

- **Phase 1 — 로컬 JWT 검증**: `getAuthenticatedUser`에서 `auth.getUser()` 대신 `auth.getClaims()`를 사용하도록 변경, Supabase Auth 서버 HTTP 왕복 제거 (요청당 ~300–400 ms 절감)
- **Phase 2 — 권한 통합 RPC**: `create_event_authorized`, `update_event_authorized`, `delete_event_authorized` 세 개의 `SECURITY DEFINER` Postgres 함수를 추가, 권한 검사와 뮤테이션을 단일 DB 호출로 통합 (기존 3–4개의 순차적 Supabase HTTP 호출 대체)
- 측정된 개선 전: POST 1814 ms, PATCH 1666 ms, DELETE 1575 ms → 개선 후 예상: ~400–500 ms (JWT 검증 + RPC 1회, 총 2회 호출)
- 측정용으로 추가했던 `[perf]` 타이밍 로그 제거

## 인증 정책 변경에 대한 결정 사항

이벤트 mutation API는 응답속도 개선을 위해 `getUser()` 대신 `getClaims()` 기반 인증을 사용합니다. Auth 서버 재조회를 생략하므로 삭제/비활성화 사용자 반영은 JWT 만료 시점까지 지연될 수 있으나, 가족 앱의 위협 모델과 짧은 토큰 만료 주기를 고려해 허용된 트레이드오프입니다.

## 테스트 계획

- [ ] 기존 이벤트 API 테스트 33개 전체 통과 (`npm test -- --testPathPatterns=events`)
- [ ] TypeScript 컴파일 오류 없음 (`npx tsc --noEmit`)
- [ ] Supabase 마이그레이션 적용: `supabase/migrations/20260413000000_event_authorized_rpcs.sql`
- [ ] 스모크 테스트: 일정 생성·수정·삭제 후 푸시 알림 정상 수신 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)