### PR TITLE
fix: show events on adjacent-month overflow days in calendar grid

### DIFF
--- a/src/__tests__/components/CalendarTab.adjacent-events.test.tsx
+++ b/src/__tests__/components/CalendarTab.adjacent-events.test.tsx
@@ -1,0 +1,180 @@
+import { render, act, waitFor, fireEvent } from '@testing-library/react'
+import type { User } from '@supabase/supabase-js'
+import { CalendarTab } from '@/components/tabs/CalendarTab'
+import { getEventsByMonth } from '@/lib/calendar'
+
+// CalendarGrid 는 events 를 data 속성으로 노출해 테스트에서 검증한다
+jest.mock('@/components/calendar/CalendarGrid', () => ({
+  CalendarGrid: ({ events, onSelectDate }: {
+    events: { id: string }[]
+    onSelectDate: (d: Date) => void
+  }) => (
+    <div data-testid="calendar-grid" data-event-ids={events.map((e) => e.id).join(',')}>
+      <button data-testid="select-date" onClick={() => onSelectDate(new Date())}>date</button>
+    </div>
+  ),
+}))
+
+jest.mock('@/components/calendar/DayEventsSheet', () => ({
+  DayEventsSheet: ({ events }: { events: { id: string }[] }) => (
+    <div data-testid="day-events-sheet" data-event-ids={events.map((e) => e.id).join(',')} />
+  ),
+}))
+
+jest.mock('@/hooks/useHolidays', () => ({ useHolidays: () => [] }))
+jest.mock('@/lib/supabase', () => ({
+  supabase: {
+    channel: jest.fn(() => ({
+      on: jest.fn().mockReturnThis(),
+      subscribe: jest.fn().mockReturnThis(),
+      send: jest.fn(),
+    })),
+    removeChannel: jest.fn(),
+  },
+}))
+jest.mock('next/navigation', () => ({ useRouter: () => ({ replace: jest.fn() }) }))
+jest.mock('@/components/calendar/CalendarFilter', () => ({ CalendarFilter: () => <div /> }))
+jest.mock('@/components/calendar/EventDetailSheet', () => ({ EventDetailSheet: () => <div /> }))
+jest.mock('@/components/calendar/EventFormModal', () => ({ EventFormModal: () => <div /> }))
+jest.mock('@/components/calendar/CalendarFormModal', () => ({ CalendarFormModal: () => <div /> }))
+jest.mock('@/components/calendar/CalendarListSheet', () => ({ CalendarListSheet: () => <div /> }))
+jest.mock('@/components/calendar/RecurrenceScopeSheet', () => ({ RecurrenceScopeSheet: () => <div /> }))
+jest.mock('@/components/calendar/YearMonthPickerSheet', () => ({ YearMonthPickerSheet: () => <div /> }))
+jest.mock('@/lib/api-client', () => ({
+  postJsonWithAuth: jest.fn(),
+  patchJsonWithAuth: jest.fn(),
+  deleteWithAuth: jest.fn().mockResolvedValue(undefined),
+}))
+jest.mock('@/lib/calendar', () => ({
+  getEventsByMonth: jest.fn().mockResolvedValue([]),
+  createCalendar: jest.fn(),
+  updateCalendar: jest.fn(),
+  deleteCalendar: jest.fn(),
+  getCalendarMembers: jest.fn().mockResolvedValue([]),
+  getCalendarMembersForCalendars: jest.fn().mockResolvedValue([]),
+  setCalendarMembers: jest.fn(),
+  getFamilyMembers: jest.fn().mockResolvedValue([]),
+  createEvent: jest.fn(),
+  updateEvent: jest.fn(),
+  deleteEvent: jest.fn(),
+  getReminders: jest.fn().mockResolvedValue([]),
+  setReminders: jest.fn(),
+  CALENDAR_COLORS: [],
+  REMINDER_OPTIONS: [],
+}))
+
+const mockGetEventsByMonth = getEventsByMonth as jest.MockedFunction<typeof getEventsByMonth>
+
+function makeEvent(id: string, startAt: string) {
+  return {
+    id,
+    family_id: 'fam-1',
+    calendar_id: null,
+    title: `이벤트 ${id}`,
+    description: null,
+    start_at: startAt,
+    end_at: null,
+    is_all_day: false,
+    created_by: 'user-1',
+    created_at: '',
+    updated_at: '',
+    series_id: null,
+    series_occurrence_date: null,
+    is_cancelled: false,
+    label_color: null,
+  }
+}
+
+const defaultProps = {
+  preferences: null,
+  updatePreferences: jest.fn().mockResolvedValue(undefined),
+  user: { id: 'user-1' } as User,
+  familyId: 'fam-1',
+  isInitializing: false,
+  calendars: [],
+  calendarsError: null,
+  reloadCalendars: jest.fn().mockResolvedValue(undefined),
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  jest.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+// today = 2026-04-18, so current month = April (month index 3)
+// prev = March (2), next = May (4)
+describe('CalendarTab — 인접 월 이벤트 표시', () => {
+  it('현재 월 이벤트와 전월/다음월 이벤트가 모두 CalendarGrid 에 전달된다', async () => {
+    const currentEvent = makeEvent('curr-1', '2026-04-15T09:00:00Z') // April
+    const prevEvent    = makeEvent('prev-1', '2026-03-29T09:00:00Z') // March
+    const nextEvent    = makeEvent('next-1', '2026-05-01T09:00:00Z') // May
+
+    mockGetEventsByMonth.mockImplementation((_fid, _year, month) => {
+      if (month === 3) return Promise.resolve([currentEvent]) // April
+      if (month === 2) return Promise.resolve([prevEvent])    // March
+      if (month === 4) return Promise.resolve([nextEvent])    // May
+      return Promise.resolve([])
+    })
+
+    const { getByTestId } = render(<CalendarTab {...defaultProps} />)
+
+    await waitFor(() => {
+      const ids = getByTestId('calendar-grid').getAttribute('data-event-ids') ?? ''
+      expect(ids).toContain('curr-1')
+      expect(ids).toContain('prev-1')
+      expect(ids).toContain('next-1')
+    }, { timeout: 3000 })
+  })
+
+  it('같은 id 이벤트는 mergedEvents 에서 중복 없이 한 번만 포함된다', async () => {
+    const event = makeEvent('dup-1', '2026-04-15T09:00:00Z')
+    mockGetEventsByMonth.mockResolvedValue([event])
+
+    const { getByTestId } = render(<CalendarTab {...defaultProps} />)
+
+    await waitFor(() => {
+      const ids = (getByTestId('calendar-grid').getAttribute('data-event-ids') ?? '')
+        .split(',').filter(Boolean)
+      expect(ids.filter((id) => id === 'dup-1')).toHaveLength(1)
+    }, { timeout: 3000 })
+  })
+
+  it('다음 달로 이동 후 이전 달의 stale adjacentMonthEvents 가 현재 뷰를 덮어쓰지 않는다', async () => {
+    // April 뷰에서 March fetch 가 지연되는 상황
+    const aprilEvent = makeEvent('apr-1', '2026-04-15T09:00:00Z')
+    const marchEvent = makeEvent('mar-1', '2026-03-29T09:00:00Z') // April 기준 전월
+    const mayEvent   = makeEvent('may-1', '2026-05-10T09:00:00Z')
+    const juneEvent  = makeEvent('jun-1', '2026-06-01T09:00:00Z') // May 기준 다음월
+
+    let resolveMarch!: (v: ReturnType<typeof makeEvent>[]) => void
+    const marchPromise = new Promise<ReturnType<typeof makeEvent>[]>((res) => { resolveMarch = res })
+
+    mockGetEventsByMonth.mockImplementation((_fid, _year, month) => {
+      if (month === 3) return Promise.resolve([aprilEvent])
+      if (month === 2) return marchPromise              // March 지연 (April 의 인접 월)
+      if (month === 4) return Promise.resolve([mayEvent])
+      if (month === 5) return Promise.resolve([juneEvent])
+      return Promise.resolve([])
+    })
+
+    const { getByTestId, getByRole } = render(<CalendarTab {...defaultProps} />)
+    await act(async () => {})
+
+    // 다음 달(May)로 이동
+    fireEvent.click(getByRole('button', { name: '다음 달' }))
+    await act(async () => {})
+
+    // April 기준 March fetch 완료 (이미 May 뷰 상태)
+    await act(async () => { resolveMarch([marchEvent]) })
+    await act(async () => {})
+
+    // race guard 가 동작해 March 이벤트가 May 뷰에 표시되면 안 됨
+    const ids = getByTestId('calendar-grid').getAttribute('data-event-ids') ?? ''
+    expect(ids).not.toContain('mar-1')
+    expect(ids).toContain('may-1')
+  })
+})

--- a/src/__tests__/components/CalendarTab.adjacent-events.test.tsx
+++ b/src/__tests__/components/CalendarTab.adjacent-events.test.tsx
@@ -32,6 +32,14 @@ jest.mock('@/lib/supabase', () => ({
     removeChannel: jest.fn(),
   },
 }))
+
+let capturedRefresh: (() => Promise<void>) | null = null
+jest.mock('@/hooks/useRealtimeSync', () => ({
+  useRealtimeSync: (_channel: unknown, refresh: () => Promise<void>) => {
+    capturedRefresh = refresh
+    return jest.fn()
+  },
+}))
 jest.mock('next/navigation', () => ({ useRouter: () => ({ replace: jest.fn() }) }))
 jest.mock('@/components/calendar/CalendarFilter', () => ({ CalendarFilter: () => <div /> }))
 jest.mock('@/components/calendar/EventDetailSheet', () => ({ EventDetailSheet: () => <div /> }))
@@ -98,6 +106,7 @@ const defaultProps = {
 
 beforeEach(() => {
   jest.clearAllMocks()
+  capturedRefresh = null
   jest.spyOn(console, 'error').mockImplementation(() => {})
 })
 
@@ -176,5 +185,48 @@ describe('CalendarTab — 인접 월 이벤트 표시', () => {
     const ids = getByTestId('calendar-grid').getAttribute('data-event-ids') ?? ''
     expect(ids).not.toContain('mar-1')
     expect(ids).toContain('may-1')
+  })
+})
+
+describe('CalendarTab — refreshEvents 인접 월 invalidation', () => {
+  it('broadcast refresh 시 in-flight 상태의 인접 월 요청을 무효화하고 새로 fetch한다', async () => {
+    // today = April (month=3). prev = March (2), next = May (4)
+    const aprilEvent = makeEvent('apr-1', '2026-04-15T09:00:00Z')
+    const marchFresh = makeEvent('mar-fresh', '2026-03-28T09:00:00Z')
+
+    let marchCallCount = 0
+    mockGetEventsByMonth.mockImplementation((_fid, _year, month) => {
+      if (month === 3) return Promise.resolve([aprilEvent])
+      if (month === 2) {
+        marchCallCount++
+        if (marchCallCount === 1) {
+          // 1st call: never resolves — stays in-flight during refresh
+          return new Promise(() => {})
+        }
+        // 2nd call (after invalidation): resolves with fresh data
+        return Promise.resolve([marchFresh])
+      }
+      return Promise.resolve([])
+    })
+
+    const { getByTestId } = render(<CalendarTab {...defaultProps} />)
+    await act(async () => {})
+
+    // 초기 prefetch: March 1st call이 in-flight 상태 (resolve 안 됨)
+    expect(marchCallCount).toBe(1)
+
+    // broadcast refresh 트리거 — March in-flight 이 resolve되기 전에 실행
+    expect(capturedRefresh).not.toBeNull()
+    await act(async () => { await capturedRefresh!() })
+
+    // refreshEvents가 monthEventsRequestsRef 에서 March를 제거했으므로
+    // prefetchAdjacentMonths가 새 fetch를 시작해야 함
+    expect(marchCallCount).toBe(2)
+
+    // 새 fetch의 fresh 데이터가 표시돼야 함
+    await waitFor(() => {
+      const ids = getByTestId('calendar-grid').getAttribute('data-event-ids') ?? ''
+      expect(ids).toContain('mar-fresh')
+    }, { timeout: 3000 })
   })
 })

--- a/src/components/tabs/CalendarTab.tsx
+++ b/src/components/tabs/CalendarTab.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useSwipe } from '@/hooks/useSwipe'
 import { ChevronDown, ChevronLeft, ChevronRight, Plus } from 'lucide-react'
 import { useAsyncData } from '@/hooks/useAsyncData'
@@ -107,6 +107,7 @@ export function CalendarTab({
   })
 
   const [events, setEvents] = useState<CalendarEvent[]>([])
+  const [adjacentMonthEvents, setAdjacentMonthEvents] = useState<CalendarEvent[]>([])
   const [eventsLoading, setEventsLoading] = useState(true)
   const [eventsError, setEventsError] = useState<unknown>(null)
   const monthEventsCacheRef = useRef(new Map<string, CalendarEvent[]>())
@@ -169,13 +170,34 @@ export function CalendarTab({
     return request
   }, [storeMonthEvents])
 
+  const syncAdjacentFromCache = useCallback((
+    targetFamilyId: string, targetYear: number, targetMonth: number
+  ) => {
+    const expectedKey = getMonthEventsKey(targetFamilyId, targetYear, targetMonth)
+    if (visibleMonthKeyRef.current !== expectedKey) return
+
+    const prev = getAdjacentMonth(targetYear, targetMonth, -1)
+    const next = getAdjacentMonth(targetYear, targetMonth, 1)
+    const prevEvents = monthEventsCacheRef.current.get(
+      getMonthEventsKey(targetFamilyId, prev.year, prev.month)
+    ) ?? []
+    const nextEvents = monthEventsCacheRef.current.get(
+      getMonthEventsKey(targetFamilyId, next.year, next.month)
+    ) ?? []
+    setAdjacentMonthEvents([...prevEvents, ...nextEvents])
+  }, [])
+
   const prefetchAdjacentMonths = useCallback((targetFamilyId: string, targetYear: number, targetMonth: number) => {
     const prev = getAdjacentMonth(targetYear, targetMonth, -1)
     const next = getAdjacentMonth(targetYear, targetMonth, 1)
 
-    void fetchMonthEvents(targetFamilyId, prev.year, prev.month).catch(() => {})
-    void fetchMonthEvents(targetFamilyId, next.year, next.month).catch(() => {})
-  }, [fetchMonthEvents])
+    void Promise.all([
+      fetchMonthEvents(targetFamilyId, prev.year, prev.month).catch(() => {}),
+      fetchMonthEvents(targetFamilyId, next.year, next.month).catch(() => {}),
+    ]).then(() => {
+      syncAdjacentFromCache(targetFamilyId, targetYear, targetMonth)
+    })
+  }, [fetchMonthEvents, syncAdjacentFromCache])
 
   const loadMonthEvents = useCallback(async ({
     targetFamilyId,
@@ -204,6 +226,7 @@ export function CalendarTab({
 
     if (cached) {
       applyMonthState(cached)
+      syncAdjacentFromCache(targetFamilyId, targetYear, targetMonth)
       prefetchAdjacentMonths(targetFamilyId, targetYear, targetMonth)
       return cached
     }
@@ -217,6 +240,7 @@ export function CalendarTab({
     try {
       const nextEvents = await fetchMonthEvents(targetFamilyId, targetYear, targetMonth, { force })
       applyMonthState(nextEvents)
+      syncAdjacentFromCache(targetFamilyId, targetYear, targetMonth)
       prefetchAdjacentMonths(targetFamilyId, targetYear, targetMonth)
       return nextEvents
     } catch (error) {
@@ -229,7 +253,7 @@ export function CalendarTab({
       if (throwOnError) throw error
       return []
     }
-  }, [fetchMonthEvents, prefetchAdjacentMonths])
+  }, [fetchMonthEvents, prefetchAdjacentMonths, syncAdjacentFromCache])
 
   useEffect(() => {
     visibleMonthKeyRef.current = familyId ? getMonthEventsKey(familyId, year, month) : null
@@ -237,6 +261,7 @@ export function CalendarTab({
     if (!familyId) {
       queueMicrotask(() => {
         setEvents([])
+        setAdjacentMonthEvents([])
         setEventsError(null)
         setEventsLoading(false)
       })
@@ -250,6 +275,7 @@ export function CalendarTab({
     if (familyChanged) {
       queueMicrotask(() => {
         setEvents([])
+        setAdjacentMonthEvents([])
         setEventsError(null)
         setEventsLoading(true)
       })
@@ -263,6 +289,12 @@ export function CalendarTab({
       })
     })
   }, [familyId, year, month, loadMonthEvents])
+
+  const mergedEvents = useMemo(() => {
+    if (adjacentMonthEvents.length === 0) return events
+    const seen = new Set(events.map((e) => e.id))
+    return [...events, ...adjacentMonthEvents.filter((e) => !seen.has(e.id))]
+  }, [events, adjacentMonthEvents])
 
   const reloadEvents = useCallback(async () => {
     if (!familyId) return
@@ -720,7 +752,7 @@ export function CalendarTab({
         <CalendarGrid
           year={year}
           month={month}
-          events={events}
+          events={mergedEvents}
           calendars={calendars}
           activeIds={activeIds}
           holidays={holidays}
@@ -745,7 +777,7 @@ export function CalendarTab({
       {selectedDate && !selectedEvent && !editingEvent && !calendarForm && (
         <DayEventsSheet
           date={selectedDate}
-          events={events}
+          events={mergedEvents}
           calendars={calendars}
           onClose={() => setSelectedDate(null)}
           onSelectEvent={setSelectedEvent}

--- a/src/components/tabs/CalendarTab.tsx
+++ b/src/components/tabs/CalendarTab.tsx
@@ -313,8 +313,12 @@ export function CalendarTab({
     if (!familyId) return
     const prev = getAdjacentMonth(year, month, -1)
     const next = getAdjacentMonth(year, month, 1)
-    monthEventsCacheRef.current.delete(getMonthEventsKey(familyId, prev.year, prev.month))
-    monthEventsCacheRef.current.delete(getMonthEventsKey(familyId, next.year, next.month))
+    const prevKey = getMonthEventsKey(familyId, prev.year, prev.month)
+    const nextKey = getMonthEventsKey(familyId, next.year, next.month)
+    monthEventsCacheRef.current.delete(prevKey)
+    monthEventsCacheRef.current.delete(nextKey)
+    monthEventsRequestsRef.current.delete(prevKey)
+    monthEventsRequestsRef.current.delete(nextKey)
     await loadMonthEvents({
       targetFamilyId: familyId,
       targetYear: year,

--- a/src/components/tabs/CalendarTab.tsx
+++ b/src/components/tabs/CalendarTab.tsx
@@ -233,6 +233,7 @@ export function CalendarTab({
 
     if (!silent && isVisibleMonth()) {
       setEvents([])
+      setAdjacentMonthEvents([])
       setEventsLoading(true)
     }
     if (isVisibleMonth()) setEventsError(null)
@@ -247,6 +248,7 @@ export function CalendarTab({
       console.error('[CalendarTab] loadEvents failed:', error)
       if (isVisibleMonth()) {
         setEvents([])
+        setAdjacentMonthEvents([])
         setEventsError(error)
         setEventsLoading(false)
       }
@@ -309,6 +311,10 @@ export function CalendarTab({
 
   const refreshEvents = useCallback(async () => {
     if (!familyId) return
+    const prev = getAdjacentMonth(year, month, -1)
+    const next = getAdjacentMonth(year, month, 1)
+    monthEventsCacheRef.current.delete(getMonthEventsKey(familyId, prev.year, prev.month))
+    monthEventsCacheRef.current.delete(getMonthEventsKey(familyId, next.year, next.month))
     await loadMonthEvents({
       targetFamilyId: familyId,
       targetYear: year,


### PR DESCRIPTION
## Summary

- 5월 뷰의 4/26~4/30, 6/1~6/3 같이 그리드에 표시되는 인접 월 날짜에 이벤트가 표시되지 않던 버그 수정
- `getEventsByMonth`는 `start_at` 기준으로 현재 월만 조회하므로, 이미 prefetch된 인접 월 캐시 데이터를 `CalendarGrid`와 `DayEventsSheet`에 병합해 전달하도록 변경
- `visibleMonthKeyRef` 기반 race guard로 빠른 월 전환 시 stale adjacentMonthEvents가 현재 뷰를 덮어쓰지 않도록 방어
- `mergedEvents` id dedupe으로 동일 이벤트 중복 렌더링 방지

## Testing

- [x] `npm run test` — 439 tests passed
- [x] `npx tsc --noEmit` — no errors
- [x] 5월 뷰에서 4/29, 4/30 이벤트 표시 확인
- [x] 마지막 주 다음달 overflow 날짜 이벤트 표시 확인
- [x] overflow 날짜 클릭 시 DayEventsSheet에 이벤트 표시 확인
- [x] 월 빠르게 전환 시 잘못된 overflow 이벤트 미표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)