### PR TITLE
feat: add daily morning digest push notification

### DIFF
--- a/src/__tests__/api/push/daily-digest.test.ts
+++ b/src/__tests__/api/push/daily-digest.test.ts
@@ -22,21 +22,30 @@ jest.mock('@/lib/supabase-admin', () => ({
 
 // ── builder helper ───────────────────────────────────────────
 
-function makeBuilder(data: unknown) {
+type BuilderResult = { data: unknown; error: unknown }
+
+function makeBuilder(result: BuilderResult) {
   const builder: Record<string, unknown> = {}
-  ;['select', 'eq', 'in', 'is', 'lte', 'gte', 'or', 'insert', 'delete', 'update'].forEach((m) => {
+  ;['select', 'eq', 'in', 'is', 'lte', 'gte', 'or', 'insert', 'upsert', 'delete', 'update'].forEach((m) => {
     builder[m] = jest.fn().mockReturnValue(builder)
   })
   builder['then'] = (onFulfilled: (v: unknown) => unknown, onRejected?: (e: unknown) => unknown) =>
-    Promise.resolve({ data, error: null }).then(onFulfilled, onRejected)
+    Promise.resolve(result).then(onFulfilled, onRejected)
   builder['catch'] = (onRejected: (e: unknown) => unknown) =>
-    Promise.resolve({ data, error: null }).catch(onRejected)
+    Promise.resolve(result).catch(onRejected)
   return builder
 }
 
-function setupFromSequence(sequence: unknown[]) {
-  sequence.forEach((data) => {
-    mockFrom.mockImplementationOnce(() => makeBuilder(data))
+/** setupFromSequence에 전달할 error 결과 */
+function fail(error: unknown): BuilderResult { return { data: null, error } }
+
+function setupFromSequence(sequence: (BuilderResult | unknown)[]) {
+  sequence.forEach((item) => {
+    const result: BuilderResult =
+      item !== null && typeof item === 'object' && 'data' in (item as object) && 'error' in (item as object)
+        ? (item as BuilderResult)
+        : { data: item, error: null }
+    mockFrom.mockImplementationOnce(() => makeBuilder(result))
   })
 }
 
@@ -215,6 +224,27 @@ describe('POST /api/cron/daily-digest', () => {
       await POST(makeRequest())
       expect(mockDispatch).toHaveBeenCalledTimes(1)
     })
+
+    it('queryTodayEvents .or() 조건에 end_at.is.null 분기가 포함된다', async () => {
+      const capturedOrArgs: string[] = []
+      // setupHappyPath와 동일한 시퀀스, 단 events(family) builder에서 .or() 인자를 캡처
+      const captureOrBuilder = (data: unknown) => {
+        const builder = makeBuilder({ data, error: null })
+        const origOr = builder['or'] as jest.Mock
+        builder['or'] = jest.fn((arg: string) => { capturedOrArgs.push(arg); return origOr(arg) })
+        return builder
+      }
+      mockFrom
+        .mockImplementationOnce(() => makeBuilder({ data: [{ user_id: 'u1' }], error: null }))
+        .mockImplementationOnce(() => makeBuilder({ data: [], error: null }))
+        .mockImplementationOnce(() => makeBuilder({ data: [{ user_id: 'u1', family_id: 'fam-1' }], error: null }))
+        .mockImplementationOnce(() => makeBuilder({ data: [], error: null }))
+        .mockImplementationOnce(() => makeBuilder({ data: [SUB], error: null }))
+        .mockImplementationOnce(() => captureOrBuilder([makeEvent()])) // events(family)
+        .mockImplementationOnce(() => makeBuilder({ data: [{ user_id: 'u1' }], error: null }))
+      await POST(makeRequest())
+      expect(capturedOrArgs.some((arg) => arg.includes('end_at.is.null'))).toBe(true)
+    })
   })
 
   describe('멀티데이 종일 일정', () => {
@@ -242,7 +272,7 @@ describe('POST /api/cron/daily-digest', () => {
       expect(mockDispatch).not.toHaveBeenCalled()
     })
 
-    it('INSERT ON CONFLICT 충돌 시 push를 보내지 않는다', async () => {
+    it('upsert ON CONFLICT 충돌 시 push를 보내지 않는다', async () => {
       setupFromSequence([
         [{ user_id: 'u1' }],
         [],
@@ -250,7 +280,23 @@ describe('POST /api/cron/daily-digest', () => {
         [],
         [SUB],
         [makeEvent()],
-        [], // insert 충돌 → 빈 배열
+        [], // upsert 충돌 → 빈 배열
+      ])
+      const res = await POST(makeRequest())
+      expect(res.status).toBe(200)
+      expect(mockDispatch).not.toHaveBeenCalled()
+      expect((await res.json()).skippedUsers).toBeGreaterThan(0)
+    })
+
+    it('upsert 실제 DB 오류 시 error를 인식하고 skip한다', async () => {
+      setupFromSequence([
+        [{ user_id: 'u1' }],
+        [],
+        [{ user_id: 'u1', family_id: 'fam-1' }],
+        [],
+        [SUB],
+        [makeEvent()],
+        fail({ message: 'db error', code: '500' }), // upsert 실패
       ])
       const res = await POST(makeRequest())
       expect(res.status).toBe(200)

--- a/src/__tests__/api/push/daily-digest.test.ts
+++ b/src/__tests__/api/push/daily-digest.test.ts
@@ -130,6 +130,50 @@ describe('POST /api/cron/daily-digest', () => {
     expect(mockDispatch).not.toHaveBeenCalled()
   })
 
+  it('push_subscriptions DB 오류 시 500을 반환한다', async () => {
+    setupFromSequence([fail({ message: 'connection error', code: '500' })])
+    const res = await POST(makeRequest())
+    expect(res.status).toBe(500)
+    expect(mockDispatch).not.toHaveBeenCalled()
+  })
+
+  it('daily_digest_log 사전조회 DB 오류 시 500을 반환한다', async () => {
+    setupFromSequence([
+      [{ user_id: 'u1' }],
+      fail({ message: 'connection error', code: '500' }),
+    ])
+    const res = await POST(makeRequest())
+    expect(res.status).toBe(500)
+    expect(mockDispatch).not.toHaveBeenCalled()
+  })
+
+  it('family_members DB 오류 시 500을 반환한다', async () => {
+    setupFromSequence([
+      [{ user_id: 'u1' }],
+      [],
+      fail({ message: 'connection error', code: '500' }), // family_members
+      [],                                                  // calendar_members
+      [SUB],
+    ])
+    const res = await POST(makeRequest())
+    expect(res.status).toBe(500)
+    expect(mockDispatch).not.toHaveBeenCalled()
+  })
+
+  it('events DB 오류 시 500을 반환한다', async () => {
+    setupFromSequence([
+      [{ user_id: 'u1' }],
+      [],
+      [{ user_id: 'u1', family_id: 'fam-1' }],
+      [],
+      [SUB],
+      fail({ message: 'connection error', code: '500' }), // events(family)
+    ])
+    const res = await POST(makeRequest())
+    expect(res.status).toBe(500)
+    expect(mockDispatch).not.toHaveBeenCalled()
+  })
+
   it('이벤트가 있으면 push를 발송하고 sentUsers=1을 반환한다', async () => {
     setupHappyPath()
     const res = await POST(makeRequest())
@@ -243,7 +287,7 @@ describe('POST /api/cron/daily-digest', () => {
         .mockImplementationOnce(() => captureOrBuilder([makeEvent()])) // events(family)
         .mockImplementationOnce(() => makeBuilder({ data: [{ user_id: 'u1' }], error: null }))
       await POST(makeRequest())
-      expect(capturedOrArgs.some((arg) => arg.includes('end_at.is.null'))).toBe(true)
+      expect(capturedOrArgs.some((arg) => arg.includes('end_at.is.null,start_at.gte.'))).toBe(true)
     })
   })
 

--- a/src/__tests__/api/push/daily-digest.test.ts
+++ b/src/__tests__/api/push/daily-digest.test.ts
@@ -1,0 +1,297 @@
+/**
+ * @jest-environment node
+ */
+import { POST } from '@/app/api/cron/daily-digest/route'
+import { NextRequest } from 'next/server'
+
+// ── mocks ────────────────────────────────────────────────────
+
+const mockDispatch = jest.fn()
+jest.mock('@/lib/push-utils', () => ({
+  dispatchPushNotifications: (...args: unknown[]) => mockDispatch(...args),
+}))
+jest.mock('@/lib/webpush', () => ({
+  __esModule: true,
+  default: { sendNotification: jest.fn() },
+}))
+
+const mockFrom = jest.fn()
+jest.mock('@/lib/supabase-admin', () => ({
+  supabaseAdmin: { from: (...args: unknown[]) => mockFrom(...args) },
+}))
+
+// ── builder helper ───────────────────────────────────────────
+
+function makeBuilder(data: unknown) {
+  const builder: Record<string, unknown> = {}
+  ;['select', 'eq', 'in', 'is', 'lte', 'gte', 'or', 'insert', 'delete', 'update'].forEach((m) => {
+    builder[m] = jest.fn().mockReturnValue(builder)
+  })
+  builder['then'] = (onFulfilled: (v: unknown) => unknown, onRejected?: (e: unknown) => unknown) =>
+    Promise.resolve({ data, error: null }).then(onFulfilled, onRejected)
+  builder['catch'] = (onRejected: (e: unknown) => unknown) =>
+    Promise.resolve({ data, error: null }).catch(onRejected)
+  return builder
+}
+
+function setupFromSequence(sequence: unknown[]) {
+  sequence.forEach((data) => {
+    mockFrom.mockImplementationOnce(() => makeBuilder(data))
+  })
+}
+
+// ── fixtures ──────────────────────────────────────────────────
+
+const TODAY_KST = (() => {
+  const nowKST = new Date(Date.now() + 9 * 60 * 60 * 1000)
+  return nowKST.toISOString().slice(0, 10)
+})()
+
+function makeEvent(overrides: Partial<{
+  id: string; family_id: string; calendar_id: string | null
+  title: string; start_at: string; end_at: string | null; is_all_day: boolean
+}> = {}) {
+  return {
+    id: 'ev-1', family_id: 'fam-1', calendar_id: null,
+    title: '테스트 일정',
+    start_at: `${TODAY_KST}T10:00:00+09:00`,
+    end_at: null, is_all_day: false,
+    ...overrides,
+  }
+}
+
+const SUB = { id: 'sub1', endpoint: 'https://ep', p256dh: 'k', auth: 'a', user_id: 'u1' }
+
+/**
+ * 정상 흐름 from() 호출 순서 (병렬 쿼리 반영):
+ * 1. push_subscriptions  - distinct user_id
+ * 2. daily_digest_log    - 이미 발송 여부
+ * --- Promise.all([family_members, calendar_members, push_subscriptions]) ---
+ * 3. family_members
+ * 4. calendar_members    - [] 이면 events(calendar) 쿼리 스킵됨
+ * 5. push_subscriptions  - 기기별 전체
+ * --- Promise.all([events_family, events_calendar?]) ---
+ * 6. events (family 공용)
+ * 7. daily_digest_log    - insert
+ */
+function setupHappyPath(events: unknown[] = [makeEvent()]) {
+  setupFromSequence([
+    [{ user_id: 'u1' }],                         // 1
+    [],                                           // 2
+    [{ user_id: 'u1', family_id: 'fam-1' }],     // 3
+    [],                                           // 4 calendar_members → [] → calendar events 스킵
+    [SUB],                                        // 5 push_subscriptions full
+    events,                                       // 6 events (family)
+    [{ user_id: 'u1' }],                          // 7 insert
+  ])
+}
+
+// ── env setup ─────────────────────────────────────────────────
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  process.env.CRON_SECRET = 'test-secret'
+  process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://localhost'
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key'
+  process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY = 'pub'
+  process.env.VAPID_PRIVATE_KEY = 'priv'
+  mockDispatch.mockResolvedValue({ sent: 1, removed: 0 })
+})
+
+function makeRequest(secret = 'test-secret') {
+  return new NextRequest('http://localhost/api/cron/daily-digest', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${secret}` },
+  })
+}
+
+// ── tests ──────────────────────────────────────────────────────
+
+describe('POST /api/cron/daily-digest', () => {
+  it('CRON_SECRET 불일치 시 401을 반환한다', async () => {
+    const res = await POST(makeRequest('wrong'))
+    expect(res.status).toBe(401)
+  })
+
+  it('push 구독이 없으면 sentUsers=0을 반환한다', async () => {
+    setupFromSequence([[]])
+    const res = await POST(makeRequest())
+    expect(res.status).toBe(200)
+    expect((await res.json()).sentUsers).toBe(0)
+    expect(mockDispatch).not.toHaveBeenCalled()
+  })
+
+  it('이벤트가 있으면 push를 발송하고 sentUsers=1을 반환한다', async () => {
+    setupHappyPath()
+    const res = await POST(makeRequest())
+    expect(res.status).toBe(200)
+    expect((await res.json()).sentUsers).toBe(1)
+    expect(mockDispatch).toHaveBeenCalledTimes(1)
+  })
+
+  it('payload에 title, tag, 멘트, 이벤트명이 포함된다', async () => {
+    setupHappyPath()
+    await POST(makeRequest())
+    const payload = JSON.parse(mockDispatch.mock.calls[0][1])
+    expect(payload.title).toBe('오늘의 일정')
+    expect(payload.tag).toBe('koko-daily-digest')
+    expect(payload.body).toContain('오늘 하루도 힘차게 달려보아요!')
+    expect(payload.body).toContain('테스트 일정')
+  })
+
+  describe('이벤트 없는 날', () => {
+    it('push 미발송, log 미기록', async () => {
+      setupFromSequence([
+        [{ user_id: 'u1' }],
+        [],
+        [{ user_id: 'u1', family_id: 'fam-1' }],
+        [],   // calendar_members
+        [SUB],
+        [],   // events family - 없음
+      ])
+      const res = await POST(makeRequest())
+      expect(res.status).toBe(200)
+      expect(mockDispatch).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('캘린더 멤버십', () => {
+    it('내가 속하지 않은 캘린더 일정은 digest에 포함되지 않는다', async () => {
+      // u1은 cal-mine 소속, cal-other 이벤트는 메모리 필터에서 제거됨
+      const calEvent = makeEvent({ calendar_id: 'cal-other' })
+      setupFromSequence([
+        [{ user_id: 'u1' }],
+        [],
+        [{ user_id: 'u1', family_id: 'fam-1' }],
+        [{ user_id: 'u1', calendar_id: 'cal-mine' }],
+        [SUB],
+        [],          // events family - 없음
+        [calEvent],  // events calendar (cal-mine 기준 쿼리, 메모리 필터가 걸러냄)
+      ])
+      const res = await POST(makeRequest())
+      expect(mockDispatch).not.toHaveBeenCalled()
+      expect((await res.json()).sentUsers).toBe(0)
+    })
+  })
+
+  describe('정렬', () => {
+    it('종일 일정이 시간 일정보다 앞에 온다', async () => {
+      const timed = makeEvent({ id: 'ev-t', title: '시간 일정', start_at: `${TODAY_KST}T09:00:00+09:00` })
+      const allDay = makeEvent({ id: 'ev-a', title: '종일 일정', is_all_day: true, start_at: `${TODAY_KST}T00:00:00+09:00` })
+      setupHappyPath([timed, allDay])
+      await POST(makeRequest())
+      const body = JSON.parse(mockDispatch.mock.calls[0][1]).body as string
+      expect(body.indexOf('종일 일정')).toBeLessThan(body.indexOf('시간 일정'))
+    })
+
+    it('같은 start_at이면 title asc으로 정렬된다', async () => {
+      const same = `${TODAY_KST}T10:00:00+09:00`
+      const evB = makeEvent({ id: 'ev-b', title: 'B 일정', start_at: same })
+      const evA = makeEvent({ id: 'ev-a', title: 'A 일정', start_at: same })
+      setupHappyPath([evB, evA])
+      await POST(makeRequest())
+      const body = JSON.parse(mockDispatch.mock.calls[0][1]).body as string
+      expect(body.indexOf('A 일정')).toBeLessThan(body.indexOf('B 일정'))
+    })
+  })
+
+  describe('5개 초과', () => {
+    it('5개 초과 시 "외 N개 일정이 더 있어요"를 붙인다', async () => {
+      const events = Array.from({ length: 7 }, (_, i) =>
+        makeEvent({ id: `ev-${i}`, title: `일정${i}`, start_at: `${TODAY_KST}T${String(9 + i).padStart(2, '0')}:00:00+09:00` })
+      )
+      setupHappyPath(events)
+      await POST(makeRequest())
+      const body = JSON.parse(mockDispatch.mock.calls[0][1]).body as string
+      expect(body).toContain('외 2개 일정이 더 있어요')
+      expect(body).not.toContain('일정5')
+    })
+  })
+
+  describe('end_at null 종일 일정', () => {
+    it('end_at=null인 오늘 종일 일정은 포함된다', async () => {
+      const ev = makeEvent({ is_all_day: true, end_at: null, start_at: `${TODAY_KST}T00:00:00+09:00` })
+      setupHappyPath([ev])
+      await POST(makeRequest())
+      expect(mockDispatch).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('멀티데이 종일 일정', () => {
+    it('어제 시작해 오늘 이어지는 종일 일정은 포함된다', async () => {
+      const yesterday = new Date(Date.now() + 9 * 60 * 60 * 1000 - 86400000).toISOString().slice(0, 10)
+      const ev = makeEvent({
+        is_all_day: true,
+        start_at: `${yesterday}T00:00:00+09:00`,
+        end_at: `${TODAY_KST}T23:59:59+09:00`,
+      })
+      setupHappyPath([ev])
+      await POST(makeRequest())
+      expect(mockDispatch).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('중복 발송 방지', () => {
+    it('사전 조회에서 이미 발송된 user는 skip한다', async () => {
+      setupFromSequence([
+        [{ user_id: 'u1' }],   // push_subscriptions
+        [{ user_id: 'u1' }],   // daily_digest_log - 이미 발송됨
+      ])
+      const res = await POST(makeRequest())
+      expect(res.status).toBe(200)
+      expect(mockDispatch).not.toHaveBeenCalled()
+    })
+
+    it('INSERT ON CONFLICT 충돌 시 push를 보내지 않는다', async () => {
+      setupFromSequence([
+        [{ user_id: 'u1' }],
+        [],
+        [{ user_id: 'u1', family_id: 'fam-1' }],
+        [],
+        [SUB],
+        [makeEvent()],
+        [], // insert 충돌 → 빈 배열
+      ])
+      const res = await POST(makeRequest())
+      expect(res.status).toBe(200)
+      expect(mockDispatch).not.toHaveBeenCalled()
+      expect((await res.json()).skippedUsers).toBeGreaterThan(0)
+    })
+  })
+
+  describe('전송 실패 시 log 삭제 (재시도 허용)', () => {
+    it('sent=0이면 log를 삭제한다', async () => {
+      mockDispatch.mockResolvedValue({ sent: 0, removed: 1 })
+      setupFromSequence([
+        [{ user_id: 'u1' }],
+        [],
+        [{ user_id: 'u1', family_id: 'fam-1' }],
+        [],
+        [SUB],
+        [makeEvent()],
+        [{ user_id: 'u1' }], // insert 성공
+        null,                 // 8 delete
+      ])
+      const res = await POST(makeRequest())
+      expect(res.status).toBe(200)
+      expect(mockFrom).toHaveBeenCalledTimes(8)
+    })
+
+    it('예외 발생 시 log를 삭제한다', async () => {
+      mockDispatch.mockRejectedValue(new Error('network error'))
+      setupFromSequence([
+        [{ user_id: 'u1' }],
+        [],
+        [{ user_id: 'u1', family_id: 'fam-1' }],
+        [],
+        [SUB],
+        [makeEvent()],
+        [{ user_id: 'u1' }], // insert 성공
+        null,                 // 8 delete
+      ])
+      const res = await POST(makeRequest())
+      expect(res.status).toBe(200)
+      expect(mockFrom).toHaveBeenCalledTimes(8)
+    })
+  })
+})

--- a/src/app/api/cron/daily-digest/route.ts
+++ b/src/app/api/cron/daily-digest/route.ts
@@ -59,7 +59,11 @@ async function queryTodayEvents(
     .select('id, family_id, calendar_id, title, start_at, end_at, is_all_day')
     .eq('is_cancelled', false)
     .lte('start_at', todayEnd)
-    .or(`and(is_all_day.eq.true,end_at.gte.${todayStart}),and(is_all_day.eq.false,start_at.gte.${todayStart})`)
+    .or([
+      `and(is_all_day.eq.true,end_at.gte.${todayStart})`,      // 멀티데이 종일
+      `and(is_all_day.eq.true,end_at.is.null)`,                // 단일 종일 (end_at=null, start_at은 위 lte로 이미 오늘 이내)
+      `and(is_all_day.eq.false,start_at.gte.${todayStart})`,   // 시간 이벤트
+    ].join(','))
 
   const query =
     filter.type === 'family'
@@ -154,12 +158,17 @@ export async function POST(req: NextRequest) {
         url: '/',
       })
 
-      // INSERT ON CONFLICT DO NOTHING: 빈 배열이면 다른 실행이 이미 선점
-      const { data: inserted } = await supabaseAdmin
+      // ignoreDuplicates: true → 충돌 시 빈 배열, 실제 오류 시 error 필드로 구분
+      const { data: inserted, error: insertError } = await supabaseAdmin
         .from('daily_digest_log')
-        .insert({ user_id: userId, sent_date: sentDate })
+        .upsert({ user_id: userId, sent_date: sentDate }, { onConflict: 'user_id,sent_date', ignoreDuplicates: true })
         .select('user_id')
-      if (!inserted || inserted.length === 0) { skippedUsers++; return }
+      if (insertError) {
+        console.error('[daily-digest] log insert failed for user:', userId, insertError)
+        skippedUsers++
+        return
+      }
+      if (!inserted || inserted.length === 0) { skippedUsers++; return } // 다른 실행이 이미 선점
 
       try {
         const { sent } = await dispatchPushNotifications(userSubs, payload)

--- a/src/app/api/cron/daily-digest/route.ts
+++ b/src/app/api/cron/daily-digest/route.ts
@@ -61,7 +61,7 @@ async function queryTodayEvents(
     .lte('start_at', todayEnd)
     .or([
       `and(is_all_day.eq.true,end_at.gte.${todayStart})`,      // 멀티데이 종일
-      `and(is_all_day.eq.true,end_at.is.null)`,                // 단일 종일 (end_at=null, start_at은 위 lte로 이미 오늘 이내)
+      `and(is_all_day.eq.true,end_at.is.null,start_at.gte.${todayStart})`, // 단일 종일
       `and(is_all_day.eq.false,start_at.gte.${todayStart})`,   // 시간 이벤트
     ].join(','))
 
@@ -70,7 +70,8 @@ async function queryTodayEvents(
       ? base.in('family_id', filter.ids).is('calendar_id', null)
       : base.in('calendar_id', filter.ids)
 
-  const { data } = await query
+  const { data, error } = await query
+  if (error) throw new Error(`queryTodayEvents failed: ${error.message}`)
   return (data ?? []) as EventRow[]
 }
 
@@ -81,15 +82,17 @@ export async function POST(req: NextRequest) {
 
   const { start: todayStart, end: todayEnd, date: sentDate } = getTodayKST()
 
-  const { data: subRows } = await supabaseAdmin.from('push_subscriptions').select('user_id')
+  const { data: subRows, error: subError } = await supabaseAdmin.from('push_subscriptions').select('user_id')
+  if (subError) return NextResponse.json({ error: 'DB error' }, { status: 500 })
   const allUserIds = [...new Set((subRows ?? []).map((r) => r.user_id).filter(Boolean))] as string[]
   if (allUserIds.length === 0) return NextResponse.json({ sentUsers: 0, skippedUsers: 0 })
 
-  const { data: sentLogs } = await supabaseAdmin
+  const { data: sentLogs, error: sentLogsError } = await supabaseAdmin
     .from('daily_digest_log')
     .select('user_id')
     .eq('sent_date', sentDate)
     .in('user_id', allUserIds)
+  if (sentLogsError) return NextResponse.json({ error: 'DB error' }, { status: 500 })
   const alreadySentSet = new Set((sentLogs ?? []).map((r) => r.user_id))
   const pendingUserIds = allUserIds.filter((id) => !alreadySentSet.has(id))
   if (pendingUserIds.length === 0) return NextResponse.json({ sentUsers: 0, skippedUsers: allUserIds.length })
@@ -99,6 +102,9 @@ export async function POST(req: NextRequest) {
     supabaseAdmin.from('calendar_members').select('user_id, calendar_id').in('user_id', pendingUserIds),
     supabaseAdmin.from('push_subscriptions').select('id, endpoint, p256dh, auth, user_id').in('user_id', pendingUserIds),
   ])
+  if (memberRows.error || calMemberRows.error || allSubsRows.error) {
+    return NextResponse.json({ error: 'DB error' }, { status: 500 })
+  }
 
   const userFamilyMap = new Map<string, string>()
   for (const row of memberRows.data ?? []) {
@@ -116,10 +122,15 @@ export async function POST(req: NextRequest) {
   const familyIds = [...new Set([...userFamilyMap.values()])]
   const calendarIds = [...new Set([...userCalendarMap.values()].flat())]
 
-  const [familyEvents, calEvents] = await Promise.all([
-    familyIds.length > 0 ? queryTodayEvents({ type: 'family', ids: familyIds }, todayStart, todayEnd) : Promise.resolve([]),
-    calendarIds.length > 0 ? queryTodayEvents({ type: 'calendar', ids: calendarIds }, todayStart, todayEnd) : Promise.resolve([]),
-  ])
+  let familyEvents: EventRow[], calEvents: EventRow[]
+  try {
+    ;[familyEvents, calEvents] = await Promise.all([
+      familyIds.length > 0 ? queryTodayEvents({ type: 'family', ids: familyIds }, todayStart, todayEnd) : Promise.resolve([]),
+      calendarIds.length > 0 ? queryTodayEvents({ type: 'calendar', ids: calendarIds }, todayStart, todayEnd) : Promise.resolve([]),
+    ])
+  } catch {
+    return NextResponse.json({ error: 'DB error' }, { status: 500 })
+  }
 
   // end_at=null 종일 이벤트는 DB .or() 필터를 통과하므로 메모리에서 보정
   const allEvents = [...familyEvents, ...calEvents].filter((e) => {

--- a/src/app/api/cron/daily-digest/route.ts
+++ b/src/app/api/cron/daily-digest/route.ts
@@ -1,0 +1,181 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { supabaseAdmin } from '@/lib/supabase-admin'
+import { dispatchPushNotifications } from '@/lib/push-utils'
+
+type EventRow = {
+  id: string
+  family_id: string
+  calendar_id: string | null
+  title: string
+  start_at: string
+  end_at: string | null
+  is_all_day: boolean
+}
+
+type PushSubRow = { id: string; endpoint: string; p256dh: string; auth: string }
+
+function getTodayKST(): { start: string; end: string; date: string } {
+  const nowKST = new Date(Date.now() + 9 * 60 * 60 * 1000)
+  const dateStr = nowKST.toISOString().slice(0, 10)
+  return {
+    start: `${dateStr}T00:00:00+09:00`,
+    end: `${dateStr}T23:59:59+09:00`,
+    date: dateStr,
+  }
+}
+
+function formatTime(isoString: string): string {
+  return new Date(isoString).toLocaleTimeString('ko-KR', {
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone: 'Asia/Seoul',
+  })
+}
+
+function buildBody(events: EventRow[]): string {
+  const sorted = [...events].sort((a, b) => {
+    if (a.is_all_day !== b.is_all_day) return a.is_all_day ? -1 : 1
+    if (a.start_at !== b.start_at) return a.start_at < b.start_at ? -1 : 1
+    return a.title < b.title ? -1 : a.title > b.title ? 1 : 0
+  })
+
+  const shown = sorted.slice(0, 5)
+  const extra = sorted.length - shown.length
+  const lines = shown.map((e) => {
+    const prefix = e.is_all_day ? '하루종일' : formatTime(e.start_at)
+    return `・${prefix}  ${e.title}`
+  })
+  if (extra > 0) lines.push(`외 ${extra}개 일정이 더 있어요`)
+  return ['오늘 하루도 힘차게 달려보아요!', ...lines].join('\n')
+}
+
+async function queryTodayEvents(
+  filter: { type: 'family'; ids: string[] } | { type: 'calendar'; ids: string[] },
+  todayStart: string,
+  todayEnd: string
+): Promise<EventRow[]> {
+  const base = supabaseAdmin
+    .from('events')
+    .select('id, family_id, calendar_id, title, start_at, end_at, is_all_day')
+    .eq('is_cancelled', false)
+    .lte('start_at', todayEnd)
+    .or(`and(is_all_day.eq.true,end_at.gte.${todayStart}),and(is_all_day.eq.false,start_at.gte.${todayStart})`)
+
+  const query =
+    filter.type === 'family'
+      ? base.in('family_id', filter.ids).is('calendar_id', null)
+      : base.in('calendar_id', filter.ids)
+
+  const { data } = await query
+  return (data ?? []) as EventRow[]
+}
+
+export async function POST(req: NextRequest) {
+  if (req.headers.get('authorization') !== `Bearer ${process.env.CRON_SECRET}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { start: todayStart, end: todayEnd, date: sentDate } = getTodayKST()
+
+  const { data: subRows } = await supabaseAdmin.from('push_subscriptions').select('user_id')
+  const allUserIds = [...new Set((subRows ?? []).map((r) => r.user_id).filter(Boolean))] as string[]
+  if (allUserIds.length === 0) return NextResponse.json({ sentUsers: 0, skippedUsers: 0 })
+
+  const { data: sentLogs } = await supabaseAdmin
+    .from('daily_digest_log')
+    .select('user_id')
+    .eq('sent_date', sentDate)
+    .in('user_id', allUserIds)
+  const alreadySentSet = new Set((sentLogs ?? []).map((r) => r.user_id))
+  const pendingUserIds = allUserIds.filter((id) => !alreadySentSet.has(id))
+  if (pendingUserIds.length === 0) return NextResponse.json({ sentUsers: 0, skippedUsers: allUserIds.length })
+
+  const [memberRows, calMemberRows, allSubsRows] = await Promise.all([
+    supabaseAdmin.from('family_members').select('user_id, family_id').in('user_id', pendingUserIds),
+    supabaseAdmin.from('calendar_members').select('user_id, calendar_id').in('user_id', pendingUserIds),
+    supabaseAdmin.from('push_subscriptions').select('id, endpoint, p256dh, auth, user_id').in('user_id', pendingUserIds),
+  ])
+
+  const userFamilyMap = new Map<string, string>()
+  for (const row of memberRows.data ?? []) {
+    if (row.user_id && row.family_id) userFamilyMap.set(row.user_id, row.family_id)
+  }
+
+  const userCalendarMap = new Map<string, string[]>()
+  for (const row of calMemberRows.data ?? []) {
+    if (!row.user_id || !row.calendar_id) continue
+    const arr = userCalendarMap.get(row.user_id) ?? []
+    arr.push(row.calendar_id)
+    userCalendarMap.set(row.user_id, arr)
+  }
+
+  const familyIds = [...new Set([...userFamilyMap.values()])]
+  const calendarIds = [...new Set([...userCalendarMap.values()].flat())]
+
+  const [familyEvents, calEvents] = await Promise.all([
+    familyIds.length > 0 ? queryTodayEvents({ type: 'family', ids: familyIds }, todayStart, todayEnd) : Promise.resolve([]),
+    calendarIds.length > 0 ? queryTodayEvents({ type: 'calendar', ids: calendarIds }, todayStart, todayEnd) : Promise.resolve([]),
+  ])
+
+  // end_at=null 종일 이벤트는 DB .or() 필터를 통과하므로 메모리에서 보정
+  const allEvents = [...familyEvents, ...calEvents].filter((e) => {
+    if (!e.is_all_day) return true
+    return (e.end_at ?? e.start_at) >= todayStart
+  })
+
+  const subsByUser = new Map<string, PushSubRow[]>()
+  for (const sub of allSubsRows.data ?? []) {
+    if (!sub.user_id) continue
+    const { user_id: _uid, ...pushSub } = sub
+    const arr = subsByUser.get(sub.user_id) ?? []
+    arr.push(pushSub)
+    subsByUser.set(sub.user_id, arr)
+  }
+
+  let sentUsers = 0
+  let skippedUsers = 0
+
+  await Promise.all(
+    pendingUserIds.map(async (userId) => {
+      const familyId = userFamilyMap.get(userId)
+      const myCalendarIds = new Set(userCalendarMap.get(userId) ?? [])
+      const userSubs = subsByUser.get(userId)
+      if (!userSubs?.length) { skippedUsers++; return }
+
+      const visibleEvents = allEvents.filter(
+        (e) => e.family_id === familyId && (e.calendar_id === null || myCalendarIds.has(e.calendar_id))
+      )
+      if (visibleEvents.length === 0) { skippedUsers++; return }
+
+      const payload = JSON.stringify({
+        title: '오늘의 일정',
+        body: buildBody(visibleEvents),
+        tag: 'koko-daily-digest',
+        url: '/',
+      })
+
+      // INSERT ON CONFLICT DO NOTHING: 빈 배열이면 다른 실행이 이미 선점
+      const { data: inserted } = await supabaseAdmin
+        .from('daily_digest_log')
+        .insert({ user_id: userId, sent_date: sentDate })
+        .select('user_id')
+      if (!inserted || inserted.length === 0) { skippedUsers++; return }
+
+      try {
+        const { sent } = await dispatchPushNotifications(userSubs, payload)
+        if (sent === 0) {
+          await supabaseAdmin.from('daily_digest_log').delete().eq('user_id', userId).eq('sent_date', sentDate)
+          skippedUsers++
+        } else {
+          sentUsers++
+        }
+      } catch (err) {
+        console.error('[daily-digest] push failed for user:', userId, err)
+        await supabaseAdmin.from('daily_digest_log').delete().eq('user_id', userId).eq('sent_date', sentDate)
+        skippedUsers++
+      }
+    })
+  )
+
+  return NextResponse.json({ sentUsers, skippedUsers })
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -567,6 +567,24 @@ export type Database = {
           },
         ]
       }
+      daily_digest_log: {
+        Row: {
+          user_id: string
+          sent_date: string
+          sent_at: string
+        }
+        Insert: {
+          user_id: string
+          sent_date: string
+          sent_at?: string
+        }
+        Update: {
+          user_id?: string
+          sent_date?: string
+          sent_at?: string
+        }
+        Relationships: []
+      }
       shopping_lists: {
         Row: {
           created_at: string

--- a/supabase/migrations/20260419010000_daily_digest_log.sql
+++ b/supabase/migrations/20260419010000_daily_digest_log.sql
@@ -1,0 +1,10 @@
+-- daily_digest_log: 매일 아침 digest push 발송 기록
+-- PRIMARY KEY (user_id, sent_date)로 중복 발송 방지 (INSERT ON CONFLICT DO NOTHING)
+CREATE TABLE daily_digest_log (
+  user_id   uuid        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  sent_date date        NOT NULL,
+  sent_at   timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, sent_date)
+);
+
+ALTER TABLE daily_digest_log ENABLE ROW LEVEL SECURITY;

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "crons": [
+    { "path": "/api/cron/send-reminders", "schedule": "* * * * *" },
+    { "path": "/api/cron/daily-digest",   "schedule": "0 23 * * *" }
+  ]
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,5 @@
 {
   "crons": [
-    { "path": "/api/cron/send-reminders", "schedule": "* * * * *" },
-    { "path": "/api/cron/daily-digest",   "schedule": "0 23 * * *" }
+    { "path": "/api/cron/daily-digest", "schedule": "0 23 * * *" }
   ]
 }


### PR DESCRIPTION
## Summary

- 매일 오전 8시 KST에 가족 구성원 각각에게 그날 볼 수 있는 일정을 하나의 push 알림으로 전송
- 가족 공용 일정 + 본인이 속한 캘린더 일정만 포함해 권한 경계를 유지
- `daily_digest_log (user_id, sent_date)` PK와 `upsert(..., { onConflict, ignoreDuplicates: true })`로 race-safe 선점 처리
- 전송 실패(`sent = 0`) 또는 push 예외 발생 시 log를 삭제해 재시도 허용
- 종일 먼저 → `start_at asc` → `title asc`로 안정 정렬
- 최대 5개까지 노출하고 초과 시 `외 N개 일정이 더 있어요`로 요약
- `tag: koko-daily-digest`로 기존 reminder 알림과 분리
- KST 기준 날짜 계산 및 시간 포맷 고정
- `end_at = null` 종일 일정 포함, 과거 단일 종일 일정 과다 조회 방지를 위해 `start_at >= todayStart` 조건 추가
- cron read query 실패 시 `500`을 반환해 DB 장애를 조용히 숨기지 않도록 처리
- `vercel.json`에는 Hobby 플랜 배포 가능하도록 daily digest cron만 유지

## New Files

- `supabase/migrations/20260419010000_daily_digest_log.sql` — idempotency 테이블
- `src/app/api/cron/daily-digest/route.ts` — cron handler
- `src/__tests__/api/push/daily-digest.test.ts` — route 테스트
- `vercel.json` — daily digest cron 스케줄

## Testing

- [x] `npx tsc --noEmit` 통과
- [x] Jest 테스트 통과
- [x] 주요 검증 항목
- [x] 인증 실패 시 401
- [x] `push_subscriptions` / `daily_digest_log` / `family_members` / `events` 조회 오류 시 500
- [x] 이벤트 없는 날 push 미발송, log 미기록
- [x] 캘린더 멤버십 권한 경계
- [x] 종일/시간 정렬 및 같은 시각 `title asc`
- [x] 5개 초과 요약 문구
- [x] `end_at = null` 종일 일정 포함
- [x] 멀티데이 종일 일정 포함
- [x] `end_at.is.null,start_at.gte(...)` 조건 포함
- [x] 중복 발송 방지
- [x] upsert 충돌 시 skip
- [x] 전송 실패 / 예외 시 log 삭제

## Manual Verification

- [x] Supabase migration 적용 후 `daily_digest_log` 테이블 생성 확인
- [ ] Vercel 배포 후 cron 스케줄 등록 확인 (`0 23 * * *`)
- [ ] `/api/cron/daily-digest` POST 수동 호출 시 알림 수신 확인
- [ ] 실제 기기에서 종일 일정 / 시간 일정 / 캘린더 전용 일정이 의도대로 노출되는지 확인
