### PR TITLE
fix: apply calendar filter to DayEventsSheet

### DIFF
--- a/src/components/tabs/CalendarTab.tsx
+++ b/src/components/tabs/CalendarTab.tsx
@@ -787,7 +787,7 @@ export function CalendarTab({
       {selectedDate && !selectedEvent && !editingEvent && !calendarForm && (
         <DayEventsSheet
           date={selectedDate}
-          events={mergedEvents}
+          events={mergedEvents.filter((e) => activeIds.size === 0 || !e.calendar_id || activeIds.has(e.calendar_id))}
           calendars={calendars}
           onClose={() => setSelectedDate(null)}
           onSelectEvent={setSelectedEvent}

--- a/src/components/tabs/CalendarTab.tsx
+++ b/src/components/tabs/CalendarTab.tsx
@@ -298,6 +298,11 @@ export function CalendarTab({
     return [...events, ...adjacentMonthEvents.filter((e) => !seen.has(e.id))]
   }, [events, adjacentMonthEvents])
 
+  const filteredEvents = useMemo(
+    () => mergedEvents.filter((e) => activeIds.size === 0 || !e.calendar_id || activeIds.has(e.calendar_id)),
+    [mergedEvents, activeIds]
+  )
+
   const reloadEvents = useCallback(async () => {
     if (!familyId) return
     await loadMonthEvents({
@@ -787,7 +792,7 @@ export function CalendarTab({
       {selectedDate && !selectedEvent && !editingEvent && !calendarForm && (
         <DayEventsSheet
           date={selectedDate}
-          events={mergedEvents.filter((e) => activeIds.size === 0 || !e.calendar_id || activeIds.has(e.calendar_id))}
+          events={filteredEvents}
           calendars={calendars}
           onClose={() => setSelectedDate(null)}
           onSelectEvent={setSelectedEvent}


### PR DESCRIPTION
## Summary

- 캘린더 필터(좌상단)에서 일부 캘린더만 선택한 상태에서 날짜를 클릭해도 DayEventsSheet 모달에 필터가 적용되지 않아 모든 캘린더 일정이 표시되는 버그 수정
- `mergedEvents` 전체를 그대로 전달하던 것을 `activeIds` 기반으로 필터링된 이벤트만 전달하도록 변경
- 필터 로직을 JSX 인라인 대신 `useMemo`로 추출하여 불필요한 배열 재생성 방지 (`CalendarGrid`의 기존 패턴과 일치)

## Testing

- [ ] JGBB만 선택 시 날짜 클릭 모달에 JGBB 일정만 표시되는지 확인
- [ ] 전체 선택(필터 없음) 시 모든 캘린더 일정이 표시되는지 확인
- [ ] 캘린더 그리드와 DayEventsSheet의 표시 일정이 일치하는지 확인

`npx tsc --noEmit` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)