### PR TITLE
fix: use 종일 label for all-day events in daily digest notification

### DIFF
--- a/src/__tests__/api/push/daily-digest.test.ts
+++ b/src/__tests__/api/push/daily-digest.test.ts
@@ -281,7 +281,7 @@ describe('POST /api/cron/daily-digest', () => {
       setupHappyPath([ev])
       await POST(makeRequest())
       const body = JSON.parse(mockDispatch.mock.calls[0][1]).body as string
-      expect(body).toContain('하루종일')
+      expect(body).toContain('종일')
       expect(body).toContain('테스트 일정')
     })
 

--- a/src/app/api/cron/daily-digest/route.ts
+++ b/src/app/api/cron/daily-digest/route.ts
@@ -42,7 +42,7 @@ function buildBody(events: EventRow[]): string {
   const shown = sorted.slice(0, 5)
   const extra = sorted.length - shown.length
   const lines = shown.map((e) => {
-    const prefix = e.is_all_day ? '하루종일' : formatTime(e.start_at)
+    const prefix = e.is_all_day ? '종일' : formatTime(e.start_at)
     return `・${prefix}  ${e.title}`
   })
   if (extra > 0) lines.push(`외 ${extra}개 일정이 더 있어요`)


### PR DESCRIPTION
## Summary

- 오전 8시 데일리 다이제스트 알림에서 종일 일정 앞에 표시되는 레이블을 `하루종일` → `종일`로 수정

## Testing

- `daily-digest` 테스트 파일 내 `하루종일` assertion을 `종일`로 업데이트
- `npx jest daily-digest` 실행 결과 24개 테스트 모두 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)