### PR TITLE
fix: make calendar chip limit responsive

### DIFF
--- a/src/__tests__/components/CalendarGrid.test.tsx
+++ b/src/__tests__/components/CalendarGrid.test.tsx
@@ -1,5 +1,12 @@
 import { render, screen, fireEvent } from '@testing-library/react'
-import { CalendarGrid, buildGrid, isMultiDayAllDay, isEventOnDate, computeSegments } from '@/components/calendar/CalendarGrid'
+import {
+  CalendarGrid,
+  buildGrid,
+  isMultiDayAllDay,
+  isEventOnDate,
+  computeSegments,
+  getVisibleSingleEventLimit,
+} from '@/components/calendar/CalendarGrid'
 import type { Calendar, CalendarEvent } from '@/lib/calendar'
 import type { Holiday } from '@/hooks/useHolidays'
 
@@ -272,6 +279,60 @@ describe('computeSegments', () => {
   })
 })
 
+// ── 동적 단일 일정 표시 개수 ─────────────────────────────────
+
+describe('getVisibleSingleEventLimit', () => {
+  const base = {
+    dateHeaderHeight: 28,
+    laneAreaHeight: 0,
+    holidayCount: 0,
+    hasHolidaysAndEvents: false,
+  }
+
+  it('측정 전에는 기존 3개 기준으로 안전하게 fallback 한다', () => {
+    expect(getVisibleSingleEventLimit({
+      ...base,
+      rowHeight: null,
+      singleEventCount: 5,
+    })).toBe(3)
+  })
+
+  it('셀 높이가 충분하면 고정 상한 없이 들어가는 만큼 표시한다', () => {
+    expect(getVisibleSingleEventLimit({
+      ...base,
+      rowHeight: 150,
+      singleEventCount: 6,
+    })).toBe(6)
+  })
+
+  it('넘치는 일정이 있으면 +N 표시 줄을 남겨둔다', () => {
+    expect(getVisibleSingleEventLimit({
+      ...base,
+      rowHeight: 118,
+      singleEventCount: 6,
+    })).toBe(4)
+  })
+
+  it('6주 월처럼 낮은 셀에서는 표시 개수를 줄여 overflow 줄까지 포함해 맞춘다', () => {
+    expect(getVisibleSingleEventLimit({
+      ...base,
+      rowHeight: 96,
+      singleEventCount: 5,
+    })).toBe(2)
+  })
+
+  it('음력, 멀티데이 lane, 공휴일이 있으면 남은 공간 기준으로 더 적게 표시한다', () => {
+    expect(getVisibleSingleEventLimit({
+      rowHeight: 118,
+      dateHeaderHeight: 40,
+      laneAreaHeight: 18,
+      holidayCount: 1,
+      hasHolidaysAndEvents: true,
+      singleEventCount: 4,
+    })).toBe(1)
+  })
+})
+
 // ── CalendarGrid 렌더링 ──────────────────────────────────────
 
 describe('CalendarGrid', () => {
@@ -478,8 +539,6 @@ describe('라벨 색상 우선순위', () => {
 // ── 칩 variant: allDay vs timed ──────────────────────────────
 
 describe('칩 variant', () => {
-  const color = '#f97316' // calendars[0].color
-
   it('is_all_day=true 단일 일정은 solid fill + white text로 렌더된다', () => {
     const event = makeEvent({ is_all_day: true, title: '종일일정' })
     render(<CalendarGrid {...defaultProps} events={[event]} />)

--- a/src/__tests__/components/CalendarGrid.test.tsx
+++ b/src/__tests__/components/CalendarGrid.test.tsx
@@ -1,11 +1,11 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import {
   CalendarGrid,
   buildGrid,
   isMultiDayAllDay,
   isEventOnDate,
   computeSegments,
-  getVisibleSingleEventLimit,
+  getSingleEventDisplayBudget,
 } from '@/components/calendar/CalendarGrid'
 import type { Calendar, CalendarEvent } from '@/lib/calendar'
 import type { Holiday } from '@/hooks/useHolidays'
@@ -281,7 +281,7 @@ describe('computeSegments', () => {
 
 // ── 동적 단일 일정 표시 개수 ─────────────────────────────────
 
-describe('getVisibleSingleEventLimit', () => {
+describe('getSingleEventDisplayBudget', () => {
   const base = {
     dateHeaderHeight: 28,
     laneAreaHeight: 0,
@@ -290,46 +290,57 @@ describe('getVisibleSingleEventLimit', () => {
   }
 
   it('측정 전에는 기존 3개 기준으로 안전하게 fallback 한다', () => {
-    expect(getVisibleSingleEventLimit({
+    expect(getSingleEventDisplayBudget({
       ...base,
       rowHeight: null,
       singleEventCount: 5,
-    })).toBe(3)
+    })).toEqual({ visibleCount: 3, showOverflow: true })
   })
 
   it('셀 높이가 충분하면 고정 상한 없이 들어가는 만큼 표시한다', () => {
-    expect(getVisibleSingleEventLimit({
+    expect(getSingleEventDisplayBudget({
       ...base,
       rowHeight: 150,
       singleEventCount: 6,
-    })).toBe(6)
+    })).toEqual({ visibleCount: 6, showOverflow: false })
   })
 
-  it('넘치는 일정이 있으면 +N 표시 줄을 남겨둔다', () => {
-    expect(getVisibleSingleEventLimit({
+  it('실제 chip gap과 cell chrome을 고려해 exact-fit 케이스를 보수적으로 줄인다', () => {
+    expect(getSingleEventDisplayBudget({
       ...base,
       rowHeight: 118,
-      singleEventCount: 6,
-    })).toBe(4)
+      singleEventCount: 5,
+    })).toEqual({ visibleCount: 3, showOverflow: true })
   })
 
   it('6주 월처럼 낮은 셀에서는 표시 개수를 줄여 overflow 줄까지 포함해 맞춘다', () => {
-    expect(getVisibleSingleEventLimit({
+    expect(getSingleEventDisplayBudget({
       ...base,
       rowHeight: 96,
       singleEventCount: 5,
-    })).toBe(2)
+    })).toEqual({ visibleCount: 2, showOverflow: true })
+  })
+
+  it('단일 일정 영역이 0줄이면 +N도 표시하지 않는다', () => {
+    expect(getSingleEventDisplayBudget({
+      rowHeight: 60,
+      dateHeaderHeight: 40,
+      laneAreaHeight: 18,
+      holidayCount: 1,
+      hasHolidaysAndEvents: true,
+      singleEventCount: 3,
+    })).toEqual({ visibleCount: 0, showOverflow: false })
   })
 
   it('음력, 멀티데이 lane, 공휴일이 있으면 남은 공간 기준으로 더 적게 표시한다', () => {
-    expect(getVisibleSingleEventLimit({
+    expect(getSingleEventDisplayBudget({
       rowHeight: 118,
       dateHeaderHeight: 40,
       laneAreaHeight: 18,
       holidayCount: 1,
       hasHolidaysAndEvents: true,
       singleEventCount: 4,
-    })).toBe(1)
+    })).toEqual({ visibleCount: 1, showOverflow: true })
   })
 })
 
@@ -338,6 +349,36 @@ describe('getVisibleSingleEventLimit', () => {
 describe('CalendarGrid', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+  })
+
+  it('측정된 셀 높이가 충분하면 렌더링에서도 3개 제한을 넘겨 표시한다', async () => {
+    const getBoundingClientRectSpy = jest
+      .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
+      .mockImplementation(function (this: HTMLElement) {
+        if (this.getAttribute('data-testid') === 'calendar-grid') {
+          return { width: 390, height: 778, top: 0, left: 0, right: 390, bottom: 778, x: 0, y: 0, toJSON: () => ({}) } as DOMRect
+        }
+        if (this.className === 'grid grid-cols-7') {
+          return { width: 390, height: 28, top: 0, left: 0, right: 390, bottom: 28, x: 0, y: 0, toJSON: () => ({}) } as DOMRect
+        }
+        return { width: 0, height: 0, top: 0, left: 0, right: 0, bottom: 0, x: 0, y: 0, toJSON: () => ({}) } as DOMRect
+      })
+    const events = Array.from({ length: 6 }, (_, i) => makeEvent({
+      id: `evt-dynamic-${i}`,
+      title: `동적일정${i + 1}`,
+      start_at: '2025-06-15T10:00:00Z',
+    }))
+
+    try {
+      render(<CalendarGrid {...defaultProps} events={events} />)
+
+      await waitFor(() => {
+        expect(screen.getByText('동적일정6')).toBeInTheDocument()
+      })
+      expect(screen.queryByText('+3')).not.toBeInTheDocument()
+    } finally {
+      getBoundingClientRectSpy.mockRestore()
+    }
   })
 
   it('날짜 클릭 시 onSelectDate가 호출된다', () => {

--- a/src/components/calendar/CalendarGrid.tsx
+++ b/src/components/calendar/CalendarGrid.tsx
@@ -11,8 +11,9 @@ const DATE_HEADER_HEIGHT = 28  // px – date circle (h-6=24) + mb-0.5 (2) + bor
 const LUNAR_DATE_HEIGHT = 12   // px – text-[9px] leading-tight (9 × 1.25 ≈ 12)
 const LANE_HEIGHT = 18         // px – bar (16) + gap (2)
 const WEEKDAY_HEADER_HEIGHT = 28
-const SINGLE_EVENT_LINE_HEIGHT = 18
-const HOLIDAY_LINE_HEIGHT = 18
+const CELL_VERTICAL_CHROME = 5 // p-0.5 top/bottom + border-t
+const CHIP_HEIGHT = 17        // text-[10px] leading-tight + py-0.5
+const CHIP_GAP = 2            // space-y-0.5
 const HOLIDAY_EVENT_GAP = 2
 
 interface DayCell {
@@ -74,7 +75,7 @@ function getChipStyle(isAllDay: boolean, color: string): CSSProperties {
   return { backgroundColor: color + '26', color }
 }
 
-export function getVisibleSingleEventLimit({
+export function getSingleEventDisplayBudget({
   rowHeight,
   dateHeaderHeight,
   laneAreaHeight,
@@ -88,23 +89,32 @@ export function getVisibleSingleEventLimit({
   holidayCount: number
   hasHolidaysAndEvents: boolean
   singleEventCount: number
-}): number {
-  if (singleEventCount <= 0) return 0
-  if (rowHeight === null || rowHeight <= 0) return Math.min(3, singleEventCount)
+}): { visibleCount: number; showOverflow: boolean } {
+  if (singleEventCount <= 0) return { visibleCount: 0, showOverflow: false }
+  if (rowHeight === null || rowHeight <= 0) {
+    const visibleCount = Math.min(3, singleEventCount)
+    return { visibleCount, showOverflow: singleEventCount > visibleCount }
+  }
 
   const reservedHeight =
+    CELL_VERTICAL_CHROME +
     dateHeaderHeight +
     laneAreaHeight +
-    holidayCount * HOLIDAY_LINE_HEIGHT +
+    holidayCount * CHIP_HEIGHT +
+    Math.max(0, holidayCount - 1) * CHIP_GAP +
     (hasHolidaysAndEvents ? HOLIDAY_EVENT_GAP : 0)
   const availableHeight = Math.max(0, rowHeight - reservedHeight)
-  const availableLines = Math.floor(availableHeight / SINGLE_EVENT_LINE_HEIGHT)
+  const availableLines = availableHeight >= CHIP_HEIGHT
+    ? Math.floor((availableHeight + CHIP_GAP) / (CHIP_HEIGHT + CHIP_GAP))
+    : 0
 
-  if (availableLines <= 0) return 0
-  if (singleEventCount <= availableLines) return singleEventCount
+  if (availableLines <= 0) return { visibleCount: 0, showOverflow: false }
+  if (singleEventCount <= availableLines) {
+    return { visibleCount: singleEventCount, showOverflow: false }
+  }
 
   // Leave one visible line for the "+N" overflow indicator.
-  return Math.max(0, availableLines - 1)
+  return { visibleCount: Math.max(0, availableLines - 1), showOverflow: true }
 }
 
 interface EventSegment {
@@ -301,6 +311,7 @@ export function CalendarGrid({
   return (
     <div
       ref={gridRef}
+      data-testid="calendar-grid"
       className={`w-full grid ${className ?? ''}`}
       style={{ gridTemplateRows: `auto repeat(${rows.length}, minmax(0, 1fr))`, height: '100%' }}
     >
@@ -339,7 +350,7 @@ export function CalendarGrid({
                   const isSun = dow === 0
                   const isSat = dow === 6
                   const hasHolidaysAndEvents = dayHolidays.length > 0 && daySingleEvents.length > 0
-                  const visibleSingleEventLimit = getVisibleSingleEventLimit({
+                  const singleEventDisplay = getSingleEventDisplayBudget({
                     rowHeight,
                     dateHeaderHeight: effectiveDateHeaderHeight,
                     laneAreaHeight,
@@ -347,7 +358,7 @@ export function CalendarGrid({
                     hasHolidaysAndEvents,
                     singleEventCount: daySingleEvents.length,
                   })
-                  const visibleSingleEvents = daySingleEvents.slice(0, visibleSingleEventLimit)
+                  const visibleSingleEvents = daySingleEvents.slice(0, singleEventDisplay.visibleCount)
                   const hiddenSingleEventCount = daySingleEvents.length - visibleSingleEvents.length
 
                   return (
@@ -428,7 +439,7 @@ export function CalendarGrid({
                             </div>
                           )
                         })}
-                        {hiddenSingleEventCount > 0 && (
+                        {singleEventDisplay.showOverflow && hiddenSingleEventCount > 0 && (
                           <div className="text-[10px] text-stone-500 dark:text-stone-400 font-medium px-1">
                             +{hiddenSingleEventCount}
                           </div>

--- a/src/components/calendar/CalendarGrid.tsx
+++ b/src/components/calendar/CalendarGrid.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { type CSSProperties, useMemo } from 'react'
+import { type CSSProperties, useEffect, useMemo, useRef, useState } from 'react'
 import KoreanLunarCalendar from 'korean-lunar-calendar'
 import type { Calendar, CalendarEvent } from '@/lib/calendar'
 import { toDisplayColor } from '@/lib/label-colors'
@@ -10,6 +10,10 @@ const DOW = ['일', '월', '화', '수', '목', '금', '토']
 const DATE_HEADER_HEIGHT = 28  // px – date circle (h-6=24) + mb-0.5 (2) + border (1) ≈ 28
 const LUNAR_DATE_HEIGHT = 12   // px – text-[9px] leading-tight (9 × 1.25 ≈ 12)
 const LANE_HEIGHT = 18         // px – bar (16) + gap (2)
+const WEEKDAY_HEADER_HEIGHT = 28
+const SINGLE_EVENT_LINE_HEIGHT = 18
+const HOLIDAY_LINE_HEIGHT = 18
+const HOLIDAY_EVENT_GAP = 2
 
 interface DayCell {
   date: Date
@@ -68,6 +72,39 @@ export function isEventOnDate(event: CalendarEvent, date: Date): boolean {
 function getChipStyle(isAllDay: boolean, color: string): CSSProperties {
   if (isAllDay) return { backgroundColor: color }
   return { backgroundColor: color + '26', color }
+}
+
+export function getVisibleSingleEventLimit({
+  rowHeight,
+  dateHeaderHeight,
+  laneAreaHeight,
+  holidayCount,
+  hasHolidaysAndEvents,
+  singleEventCount,
+}: {
+  rowHeight: number | null
+  dateHeaderHeight: number
+  laneAreaHeight: number
+  holidayCount: number
+  hasHolidaysAndEvents: boolean
+  singleEventCount: number
+}): number {
+  if (singleEventCount <= 0) return 0
+  if (rowHeight === null || rowHeight <= 0) return Math.min(3, singleEventCount)
+
+  const reservedHeight =
+    dateHeaderHeight +
+    laneAreaHeight +
+    holidayCount * HOLIDAY_LINE_HEIGHT +
+    (hasHolidaysAndEvents ? HOLIDAY_EVENT_GAP : 0)
+  const availableHeight = Math.max(0, rowHeight - reservedHeight)
+  const availableLines = Math.floor(availableHeight / SINGLE_EVENT_LINE_HEIGHT)
+
+  if (availableLines <= 0) return 0
+  if (singleEventCount <= availableLines) return singleEventCount
+
+  // Leave one visible line for the "+N" overflow indicator.
+  return Math.max(0, availableLines - 1)
 }
 
 interface EventSegment {
@@ -155,6 +192,12 @@ export function CalendarGrid({
   year, month, events, calendars, activeIds,
   holidays = [], selectedDate, onSelectDate, showLunar = false, className,
 }: Props) {
+  const gridRef = useRef<HTMLDivElement>(null)
+  const weekdayHeaderRef = useRef<HTMLDivElement>(null)
+  const [gridMetrics, setGridMetrics] = useState({
+    height: 0,
+    weekdayHeaderHeight: WEEKDAY_HEADER_HEIGHT,
+  })
   const cells = useMemo(() => buildGrid(year, month), [year, month])
   const today = useMemo(() => new Date(), [])
   const calendarMap = useMemo(() => new Map(calendars.map((c) => [c.id, c])), [calendars])
@@ -221,14 +264,48 @@ export function CalendarGrid({
   }, [cells])
 
   const effectiveDateHeaderHeight = DATE_HEADER_HEIGHT + (showLunar ? LUNAR_DATE_HEIGHT : 0)
+  const rowHeight = gridMetrics.height > 0
+    ? Math.max(0, (gridMetrics.height - gridMetrics.weekdayHeaderHeight) / rows.length)
+    : null
+
+  useEffect(() => {
+    const measure = () => {
+      const height = gridRef.current?.getBoundingClientRect().height ?? 0
+      const weekdayHeaderHeight =
+        weekdayHeaderRef.current?.getBoundingClientRect().height || WEEKDAY_HEADER_HEIGHT
+
+      setGridMetrics((prev) => (
+        prev.height === height && prev.weekdayHeaderHeight === weekdayHeaderHeight
+          ? prev
+          : { height, weekdayHeaderHeight }
+      ))
+    }
+
+    measure()
+    window.addEventListener('resize', measure)
+
+    if (typeof ResizeObserver === 'undefined') {
+      return () => window.removeEventListener('resize', measure)
+    }
+
+    const observer = new ResizeObserver(measure)
+    if (gridRef.current) observer.observe(gridRef.current)
+    if (weekdayHeaderRef.current) observer.observe(weekdayHeaderRef.current)
+
+    return () => {
+      window.removeEventListener('resize', measure)
+      observer.disconnect()
+    }
+  }, [rows.length])
 
   return (
     <div
+      ref={gridRef}
       className={`w-full grid ${className ?? ''}`}
       style={{ gridTemplateRows: `auto repeat(${rows.length}, minmax(0, 1fr))`, height: '100%' }}
     >
       {/* 요일 헤더 — auto 트랙 */}
-      <div className="grid grid-cols-7">
+      <div ref={weekdayHeaderRef} className="grid grid-cols-7">
         {DOW.map((d, i) => (
           <div
             key={d}
@@ -262,6 +339,16 @@ export function CalendarGrid({
                   const isSun = dow === 0
                   const isSat = dow === 6
                   const hasHolidaysAndEvents = dayHolidays.length > 0 && daySingleEvents.length > 0
+                  const visibleSingleEventLimit = getVisibleSingleEventLimit({
+                    rowHeight,
+                    dateHeaderHeight: effectiveDateHeaderHeight,
+                    laneAreaHeight,
+                    holidayCount: dayHolidays.length,
+                    hasHolidaysAndEvents,
+                    singleEventCount: daySingleEvents.length,
+                  })
+                  const visibleSingleEvents = daySingleEvents.slice(0, visibleSingleEventLimit)
+                  const hiddenSingleEventCount = daySingleEvents.length - visibleSingleEvents.length
 
                   return (
                     <button
@@ -329,7 +416,7 @@ export function CalendarGrid({
 
                       {/* 단일 일정 pills */}
                       <div className={`w-full space-y-0.5${hasHolidaysAndEvents ? ' mt-0.5' : ''}`}>
-                        {daySingleEvents.slice(0, 3).map((evt) => {
+                        {visibleSingleEvents.map((evt) => {
                           const color = getEventColor(evt)
                           return (
                             <div
@@ -341,9 +428,9 @@ export function CalendarGrid({
                             </div>
                           )
                         })}
-                        {daySingleEvents.length > 3 && (
+                        {hiddenSingleEventCount > 0 && (
                           <div className="text-[10px] text-stone-500 dark:text-stone-400 font-medium px-1">
-                            +{daySingleEvents.length - 3}
+                            +{hiddenSingleEventCount}
                           </div>
                         )}
                       </div>


### PR DESCRIPTION
## Summary
- 캘린더 그리드의 실제 높이와 요일 헤더 높이를 측정해 주별 날짜 셀 높이를 계산합니다.
- 날짜/음력 영역, 멀티데이 일정 lane, 공휴일 칩, 셀 패딩/테두리, 칩 간격, +N 표시 줄을 고려해 단일 일정 칩 표시 개수를 동적으로 결정합니다.
- 5주/6주 월과 화면 크기 차이에 따라 가능한 만큼 칩을 보여주되, 공간이 부족하면 +N으로 접고, +N을 표시할 공간도 없으면 렌더하지 않도록 보수적으로 처리합니다.
- 동적 표시 개수 계산과 실제 CalendarGrid 재측정 렌더링을 테스트로 보강했습니다.

## Testing
- `npm run test -- --runTestsByPath src/__tests__/components/CalendarGrid.test.tsx`
- `npx tsc --noEmit`
- `npm run lint` (이번 변경과 무관한 기존 warning만 남아 있습니다)

## Manual Visual Verification
- [ ] 모바일에서 5주짜리 월을 열고, 공간이 충분한 날짜 셀에 기존 3개보다 많은 단일 일정 칩이 표시되는지 확인합니다.
- [ ] 모바일에서 2026년 5월처럼 6주짜리 월을 열고, 일정 칩과 +N 표시가 날짜 셀 밖으로 밀리거나 잘리지 않는지 확인합니다.
- [ ] 데스크톱처럼 높이가 넉넉한 화면에서 날짜 셀이 더 많은 일정 칩을 자연스럽게 표시하는지 확인합니다.