### PR TITLE
fix: use inline styles for pre-hydration splash

### DIFF
--- a/src/components/PreHydrationSplash.tsx
+++ b/src/components/PreHydrationSplash.tsx
@@ -16,7 +16,15 @@ export function PreHydrationSplash() {
       role="status"
       aria-label="앱을 불러오는 중"
       id="koko-pre-splash"
-      className="fixed inset-0 z-[9999] flex items-center justify-center bg-[var(--background)]"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 9999,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: '#fafaf9',
+      }}
     >
       {/* next/image requires hydration; this splash must render before hydration */}
       {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -25,7 +33,12 @@ export function PreHydrationSplash() {
         alt=""
         width={96}
         height={96}
-        className="rounded-full bg-[var(--surface-overlay)] p-6 ring-1 ring-[var(--surface-ring)]"
+        style={{
+          borderRadius: '9999px',
+          padding: '24px',
+          background: 'rgba(245,245,244,0.8)',
+          boxShadow: '0 0 0 1px rgba(0,0,0,0.05)',
+        }}
       />
     </div>
   )


### PR DESCRIPTION
## Summary

- `PreHydrationSplash`의 Tailwind 클래스를 인라인 스타일로 교체
- Tailwind 클래스는 외부 CSS 번들 로드 후에야 적용되어, 그 짧은 구간에 흰 화면이 노출됨
- 인라인 스타일은 HTML 파싱 즉시 적용되어 외부 CSS 없이도 로고가 화면을 덮음

## Testing

- [ ] PWA 첫 실행 시 흰 화면 플래시가 줄어들거나 없어지는지 확인
- [ ] 다크 모드 동작 정상 확인 (dark용 배경은 `<style>` 미디어 쿼리가 담당)
- [ ] 로그인 → 캘린더 진입 플로우 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)