### PR TITLE
fix: add gap between holiday and event chips in calendar cell

### DIFF
--- a/src/__tests__/components/CalendarGrid.test.tsx
+++ b/src/__tests__/components/CalendarGrid.test.tsx
@@ -531,3 +531,29 @@ describe('칩 variant', () => {
     expect(chip.className).toContain('whitespace-nowrap')
   })
 })
+
+// ── 공휴일·이벤트 칩 간격 ────────────────────────────────────
+
+describe('공휴일-이벤트 칩 간격', () => {
+  it('공휴일과 이벤트가 같은 날에 있으면 이벤트 블록에 mt-0.5가 적용된다', () => {
+    const holidays: Holiday[] = [{ date: '2025-06-15', localName: '테스트공휴일', countryCode: 'KR' }]
+    const event = makeEvent({ title: '테스트일정', start_at: '2025-06-15T10:00:00Z' })
+    render(<CalendarGrid {...defaultProps} events={[event]} holidays={holidays} />)
+    const chip = screen.getByText('테스트일정')
+    expect(chip.parentElement).toHaveClass('mt-0.5')
+  })
+
+  it('이벤트만 있고 같은 날 공휴일이 없으면 이벤트 블록에 mt-0.5가 없다', () => {
+    render(<CalendarGrid {...defaultProps} />)
+    const chip = screen.getByText('생일파티')
+    expect(chip.parentElement).not.toHaveClass('mt-0.5')
+  })
+
+  it('공휴일이 다른 날에 있으면 이벤트 날짜의 블록에 mt-0.5가 없다', () => {
+    const holidays: Holiday[] = [{ date: '2025-06-06', localName: '현충일', countryCode: 'KR' }]
+    render(<CalendarGrid {...defaultProps} holidays={holidays} />)
+    // 이벤트(생일파티)는 6/15, 공휴일은 6/6 → 6/15 이벤트 블록에 mt-0.5 없어야 함
+    const chip = screen.getByText('생일파티')
+    expect(chip.parentElement).not.toHaveClass('mt-0.5')
+  })
+})

--- a/src/components/calendar/CalendarGrid.tsx
+++ b/src/components/calendar/CalendarGrid.tsx
@@ -251,6 +251,7 @@ export function CalendarGrid({
                   const dow = cell.date.getDay()
                   const isSun = dow === 0
                   const isSat = dow === 6
+                  const hasHolidaysAndEvents = dayHolidays.length > 0 && daySingleEvents.length > 0
 
                   return (
                     <button
@@ -317,7 +318,7 @@ export function CalendarGrid({
                       </div>
 
                       {/* 단일 일정 pills */}
-                      <div className="w-full space-y-0.5">
+                      <div className={`w-full space-y-0.5${hasHolidaysAndEvents ? ' mt-0.5' : ''}`}>
                         {daySingleEvents.slice(0, 3).map((evt) => {
                           const color = getEventColor(evt)
                           return (


### PR DESCRIPTION
## Summary

- 공휴일 칩과 단일 이벤트 칩이 같은 날에 함께 있을 때 두 블록 사이에 간격이 없던 문제 수정
- 원인: 공휴일 div와 이벤트 div가 별개의 sibling 컨테이너로 분리되어 있어 `space-y-0.5`가 둘 사이에 적용되지 않았음
- 수정: 두 div 구조와 표시 정책은 유지하고, 두 블록이 모두 존재할 때만 이벤트 div에 `mt-0.5` 조건부 추가
- 표시 정책 변경 없음: 공휴일 전체 표시 + 이벤트 최대 3개 + +N 기준 그대로

## Testing

- [x] 공휴일만 있는 날: 기존과 동일
- [x] 이벤트만 있는 날: 기존과 동일
- [x] 공휴일 1개 + 이벤트 1개: 두 칩 사이 간격 생김 (5/25 케이스)
- [x] 공휴일 여러 개 + 이벤트 여러 개: 공휴일 블록 끝 ↔ 이벤트 블록 시작 사이만 2px 추가
- [x] 이벤트 4개 이상: +N 위치·숫자 기존과 동일

🤖 Generated with [Claude Code](https://claude.com/claude-code)