### PR TITLE
polish: anchor calendar FAB to content area

### DIFF
--- a/src/__tests__/components/CalendarTab.test.tsx
+++ b/src/__tests__/components/CalendarTab.test.tsx
@@ -289,6 +289,19 @@ describe('CalendarTab — touch-action 스크롤 차단', () => {
     expect(wrapper.style.touchAction).toBe('none')
   })
 
+  it('일정 추가 FAB를 캘린더 콘텐츠 영역 하단에 배치한다', async () => {
+    const { container } = render(<CalendarTab {...defaultProps} />)
+    await act(async () => {})
+
+    const wrapper = container.firstChild as HTMLElement
+    const addButton = screen.getByRole('button', { name: '일정 추가' })
+
+    expect(wrapper).toHaveClass('relative')
+    expect(addButton).toHaveClass('absolute', 'right-4', 'bottom-4')
+    expect(addButton).not.toHaveClass('fixed', 'calendar-fab')
+    expect(addButton).not.toHaveAttribute('style')
+  })
+
   it('초기 이벤트 로드 실패 시 전체 스피너 대신 오류 배너와 캘린더 그리드를 유지한다', async () => {
     mockGetEventsByMonth.mockRejectedValue(new Error('load failed'))
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -204,7 +204,3 @@ h1, h2, h3, h4, h5, h6 {
   -ms-overflow-style: none;
   scrollbar-width: none;
 }
-
-.calendar-fab {
-  bottom: calc(4.125rem + env(safe-area-inset-bottom, 0px) + 0.25rem);
-}

--- a/src/components/tabs/CalendarTab.tsx
+++ b/src/components/tabs/CalendarTab.tsx
@@ -733,7 +733,7 @@ export function CalendarTab({
   return (
     <div
       ref={containerRef}
-      className="w-full flex-1 min-h-0 flex flex-col bg-white dark:bg-stone-950 overflow-hidden"
+      className="relative w-full flex-1 min-h-0 flex flex-col bg-white dark:bg-stone-950 overflow-hidden"
       style={{ touchAction: isModalOpen ? 'auto' : 'none' }}
       onTouchStart={onTouchStart}
       onTouchEnd={onTouchEnd}
@@ -829,7 +829,7 @@ export function CalendarTab({
       <button
         aria-label="일정 추가"
         onClick={() => setEditingEvent({ date: selectedDate ?? today })}
-        className="calendar-fab fixed right-4 w-11 h-11 rounded-full bg-accent-400 hover:bg-accent-500 text-white shadow-lg flex items-center justify-center transition-colors z-30"
+        className="absolute right-4 bottom-4 w-11 h-11 rounded-full bg-accent-400 hover:bg-accent-500 text-white shadow-lg flex items-center justify-center transition-colors z-30"
       >
         <Plus size={18} />
       </button>


### PR DESCRIPTION
## Summary

- 일정 추가 FAB를 viewport fixed 배치에서 캘린더 콘텐츠 영역 absolute 배치로 변경
- 하단 네비 높이 계산용 `.calendar-fab` 전역 CSS 제거
- CalendarTab 테스트에 FAB positioning contract 추가

## Testing

- `npm run test -- --testPathPatterns=src/__tests__/components/CalendarTab.test.tsx`
- `npx tsc --noEmit`

## Manual visual verification:

- [ ] 모바일에서 일정 추가 FAB가 하단 네비게이션 바로 위 캘린더 영역 하단에 위치하는지 확인
- [ ] FAB가 마지막 달력 행 날짜 칸을 가리지 않는지 확인
- [ ] FAB 클릭 시 일정 추가 모달이 정상적으로 열리는지 확인