### PR TITLE
feat: persist calendar filter selection across app restarts

### DIFF
--- a/src/__tests__/components/CalendarTab.test.tsx
+++ b/src/__tests__/components/CalendarTab.test.tsx
@@ -472,14 +472,35 @@ describe('CalendarTab — 캘린더 필터 localStorage 복원', () => {
     expect(saved).toEqual(['cal-1'])
   })
 
-  it('더 이상 존재하지 않는 캘린더 ID는 필터링된다', async () => {
+  it('더 이상 존재하지 않는 캘린더 ID는 필터링되고 유효 ID는 보존된다', async () => {
     localStorage.setItem('koko_calendar_filter_fam-1', JSON.stringify(['cal-1', 'cal-deleted']))
 
     render(<CalendarTab {...defaultProps} />)
     await act(async () => {})
 
     const saved = JSON.parse(localStorage.getItem('koko_calendar_filter_fam-1') ?? '[]') as string[]
-    expect(saved).not.toContain('cal-deleted')
+    expect(saved).toEqual(['cal-1'])
+  })
+
+  it('가족 전환 시 이전 가족의 필터가 새 가족 키에 저장되지 않는다', async () => {
+    const familyACalendars = [{ id: 'cal-a', family_id: 'fam-a', created_by: 'user-1', name: 'A캘린더', color: '#f97316', created_at: '', updated_at: '' }]
+    const familyBCalendars = [{ id: 'cal-b', family_id: 'fam-b', created_by: 'user-1', name: 'B캘린더', color: '#3b82f6', created_at: '', updated_at: '' }]
+
+    localStorage.setItem('koko_calendar_filter_fam-a', JSON.stringify(['cal-a']))
+
+    const { rerender } = render(
+      <CalendarTab {...defaultProps} familyId="fam-a" calendars={familyACalendars} />
+    )
+    await act(async () => {})
+
+    rerender(
+      <CalendarTab {...defaultProps} familyId="fam-b" calendars={familyBCalendars} />
+    )
+    await act(async () => {})
+
+    const savedB = JSON.parse(localStorage.getItem('koko_calendar_filter_fam-b') ?? 'null') as string[] | null
+    expect(savedB).not.toContain('cal-a')
+    expect(savedB).toEqual([])
   })
 })
 

--- a/src/__tests__/components/CalendarTab.test.tsx
+++ b/src/__tests__/components/CalendarTab.test.tsx
@@ -435,6 +435,54 @@ describe('CalendarTab — touch-action 스크롤 차단', () => {
   })
 })
 
+describe('CalendarTab — 캘린더 필터 localStorage 복원', () => {
+  let consoleErrorSpy: jest.SpyInstance
+
+  beforeAll(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterAll(() => {
+    consoleErrorSpy.mockRestore()
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    localStorage.clear()
+    mockGetEventsByMonth.mockResolvedValue([])
+    mockGetFamilyMembers.mockResolvedValue([])
+    mockGetCalendarMembers.mockResolvedValue([])
+  })
+
+  it('저장된 값이 없으면 전체 선택 상태(빈 배열)를 저장한다', async () => {
+    render(<CalendarTab {...defaultProps} />)
+    await act(async () => {})
+
+    const saved = JSON.parse(localStorage.getItem('koko_calendar_filter_fam-1') ?? 'null') as string[] | null
+    expect(saved).toEqual([])
+  })
+
+  it('저장된 필터 ID를 복원하고 localStorage에 저장한다', async () => {
+    localStorage.setItem('koko_calendar_filter_fam-1', JSON.stringify(['cal-1']))
+
+    render(<CalendarTab {...defaultProps} />)
+    await act(async () => {})
+
+    const saved = JSON.parse(localStorage.getItem('koko_calendar_filter_fam-1') ?? '[]') as string[]
+    expect(saved).toEqual(['cal-1'])
+  })
+
+  it('더 이상 존재하지 않는 캘린더 ID는 필터링된다', async () => {
+    localStorage.setItem('koko_calendar_filter_fam-1', JSON.stringify(['cal-1', 'cal-deleted']))
+
+    render(<CalendarTab {...defaultProps} />)
+    await act(async () => {})
+
+    const saved = JSON.parse(localStorage.getItem('koko_calendar_filter_fam-1') ?? '[]') as string[]
+    expect(saved).not.toContain('cal-deleted')
+  })
+})
+
 describe('CalendarTab — handleCalendarUpdate', () => {
   let consoleErrorSpy: jest.SpyInstance
 

--- a/src/components/tabs/CalendarTab.tsx
+++ b/src/components/tabs/CalendarTab.tsx
@@ -283,14 +283,18 @@ export function CalendarTab({
   useEffect(() => {
     if (!familyId || calendars.length === 0) return
     if (filterInitializedForRef.current === familyId) return
-    filterInitializedForRef.current = familyId
 
     const stored = readStoredFilter(familyId)
-    if (stored === null) return
-
     const calendarIdSet = new Set(calendars.map((c) => c.id))
-    const validIds = new Set([...stored].filter((id) => calendarIdSet.has(id)))
-    queueMicrotask(() => setActiveIds(validIds))
+    const validIds = stored
+      ? new Set([...stored].filter((id) => calendarIdSet.has(id)))
+      : new Set<string>()
+    const targetFamilyId = familyId
+
+    queueMicrotask(() => {
+      filterInitializedForRef.current = targetFamilyId
+      setActiveIds(validIds)
+    })
   }, [familyId, calendars])
 
   useEffect(() => {

--- a/src/components/tabs/CalendarTab.tsx
+++ b/src/components/tabs/CalendarTab.tsx
@@ -290,7 +290,7 @@ export function CalendarTab({
 
     const calendarIdSet = new Set(calendars.map((c) => c.id))
     const validIds = new Set([...stored].filter((id) => calendarIdSet.has(id)))
-    setActiveIds(validIds)
+    queueMicrotask(() => setActiveIds(validIds))
   }, [familyId, calendars])
 
   useEffect(() => {

--- a/src/components/tabs/CalendarTab.tsx
+++ b/src/components/tabs/CalendarTab.tsx
@@ -48,6 +48,28 @@ function getMonthEventsKey(familyId: string, year: number, month: number) {
   return `${familyId}:${year}:${month}`
 }
 
+function calendarFilterKey(familyId: string) {
+  return `koko_calendar_filter_${familyId}`
+}
+
+function readStoredFilter(familyId: string): Set<string> | null {
+  try {
+    const raw = localStorage.getItem(calendarFilterKey(familyId))
+    if (!raw) return null
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return null
+    return new Set(parsed as string[])
+  } catch {
+    return null
+  }
+}
+
+function saveStoredFilter(familyId: string, ids: Set<string>) {
+  try {
+    localStorage.setItem(calendarFilterKey(familyId), JSON.stringify([...ids]))
+  } catch {}
+}
+
 function getAdjacentMonth(year: number, month: number, delta: -1 | 1) {
   if (delta === -1) {
     return month === 0
@@ -89,6 +111,7 @@ export function CalendarTab({
 
   const containerRef = useRef<HTMLDivElement>(null)
   const yearMonthButtonRef = useRef<HTMLButtonElement>(null)
+  const filterInitializedForRef = useRef<string | null>(null)
 
   const [slideKey, setSlideKey] = useState(0)
   const [slideDir, setSlideDir] = useState<'left' | 'right' | null>(null)
@@ -256,6 +279,24 @@ export function CalendarTab({
       return []
     }
   }, [fetchMonthEvents, prefetchAdjacentMonths, syncAdjacentFromCache])
+
+  useEffect(() => {
+    if (!familyId || calendars.length === 0) return
+    if (filterInitializedForRef.current === familyId) return
+    filterInitializedForRef.current = familyId
+
+    const stored = readStoredFilter(familyId)
+    if (stored === null) return
+
+    const calendarIdSet = new Set(calendars.map((c) => c.id))
+    const validIds = new Set([...stored].filter((id) => calendarIdSet.has(id)))
+    setActiveIds(validIds)
+  }, [familyId, calendars])
+
+  useEffect(() => {
+    if (!familyId || filterInitializedForRef.current !== familyId) return
+    saveStoredFilter(familyId, activeIds)
+  }, [familyId, activeIds])
 
   useEffect(() => {
     visibleMonthKeyRef.current = familyId ? getMonthEventsKey(familyId, year, month) : null


### PR DESCRIPTION
## Summary

- 앱을 껐다 켜도 이전에 선택했던 캘린더 필터 상태가 복원됩니다
- 선택된 캘린더 ID를 `koko_calendar_filter_{familyId}` 키로 localStorage에 저장합니다
- 앱 재시작 시 저장된 ID 중 삭제된 캘린더는 자동으로 걸러냅니다
- 가족 전환 시 이전 가족의 필터 상태가 새 가족 키에 저장되지 않습니다 (`filterInitializedForRef` 설정을 `queueMicrotask` 안으로 이동해 save effect 실행 순서 문제 해결)

## Testing

- [x] 단위 테스트 4개 추가 (`CalendarTab — 캘린더 필터 localStorage 복원`)
  - 저장된 값이 없을 때 전체 선택(빈 배열) 저장 확인
  - 저장된 ID 복원 확인
  - 삭제된 캘린더 ID 필터링 및 유효 ID 보존 확인
  - 가족 전환 시 이전 가족 필터가 새 가족 키에 저장되지 않는 것 확인
- [x] `npx tsc --noEmit` 통과
- [x] 전체 테스트 통과
- [x] lint error 0

## Manual Verification

- [ ] 캘린더 필터에서 일부 그룹만 선택한 뒤 앱 종료 후 재시작 시 선택 상태 복원 확인
- [ ] 전체 선택 상태에서 앱 재시작 시 전체 선택 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)