### PR TITLE
fix: open native date picker on desktop via showPicker()

### DIFF
--- a/src/__tests__/components/EventFormModal.test.tsx
+++ b/src/__tests__/components/EventFormModal.test.tsx
@@ -207,6 +207,33 @@ describe('EventFormModal', () => {
     expect(screen.getAllByText(/2026\/03\/31\(화\)/).length).toBeGreaterThan(0)
   })
 
+  it('날짜 버튼 클릭 시 showPicker()를 호출한다', () => {
+    render(<EventFormModal {...defaultProps} initialDate={new Date('2026-03-31')} />)
+    const dateInputs = document.querySelectorAll('input[type="date"]')
+    const showPickerMock = jest.fn()
+    ;(dateInputs[0] as HTMLInputElement).showPicker = showPickerMock
+    ;(dateInputs[1] as HTMLInputElement).showPicker = showPickerMock
+
+    const dateBtns = document.querySelectorAll('input[type="date"]')
+    fireEvent.click(dateBtns[0].parentElement!)
+    fireEvent.click(dateBtns[1].parentElement!)
+
+    expect(showPickerMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('showPicker()가 없는 브라우저에서 날짜 버튼 클릭 시 예외가 발생하지 않는다', () => {
+    render(<EventFormModal {...defaultProps} initialDate={new Date('2026-03-31')} />)
+    const dateInputs = document.querySelectorAll('input[type="date"]')
+    // showPicker 메서드가 없는 환경 시뮬레이션
+    Object.defineProperty(dateInputs[0], 'showPicker', { value: undefined, configurable: true })
+    Object.defineProperty(dateInputs[1], 'showPicker', { value: undefined, configurable: true })
+
+    expect(() => {
+      fireEvent.click(dateInputs[0].parentElement!)
+      fireEvent.click(dateInputs[1].parentElement!)
+    }).not.toThrow()
+  })
+
   it('시간 버튼 클릭 시 wheel picker가 나타난다', () => {
     render(<EventFormModal {...defaultProps} />)
     // 종일 해제

--- a/src/components/calendar/EventFormModal.tsx
+++ b/src/components/calendar/EventFormModal.tsx
@@ -124,6 +124,8 @@ export function EventFormModal({
   const canEditOccurrenceDate = !isScopedRecurringEdit
 
   const titleInputRef = useRef<HTMLInputElement>(null)
+  const startDateInputRef = useRef<HTMLInputElement>(null)
+  const endDateInputRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -380,9 +382,13 @@ export function EventFormModal({
           <div>
             <label className="text-xs text-stone-500 mb-1.5 block">시작</label>
             <div className="flex gap-2">
-              <div className={`${isAllDay ? '' : 'flex-1 '}${dateBtnCls}`}>
+              <div
+                className={`${isAllDay ? '' : 'flex-1 '}${dateBtnCls}`}
+                onClick={() => { if (canEditOccurrenceDate) startDateInputRef.current?.showPicker() }}
+              >
                 <span className="relative z-10 pointer-events-none">{formatDateWithDOW(startDate)}</span>
                 <input
+                  ref={startDateInputRef}
                   type="date"
                   value={startDate}
                   disabled={!canEditOccurrenceDate}
@@ -414,9 +420,13 @@ export function EventFormModal({
           <div className={endShake ? 'shake' : ''}>
             <label className="text-xs text-stone-500 mb-1.5 block">종료</label>
             <div className="flex gap-2">
-              <div className={`${isAllDay ? '' : 'flex-1 '}${dateBtnCls}`}>
+              <div
+                className={`${isAllDay ? '' : 'flex-1 '}${dateBtnCls}`}
+                onClick={() => { if (canEditOccurrenceDate) endDateInputRef.current?.showPicker() }}
+              >
                 <span className="relative z-10 pointer-events-none">{formatDateWithDOW(endDate)}</span>
                 <input
+                  ref={endDateInputRef}
                   type="date"
                   value={endDate}
                   disabled={!canEditOccurrenceDate}

--- a/src/components/calendar/EventFormModal.tsx
+++ b/src/components/calendar/EventFormModal.tsx
@@ -384,7 +384,7 @@ export function EventFormModal({
             <div className="flex gap-2">
               <div
                 className={`${isAllDay ? '' : 'flex-1 '}${dateBtnCls}`}
-                onClick={() => { if (canEditOccurrenceDate) startDateInputRef.current?.showPicker() }}
+                onClick={() => { if (canEditOccurrenceDate) startDateInputRef.current?.showPicker?.() }}
               >
                 <span className="relative z-10 pointer-events-none">{formatDateWithDOW(startDate)}</span>
                 <input
@@ -422,7 +422,7 @@ export function EventFormModal({
             <div className="flex gap-2">
               <div
                 className={`${isAllDay ? '' : 'flex-1 '}${dateBtnCls}`}
-                onClick={() => { if (canEditOccurrenceDate) endDateInputRef.current?.showPicker() }}
+                onClick={() => { if (canEditOccurrenceDate) endDateInputRef.current?.showPicker?.() }}
               >
                 <span className="relative z-10 pointer-events-none">{formatDateWithDOW(endDate)}</span>
                 <input


### PR DESCRIPTION
## Summary

- On desktop browsers, clicking an \`opacity-0\` date input overlay does not reliably open the native date picker (browser requires a click on the calendar icon, not the full input area)
- Added \`startDateInputRef\` and \`endDateInputRef\` refs to the two hidden date inputs
- Added \`onClick\` on each container div that calls \`inputRef.current?.showPicker?.()\` when \`canEditOccurrenceDate\` is true
- Used \`?.showPicker?.()\` double optional chaining to silently no-op on browsers without \`showPicker\` support (iOS Safari, Safari < 17.4) instead of throwing TypeError
- Mobile behavior is unchanged — the touch path already worked via the native date selector

## Testing

- [ ] Desktop: 종일 ON → 시작/종료 날짜 버튼 클릭 시 네이티브 날짜 피커 열림
- [ ] Desktop: 종일 OFF → 시작/종료 날짜 버튼 클릭 시 네이티브 날짜 피커 열림
- [ ] Mobile: 시작/종료 날짜 버튼 터치 시 기존과 동일하게 동작
- [ ] 반복 일정 편집(scoped) 시 날짜 버튼 비활성 유지
- [ ] 23 existing + new EventFormModal tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)