### PR TITLE
fix: restore realtime sync for calendar and shopping

### DIFF
--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -65,7 +65,7 @@ DB migration -> src/types/database.ts -> src/lib/* -> src/hooks/* -> src/app/* -
 - 구독 훅은 `src/hooks/useRealtimeSync.ts` 패턴을 재사용한다.
 - 채널명은 기능 경계가 드러나야 한다.
 - 가족 범위 데이터는 `family_*_${familyId}` 형식을 우선한다.
-- 월별 이벤트는 `family_events_${familyId}_${year}_${month}`처럼 조회 범위와 맞춘다.
+- 이벤트 동기화 채널은 `family_events_${familyId}`처럼 가족 단위로 유지한다. 연/월을 채널명에 포함하면 다른 달을 보는 클라이언트가 broadcast를 수신하지 못한다.
 - 상세/부분 범위 데이터는 `list_items_${listId}`처럼 더 좁은 범위를 사용한다.
 
 ## 6. Calendar Patterns

--- a/src/__tests__/components/CalendarTab.test.tsx
+++ b/src/__tests__/components/CalendarTab.test.tsx
@@ -34,7 +34,7 @@ jest.mock('@/lib/supabase', () => ({
     channel: jest.fn(() => ({
       on: jest.fn().mockReturnThis(),
       subscribe: jest.fn().mockReturnThis(),
-      send: jest.fn(),
+      send: jest.fn().mockResolvedValue('ok'),
     })),
     removeChannel: jest.fn(),
   },
@@ -222,6 +222,61 @@ describe('CalendarTab — touch-action 스크롤 차단', () => {
     await act(async () => {})
     expect(mockSupabase.channel).toHaveBeenCalledWith('family_events_fam-1')
     expect(mockSupabase.channel).not.toHaveBeenCalledWith(expect.stringMatching(/_\d{4}_\d{1,2}$/))
+  })
+
+  it('broadcast 수신 시 인접하지 않은 달의 캐시도 무효화하여 재탐색 시 새로 불러온다', async () => {
+    const today = new Date()
+    const y = today.getFullYear()
+    const m = today.getMonth()
+    let farYear = y, farMonth = m + 2
+    if (farMonth > 11) { farYear += 1; farMonth -= 12 }
+
+    let broadcastCb: (() => void) | undefined
+    const { supabase: mockSupabase } = jest.requireMock('@/lib/supabase') as {
+      supabase: { channel: jest.Mock }
+    }
+    const channelStub = {
+      on: jest.fn().mockImplementation((_t: string, _f: unknown, cb: () => void) => {
+        broadcastCb = cb
+        return channelStub
+      }),
+      subscribe: jest.fn().mockReturnThis(),
+      send: jest.fn().mockResolvedValue('ok'),
+    }
+    mockSupabase.channel.mockReturnValueOnce(channelStub)
+
+    render(<CalendarTab {...defaultProps} />)
+    await act(async () => {})
+
+    // month+2를 방문해 캐시에 올린다
+    fireEvent.click(screen.getByRole('button', { name: '다음 달' }))
+    await act(async () => {})
+    fireEvent.click(screen.getByRole('button', { name: '다음 달' }))
+    await act(async () => {})
+
+    // 현재 달로 돌아온다
+    fireEvent.click(screen.getByRole('button', { name: '이전 달' }))
+    await act(async () => {})
+    fireEvent.click(screen.getByRole('button', { name: '이전 달' }))
+    await act(async () => {})
+
+    const callsBefore = mockGetEventsByMonth.mock.calls.filter(
+      ([, ey, em]) => ey === farYear && em === farMonth
+    ).length
+
+    // broadcast 수신 → 전체 캐시 무효화
+    await act(async () => { broadcastCb?.() })
+
+    // month+1로 이동 (이때 month+2 prefetch 발생)
+    fireEvent.click(screen.getByRole('button', { name: '다음 달' }))
+    await act(async () => {})
+
+    const callsAfter = mockGetEventsByMonth.mock.calls.filter(
+      ([, ey, em]) => ey === farYear && em === farMonth
+    ).length
+
+    // 캐시가 무효화됐으므로 broadcast 후 재탐색 시 새로 불러온 횟수가 증가해야 한다
+    expect(callsAfter).toBeGreaterThan(callsBefore)
   })
 
   it('모달이 없을 때 컨테이너에 touch-action: none이 적용된다', async () => {

--- a/src/__tests__/components/CalendarTab.test.tsx
+++ b/src/__tests__/components/CalendarTab.test.tsx
@@ -216,6 +216,14 @@ describe('CalendarTab — touch-action 스크롤 차단', () => {
     mockDeleteWithAuth.mockResolvedValue(undefined)
   })
 
+  it('가족 단위 채널명을 사용하고 연/월을 포함하지 않는다', async () => {
+    const { supabase: mockSupabase } = jest.requireMock('@/lib/supabase') as { supabase: { channel: jest.Mock } }
+    render(<CalendarTab {...defaultProps} />)
+    await act(async () => {})
+    expect(mockSupabase.channel).toHaveBeenCalledWith('family_events_fam-1')
+    expect(mockSupabase.channel).not.toHaveBeenCalledWith(expect.stringMatching(/_\d{4}_\d{1,2}$/))
+  })
+
   it('모달이 없을 때 컨테이너에 touch-action: none이 적용된다', async () => {
     const { container } = render(
       <CalendarTab {...defaultProps} />

--- a/src/__tests__/hooks/useRealtimeSync.test.ts
+++ b/src/__tests__/hooks/useRealtimeSync.test.ts
@@ -1,7 +1,7 @@
 import { renderHook, act } from '@testing-library/react'
 import { useRealtimeSync } from '@/hooks/useRealtimeSync'
 
-const mockSend = jest.fn()
+const mockSend = jest.fn().mockResolvedValue('ok')
 const mockRemoveChannel = jest.fn()
 let subscribeCb: ((status: string) => void) | undefined
 let broadcastCb: (() => void) | undefined
@@ -114,6 +114,64 @@ describe('useRealtimeSync', () => {
       event: 'refresh',
       payload: {},
     })
+  })
+
+  it('SUBSCRIBED 전 broadcast() 호출 시 전송하지 않고 pending으로 예약한다', () => {
+    const onRefresh = jest.fn()
+    const { result } = renderHook(() => useRealtimeSync('test-channel', onRefresh))
+
+    act(() => { result.current() })
+
+    expect(mockSend).not.toHaveBeenCalled()
+  })
+
+  it('pending broadcast가 있을 때 SUBSCRIBED가 되면 1회 flush한다', async () => {
+    const onRefresh = jest.fn()
+    const { result } = renderHook(() => useRealtimeSync('test-channel', onRefresh))
+
+    act(() => { result.current() })
+    expect(mockSend).not.toHaveBeenCalled()
+
+    await act(async () => { subscribeCb?.('SUBSCRIBED') })
+
+    expect(mockSend).toHaveBeenCalledTimes(1)
+    expect(mockSend).toHaveBeenCalledWith({ type: 'broadcast', event: 'refresh', payload: {} })
+  })
+
+  it('SUBSCRIBED 전 broadcast()를 여러 번 호출해도 flush는 1회만 한다', async () => {
+    const onRefresh = jest.fn()
+    const { result } = renderHook(() => useRealtimeSync('test-channel', onRefresh))
+
+    act(() => {
+      result.current()
+      result.current()
+      result.current()
+    })
+
+    await act(async () => { subscribeCb?.('SUBSCRIBED') })
+
+    expect(mockSend).toHaveBeenCalledTimes(1)
+  })
+
+  it('pending이 없으면 SUBSCRIBED 시 flush하지 않는다', async () => {
+    const onRefresh = jest.fn()
+    renderHook(() => useRealtimeSync('test-channel', onRefresh))
+
+    await act(async () => { subscribeCb?.('SUBSCRIBED') })
+
+    expect(mockSend).not.toHaveBeenCalled()
+  })
+
+  it('flush 후 두 번째 SUBSCRIBED에서 재flush하지 않는다', async () => {
+    const onRefresh = jest.fn()
+    const { result } = renderHook(() => useRealtimeSync('test-channel', onRefresh))
+
+    act(() => { result.current() })
+    await act(async () => { subscribeCb?.('SUBSCRIBED') })
+    expect(mockSend).toHaveBeenCalledTimes(1)
+
+    await act(async () => { subscribeCb?.('SUBSCRIBED') })
+    expect(mockSend).toHaveBeenCalledTimes(1)
   })
 
   it('언마운트 시 채널을 제거한다', () => {

--- a/src/__tests__/hooks/useRealtimeSync.test.ts
+++ b/src/__tests__/hooks/useRealtimeSync.test.ts
@@ -183,6 +183,28 @@ describe('useRealtimeSync', () => {
     expect(mockSupabaseRemoveChannel).toHaveBeenCalledWith(mockChannel)
   })
 
+  it('언마운트 시 pending broadcast가 있으면 채널 제거 전에 전송한다', () => {
+    const onRefresh = jest.fn()
+    const { result, unmount } = renderHook(() => useRealtimeSync('test-channel', onRefresh))
+
+    act(() => { result.current() }) // pending=true, 미구독 상태
+
+    unmount()
+
+    expect(mockSend).toHaveBeenCalledTimes(1)
+    expect(mockSend).toHaveBeenCalledWith({ type: 'broadcast', event: 'refresh', payload: {} })
+    expect(mockSupabaseRemoveChannel).toHaveBeenCalledWith(mockChannel)
+  })
+
+  it('언마운트 시 pending이 없으면 전송하지 않는다', () => {
+    const onRefresh = jest.fn()
+    const { unmount } = renderHook(() => useRealtimeSync('test-channel', onRefresh))
+
+    unmount()
+
+    expect(mockSend).not.toHaveBeenCalled()
+  })
+
   it('channelName 변경 시 이전 채널을 제거하고 새 채널을 구독한다', () => {
     const onRefresh = jest.fn()
     const { rerender } = renderHook(

--- a/src/__tests__/shopping/ShoppingDetailView.test.tsx
+++ b/src/__tests__/shopping/ShoppingDetailView.test.tsx
@@ -1,14 +1,16 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { User } from '@supabase/supabase-js'
 import { ShoppingDetailView } from '@/components/shopping/ShoppingDetailView'
 import { getShoppingItems, getShoppingList } from '@/lib/shopping'
 
 const mockBroadcast = jest.fn()
+const mockUseRealtimeSync = jest.fn((_c: unknown, _r: unknown, _o: unknown) => mockBroadcast)
 const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
 
 jest.mock('@/hooks/useRealtimeSync', () => ({
-  useRealtimeSync: () => mockBroadcast,
+  useRealtimeSync: (channelName: unknown, refresh: unknown, options: unknown) =>
+    mockUseRealtimeSync(channelName, refresh, options),
 }))
 
 jest.mock('@/lib/shopping', () => ({
@@ -71,6 +73,21 @@ describe('ShoppingDetailView', () => {
 
   afterAll(() => {
     consoleErrorSpy.mockRestore()
+  })
+
+  it('refreshOnSubscribed: false를 전달하지 않는다', async () => {
+    render(
+      <ShoppingDetailView
+        listId="list-1"
+        user={mockUser}
+        onClose={onClose}
+        onPreviewItemsChange={onPreviewItemsChange}
+      />
+    )
+    await act(async () => {})
+    const calls = mockUseRealtimeSync.mock.calls as unknown as Array<[unknown, unknown, { refreshOnSubscribed?: boolean } | undefined]>
+    const options = calls[0]?.[2]
+    expect(options?.refreshOnSubscribed).not.toBe(false)
   })
 
   it('정상 로드 시 상세 헤더를 렌더링한다', async () => {

--- a/src/__tests__/shopping/ShoppingTab.test.tsx
+++ b/src/__tests__/shopping/ShoppingTab.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { User } from '@supabase/supabase-js'
 import { ShoppingTab, clearShoppingTabCache } from '@/components/tabs/ShoppingTab'
@@ -9,6 +9,7 @@ const mockDeleteShoppingList = jest.fn()
 const mockRenameShoppingList = jest.fn()
 const mockReorderShoppingLists = jest.fn()
 const mockBroadcast = jest.fn()
+const mockUseRealtimeSync = jest.fn((_c: unknown, _r: unknown, _o: unknown) => mockBroadcast)
 const mockPush = jest.fn()
 const mockReplace = jest.fn()
 let mockListParam: string | null = null
@@ -23,7 +24,8 @@ jest.mock('@/lib/shopping', () => ({
 }))
 
 jest.mock('@/hooks/useRealtimeSync', () => ({
-  useRealtimeSync: () => mockBroadcast,
+  useRealtimeSync: (channelName: unknown, refresh: unknown, options: unknown) =>
+    mockUseRealtimeSync(channelName, refresh, options),
 }))
 
 jest.mock('next/navigation', () => ({
@@ -82,6 +84,16 @@ describe('ShoppingTab', () => {
 
   afterAll(() => {
     consoleErrorSpy.mockRestore()
+  })
+
+  it('refreshOnSubscribed: false를 전달하지 않는다', async () => {
+    render(
+      <ShoppingTab user={{ id: 'user-1' } as User} familyId="fam-1" isInitializing={false} />
+    )
+    await act(async () => {})
+    const calls = mockUseRealtimeSync.mock.calls as unknown as Array<[unknown, unknown, { refreshOnSubscribed?: boolean } | undefined]>
+    const options = calls[0]?.[2]
+    expect(options?.refreshOnSubscribed).not.toBe(false)
   })
 
   it('목록 생성 실패 시 optimistic 항목을 롤백하고 에러를 표시한다', async () => {

--- a/src/components/shopping/ShoppingDetailView.tsx
+++ b/src/components/shopping/ShoppingDetailView.tsx
@@ -67,9 +67,7 @@ export function ShoppingDetailView({
       .catch((e) => console.error('[ShoppingDetailView] getShoppingItems failed:', e))
   }, [listId, syncPreview])
 
-  const broadcast = useRealtimeSync(`list_items_${listId}`, refreshItems, {
-    refreshOnSubscribed: false,
-  })
+  const broadcast = useRealtimeSync(`list_items_${listId}`, refreshItems)
 
   const fetchDetailData = useCallback(async () => {
     const shoppingList = await getShoppingList(listId)

--- a/src/components/tabs/CalendarTab.tsx
+++ b/src/components/tabs/CalendarTab.tsx
@@ -332,8 +332,8 @@ export function CalendarTab({
     await Promise.allSettled([reloadCalendars(), reloadFamilyMembers()])
   }, [reloadCalendars, reloadFamilyMembers])
 
-  const channelName = familyId ? `family_events_${familyId}_${year}_${month}` : null
-  const broadcast = useRealtimeSync(channelName, refreshEvents, { refreshOnSubscribed: false })
+  const channelName = familyId ? `family_events_${familyId}` : null
+  const broadcast = useRealtimeSync(channelName, refreshEvents)
 
   const prevMonth = () => {
     setSlideDir('right')

--- a/src/components/tabs/CalendarTab.tsx
+++ b/src/components/tabs/CalendarTab.tsx
@@ -311,14 +311,13 @@ export function CalendarTab({
 
   const refreshEvents = useCallback(async () => {
     if (!familyId) return
-    const prev = getAdjacentMonth(year, month, -1)
-    const next = getAdjacentMonth(year, month, 1)
-    const prevKey = getMonthEventsKey(familyId, prev.year, prev.month)
-    const nextKey = getMonthEventsKey(familyId, next.year, next.month)
-    monthEventsCacheRef.current.delete(prevKey)
-    monthEventsCacheRef.current.delete(nextKey)
-    monthEventsRequestsRef.current.delete(prevKey)
-    monthEventsRequestsRef.current.delete(nextKey)
+    const prefix = `${familyId}:`
+    for (const key of monthEventsCacheRef.current.keys()) {
+      if (key.startsWith(prefix)) monthEventsCacheRef.current.delete(key)
+    }
+    for (const key of monthEventsRequestsRef.current.keys()) {
+      if (key.startsWith(prefix)) monthEventsRequestsRef.current.delete(key)
+    }
     await loadMonthEvents({
       targetFamilyId: familyId,
       targetYear: year,

--- a/src/components/tabs/ShoppingTab.tsx
+++ b/src/components/tabs/ShoppingTab.tsx
@@ -87,9 +87,7 @@ export function ShoppingTab({ user, familyId, isInitializing }: Props) {
       })
   }, [familyId, updateLists])
 
-  const broadcast = useRealtimeSync(familyId ? `family_lists_${familyId}` : null, refresh, {
-    refreshOnSubscribed: false,
-  })
+  const broadcast = useRealtimeSync(familyId ? `family_lists_${familyId}` : null, refresh)
 
   useEffect(() => {
     refresh()

--- a/src/hooks/useRealtimeSync.ts
+++ b/src/hooks/useRealtimeSync.ts
@@ -1,12 +1,17 @@
 import { useCallback, useEffect, useRef } from 'react'
 import { supabase } from '@/lib/supabase'
 
-/**
- * Supabase Realtime broadcast 구독을 관리하는 훅.
- * - channelName이 null이면 구독하지 않는다.
- * - 기본적으로 SUBSCRIBED 시점과 broadcast 수신 시 onRefresh를 호출한다.
- * - broadcast()는 채널이 SUBSCRIBED 상태일 때만 전송한다 (PATTERNS.md 참조).
- */
+function sendBroadcast(channel: ReturnType<typeof supabase.channel> | null) {
+  if (!channel) return
+  channel.send({ type: 'broadcast', event: 'refresh', payload: {} })
+    .then((result) => {
+      if (result !== 'ok') {
+        console.error('[useRealtimeSync] broadcast failed:', result)
+      }
+    })
+    .catch((e) => console.error('[useRealtimeSync] broadcast error:', e))
+}
+
 export function useRealtimeSync(
   channelName: string | null,
   onRefresh: () => void,
@@ -22,6 +27,7 @@ export function useRealtimeSync(
 
   const channelRef = useRef<ReturnType<typeof supabase.channel> | null>(null)
   const channelReadyRef = useRef(false)
+  const pendingBroadcastRef = useRef(false)
 
   useEffect(() => {
     if (!channelName) return
@@ -36,6 +42,10 @@ export function useRealtimeSync(
           if (refreshOnSubscribed) {
             onRefreshRef.current()
           }
+          if (pendingBroadcastRef.current) {
+            pendingBroadcastRef.current = false
+            sendBroadcast(channel)
+          }
         }
       })
     channelRef.current = channel
@@ -43,13 +53,16 @@ export function useRealtimeSync(
     return () => {
       channelReadyRef.current = false
       channelRef.current = null
+      pendingBroadcastRef.current = false
       supabase.removeChannel(channel)
     }
   }, [channelName, refreshOnSubscribed])
 
   return useCallback(() => {
     if (channelReadyRef.current) {
-      channelRef.current?.send({ type: 'broadcast', event: 'refresh', payload: {} })
+      sendBroadcast(channelRef.current)
+    } else {
+      pendingBroadcastRef.current = true
     }
   }, [])
 }

--- a/src/hooks/useRealtimeSync.ts
+++ b/src/hooks/useRealtimeSync.ts
@@ -53,7 +53,10 @@ export function useRealtimeSync(
     return () => {
       channelReadyRef.current = false
       channelRef.current = null
-      pendingBroadcastRef.current = false
+      if (pendingBroadcastRef.current) {
+        pendingBroadcastRef.current = false
+        sendBroadcast(channel)
+      }
       supabase.removeChannel(channel)
     }
   }, [channelName, refreshOnSubscribed])


### PR DESCRIPTION
## Summary

- **송신 측 broadcast 유실 수정**: 채널이 SUBSCRIBED 되기 전에 `broadcast()`가 호출되면 기존에는 조용히 드롭됐음. HTTP mutation은 성공하지만 다른 클라이언트에 신호가 안 가는 원인. `pendingBroadcastRef`로 예약 후 SUBSCRIBED 시 1회 flush하도록 수정 (`useRealtimeSync.ts`)
- **수신 측 재연결 후 갱신 누락 수정**: CalendarTab, ShoppingTab, ShoppingDetailView 세 곳에서 `refreshOnSubscribed: false`를 명시해 재연결(토큰 갱신, 네트워크 복구, 백그라운드 복귀) 후 데이터를 다시 가져오지 않았음. 옵션 제거로 훅 기본값(`true`) 사용
- **캘린더 채널명 스코프 수정**: `family_events_${familyId}_${year}_${month}` → `family_events_${familyId}`. 연/월이 채널명에 포함되면 다른 달을 보는 클라이언트가 broadcast를 수신하지 못함
- **중복 코드 정리**: `channel.send()` + 에러 로깅 패턴을 `sendBroadcast()` 헬퍼로 통합
- **문서 갱신**: `docs/PATTERNS.md` 채널 네이밍 가이드 업데이트

## Testing

- `npx tsc --noEmit` 통과
- `useRealtimeSync`: pending flush 시나리오 5개 케이스 추가 (미준비 상태 broadcast 예약, SUBSCRIBED 시 1회 flush, 중복 방지, 재flush 방지)
- `CalendarTab`: 가족 단위 채널명 검증 (연/월 포함 여부 assert)
- `ShoppingTab`, `ShoppingDetailView`: `refreshOnSubscribed: false` 미전달 검증
- 전체 관련 테스트 49개 통과

## Manual Verification

- [ ] 두 기기(또는 브라우저 탭)에서 같은 달 캘린더를 열고, 한쪽에서 이벤트 추가/수정/삭제 시 다른 쪽에 실시간 반영 확인
- [ ] 두 기기에서 다른 달을 보는 상태에서 이벤트 변경 시 양쪽 모두 반영 확인
- [ ] 두 기기에서 같은 장바구니 상세를 열고, 한쪽에서 아이템 추가/삭제/체크 시 다른 쪽에 실시간 반영 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)