### PR TITLE
fix: resolve iOS status bar regression and dark mode splash flash

### DIFF
--- a/src/__tests__/app/LayoutMetadata.test.tsx
+++ b/src/__tests__/app/LayoutMetadata.test.tsx
@@ -20,6 +20,14 @@ describe('RootLayout metadata', () => {
     ])
   })
 
+  it('viewport-fit cover를 설정한다', () => {
+    expect(viewport.viewportFit).toBe('cover')
+  })
+
+  it('iOS 상태바를 black-translucent로 설정한다', () => {
+    expect(metadata.appleWebApp).toMatchObject({ statusBarStyle: 'black-translucent' })
+  })
+
   it('고정 주황색 theme-color 메타를 남기지 않는다', () => {
     expect(metadata.other).toEqual({
       'mobile-web-app-capable': 'yes',

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
   manifest: '/manifest.json',
   appleWebApp: {
     capable: true,
-    statusBarStyle: 'default',
+    statusBarStyle: 'black-translucent',
     title: 'Koko',
   },
   other: {
@@ -20,15 +20,16 @@ export const metadata: Metadata = {
 }
 
 export const viewport: Viewport = {
+  viewportFit: 'cover',
   themeColor: [
     { media: '(prefers-color-scheme: light)', color: '#fafaf9' },
     { media: '(prefers-color-scheme: dark)', color: '#0f0e0d' },
   ],
 }
 
-// Prevents FOUC: localStorage takes priority; cookie is the SSR-safe fallback
-// Must run before first paint, so it lives in <head> as a blocking inline script
-const HEAD_SCRIPT = `(function(){var k='koko_theme';var ls=localStorage.getItem(k);if(ls){document.documentElement.setAttribute('data-theme',ls);return;}var m=document.cookie.match('(?:^|;)\\s*'+k+'=([^;]+)');if(m)document.documentElement.setAttribute('data-theme',m[1]);})();`
+// Applies accent theme and dark class before first paint to prevent FOUC.
+// next-themes stores dark/light preference under 'theme' key in localStorage.
+const HEAD_SCRIPT = `(function(){var de=document.documentElement;var k='koko_theme';var ls=localStorage.getItem(k);if(ls){de.setAttribute('data-theme',ls);}else{var m=document.cookie.match('(?:^|;)\\s*'+k+'=([^;]+)');if(m)de.setAttribute('data-theme',m[1]);}var t=localStorage.getItem('theme');var dark=(t==='dark')||(t!=='light'&&window.matchMedia('(prefers-color-scheme:dark)').matches);if(dark)de.classList.add('dark');})();`
 
 export default async function RootLayout({
   children,
@@ -57,7 +58,7 @@ export default async function RootLayout({
           href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard-jp.min.css"
         />
         <link rel="preload" href="/logo.webp" as="image" />
-        <style dangerouslySetInnerHTML={{ __html: `@media(prefers-color-scheme:dark){#koko-pre-splash{background:#0f0e0d}}` }} />
+        <style dangerouslySetInnerHTML={{ __html: `#koko-pre-splash{background:#fafaf9}@media(prefers-color-scheme:dark){#koko-pre-splash{background:#0f0e0d}}.dark #koko-pre-splash{background:#0f0e0d}#koko-pre-splash-logo{background:rgba(245,245,244,0.8)}@media(prefers-color-scheme:dark){#koko-pre-splash-logo{background:rgba(255,255,255,0.1)}}.dark #koko-pre-splash-logo{background:rgba(255,255,255,0.1)}` }} />
       </head>
       <body className="min-h-full flex flex-col bg-[var(--background)] text-[var(--foreground)]">
         <PreHydrationSplash />

--- a/src/components/PreHydrationSplash.tsx
+++ b/src/components/PreHydrationSplash.tsx
@@ -23,23 +23,16 @@ export function PreHydrationSplash() {
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        background: '#fafaf9',
       }}
     >
-      {/* next/image requires hydration; this splash must render before hydration */}
-      {/* eslint-disable-next-line @next/next/no-img-element */}
-      <img
-        src="/logo.webp"
-        alt=""
-        width={96}
-        height={96}
-        style={{
-          borderRadius: '9999px',
-          padding: '24px',
-          background: 'rgba(245,245,244,0.8)',
-          boxShadow: '0 0 0 1px rgba(0,0,0,0.05)',
-        }}
-      />
+      <div
+        id="koko-pre-splash-logo"
+        style={{ borderRadius: '9999px', padding: '24px', boxShadow: '0 0 0 1px rgba(0,0,0,0.05)' }}
+      >
+        {/* next/image requires hydration; this splash must render before hydration */}
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img src="/logo.webp" alt="" width={96} height={96} />
+      </div>
     </div>
   )
 }

--- a/src/components/TabsShell.tsx
+++ b/src/components/TabsShell.tsx
@@ -106,7 +106,7 @@ export function TabsShell() {
   }
 
   return (
-    <div className="flex flex-col overflow-hidden" style={{ height: '100dvh' }}>
+    <div className="flex flex-col overflow-hidden" style={{ height: '100dvh', paddingTop: 'env(safe-area-inset-top, 0px)' }}>
       <div className="flex-1 min-h-0 relative">
         <div className={`absolute inset-0 flex flex-col min-h-0 overflow-hidden${activeTab !== 'calendar' ? ' hidden' : ''}`}>
           <CalendarTab

--- a/src/components/TabsShell.tsx
+++ b/src/components/TabsShell.tsx
@@ -106,7 +106,7 @@ export function TabsShell() {
   }
 
   return (
-    <div className="flex flex-col overflow-hidden" style={{ height: '100dvh', paddingTop: 'env(safe-area-inset-top, 0px)' }}>
+    <div className="flex flex-col overflow-hidden" style={{ height: '100dvh', boxSizing: 'border-box', paddingTop: 'env(safe-area-inset-top, 0px)' }}>
       <div className="flex-1 min-h-0 relative">
         <div className={`absolute inset-0 flex flex-col min-h-0 overflow-hidden${activeTab !== 'calendar' ? ' hidden' : ''}`}>
           <CalendarTab


### PR DESCRIPTION
## Summary

- `statusBarStyle` `default` → `black-translucent`으로 변경: 다크모드에서 iOS 상태바가 흰색 줄로 표시되던 회귀 수정
- `viewportFit: 'cover'` 추가: 콘텐츠가 상태바 뒤까지 채워지도록 설정
- HEAD_SCRIPT 확장: next-themes의 dark/light 설정(`theme` 키)을 첫 렌더 전에 읽어 `.dark` 클래스 적용 → OS는 라이트이지만 앱이 다크모드일 때 흰 플래시 방지
- `PreHydrationSplash` background를 inline style에서 `<style>` 태그 CSS로 이동: inline style은 `@media` 및 `.dark` 규칙으로 덮을 수 없었음 (specificity 문제)
- `TabsShell` 외부 컨테이너에 `env(safe-area-inset-top, 0px)` padding 추가: 투명 상태바에 탭 콘텐츠가 가려지지 않도록

## Root Causes

| 문제 | 원인 |
| --- | --- |
| iOS 상태바 흰색 줄 | `statusBarStyle: 'default'` — OS 기본값(흰색) 사용 |
| 다크모드에서 흰 스플래시 | `background: '#fafaf9'` 가 inline style → CSS override 불가 |
| OS 라이트 + 앱 다크 조합에서 플래시 | HEAD_SCRIPT가 accent 테마만 감지, 다크모드 `.dark` 클래스 미적용 |

## Testing

- [ ] iOS PWA 홈화면에서 앱 기동 시 상태바 영역이 검게 표시되는지 확인
- [ ] 다크모드(앱 설정) + OS 라이트모드 조합에서 첫 기동 시 흰 플래시 없는지 확인
- [ ] 라이트모드에서 탭 콘텐츠가 상태바 아래 정상 시작되는지 확인
- `npm run test -- --testPathPatterns=LayoutMetadata` 통과 확인

🤖 Generated with [Claude Code](https://claude.ai/claude-code)