### PR TITLE
fix: eliminate PWA launch orange bar and white screen flash

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -5,7 +5,7 @@
   "start_url": "/calendar",
   "display": "standalone",
   "background_color": "#fafaf9",
-  "theme_color": "#fb923c",
+  "theme_color": "#fafaf9",
   "orientation": "portrait",
   "icons": [
     {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from 'next'
 import { ThemeProvider } from 'next-themes'
 import { cookies } from 'next/headers'
 import { THEME_STORAGE_KEY } from '@/lib/preferences'
+import { PreHydrationSplash } from '@/components/PreHydrationSplash'
 import './globals.css'
 
 export const metadata: Metadata = {
@@ -55,8 +56,10 @@ export default async function RootLayout({
           rel="stylesheet"
           href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard-jp.min.css"
         />
+        <link rel="preload" href="/logo.webp" as="image" />
       </head>
       <body className="min-h-full flex flex-col bg-[var(--background)] text-[var(--foreground)]">
+        <PreHydrationSplash />
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
           {children}
         </ThemeProvider>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -57,6 +57,7 @@ export default async function RootLayout({
           href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard-jp.min.css"
         />
         <link rel="preload" href="/logo.webp" as="image" />
+        <style dangerouslySetInnerHTML={{ __html: `@media(prefers-color-scheme:dark){#koko-pre-splash{background:#0f0e0d}}` }} />
       </head>
       <body className="min-h-full flex flex-col bg-[var(--background)] text-[var(--foreground)]">
         <PreHydrationSplash />

--- a/src/components/PreHydrationSplash.tsx
+++ b/src/components/PreHydrationSplash.tsx
@@ -15,6 +15,7 @@ export function PreHydrationSplash() {
     <div
       role="status"
       aria-label="앱을 불러오는 중"
+      id="koko-pre-splash"
       className="fixed inset-0 z-[9999] flex items-center justify-center bg-[var(--background)]"
     >
       {/* next/image requires hydration; this splash must render before hydration */}

--- a/src/components/PreHydrationSplash.tsx
+++ b/src/components/PreHydrationSplash.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+export function PreHydrationSplash() {
+  const [hidden, setHidden] = useState(false)
+
+  useEffect(() => {
+    setHidden(true)
+  }, [])
+
+  if (hidden) return null
+
+  return (
+    <div
+      role="status"
+      aria-label="앱을 불러오는 중"
+      className="fixed inset-0 z-[9999] flex items-center justify-center bg-[var(--background)]"
+    >
+      {/* next/image requires hydration; this splash must render before hydration */}
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src="/logo.webp"
+        alt=""
+        width={96}
+        height={96}
+        className="rounded-full bg-[var(--surface-overlay)] p-6 ring-1 ring-[var(--surface-ring)]"
+      />
+    </div>
+  )
+}

--- a/src/components/PreHydrationSplash.tsx
+++ b/src/components/PreHydrationSplash.tsx
@@ -1,18 +1,18 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useRef } from 'react'
 
 export function PreHydrationSplash() {
-  const [hidden, setHidden] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
-    setHidden(true)
+    const el = ref.current
+    if (el) el.style.display = 'none'
   }, [])
-
-  if (hidden) return null
 
   return (
     <div
+      ref={ref}
       role="status"
       aria-label="앱을 불러오는 중"
       id="koko-pre-splash"


### PR DESCRIPTION
## Summary

- `manifest.json` `theme_color`을 주황(`#fb923c`)에서 배경색(`#fafaf9`)으로 변경 — Android PWA 네이티브 스플래시 바의 주황 노출 제거
- `PreHydrationSplash` 컴포넌트 추가 — SSR HTML에 로고를 포함시켜 React JS 로드 전 빈 흰 화면을 덮고, 하이드레이션 완료 후 자동 제거
- `@media (prefers-color-scheme: dark)` 인라인 스타일 추가 — `next-themes`가 `.dark` 클래스를 붙이기 전에도 다크 모드 배경색이 올바르게 적용됨
- `layout.tsx` `<head>`에 `logo.webp` preload 링크 추가 — 스플래시 이미지가 즉시 사용 가능하도록

> **iOS 참고**: iOS 홈화면 웹앱의 네이티브 런치 화면은 `apple-touch-startup-image` 계열로 제어되며, 이번 변경만으로 iOS까지 완전히 해결된다고 보장하기 어렵습니다. 실기기 검증이 필요합니다.

## Testing

- [ ] Android PWA 첫 실행 시 주황 상단 바가 나타나지 않는지 확인
- [ ] Android PWA 첫 실행 시 흰 화면 플래시 없이 바로 로고가 보이는지 확인
- [ ] 다크 모드 콜드 스타트 시 어두운 배경의 스플래시가 보이는지 확인
- [ ] 로그인 → 캘린더 진입 플로우 정상 동작 확인
- [ ] iOS PWA 실기기 검증 (플랫폼 한계로 부분 개선일 수 있음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)