### PR TITLE
fix: blend system bar with active color scheme

### DIFF
--- a/src/__tests__/app/LayoutMetadata.test.tsx
+++ b/src/__tests__/app/LayoutMetadata.test.tsx
@@ -1,0 +1,28 @@
+jest.mock('next/headers', () => ({
+  cookies: jest.fn(),
+}))
+
+jest.mock('next-themes', () => ({
+  ThemeProvider: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+jest.mock('@/lib/preferences', () => ({
+  THEME_STORAGE_KEY: 'koko_theme',
+}))
+
+import { metadata, viewport } from '@/app/layout'
+
+describe('RootLayout metadata', () => {
+  it('상단 시스템 바 색을 라이트/다크 배경색으로 분리한다', () => {
+    expect(viewport.themeColor).toEqual([
+      { media: '(prefers-color-scheme: light)', color: '#fafaf9' },
+      { media: '(prefers-color-scheme: dark)', color: '#0f0e0d' },
+    ])
+  })
+
+  it('고정 주황색 theme-color 메타를 남기지 않는다', () => {
+    expect(metadata.other).toEqual({
+      'mobile-web-app-capable': 'yes',
+    })
+  })
+})

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from 'next'
+import type { Metadata, Viewport } from 'next'
 import { ThemeProvider } from 'next-themes'
 import { cookies } from 'next/headers'
 import { THEME_STORAGE_KEY } from '@/lib/preferences'
@@ -15,8 +15,14 @@ export const metadata: Metadata = {
   },
   other: {
     'mobile-web-app-capable': 'yes',
-    'theme-color': '#fb923c',
   },
+}
+
+export const viewport: Viewport = {
+  themeColor: [
+    { media: '(prefers-color-scheme: light)', color: '#fafaf9' },
+    { media: '(prefers-color-scheme: dark)', color: '#0f0e0d' },
+  ],
 }
 
 // Prevents FOUC: localStorage takes priority; cookie is the SSR-safe fallback


### PR DESCRIPTION
## Summary
- 고정 주황색 `theme-color` 메타를 제거하고 라이트/다크 배경색에 맞는 시스템 바 색을 설정했습니다.
- 액센트 테마와 무관하게 상단 시스템 바가 현재 색상 모드의 배경과 자연스럽게 이어지도록 조정했습니다.
- 고정 주황색 메타가 다시 추가되지 않도록 레이아웃 메타데이터 테스트를 추가했습니다.

## Testing
- `npm test -- --runInBand src/__tests__/app/LayoutMetadata.test.tsx`
- `npx tsc --noEmit`

## Manual Verification
- [x] 실제 기기 라이트 모드에서 상단 시스템 바가 밝은 배경과 자연스럽게 이어지는지 확인
- [x] 실제 기기 다크 모드에서 상단 시스템 바가 어두운 배경과 자연스럽게 이어지는지 확인