### PR TITLE
fix: format reminder notifications in app timezone

### DIFF
--- a/src/__tests__/api/push/send-reminders.test.ts
+++ b/src/__tests__/api/push/send-reminders.test.ts
@@ -62,7 +62,13 @@ describe('POST /api/cron/send-reminders', () => {
 
   it('리마인더가 있고 구독이 있으면 web-push를 호출한다', async () => {
     mockRpcResult = {
-      data: [{ reminder_id: 'r1', event_title: '회의', event_start: '2026-04-05T10:00:00Z', family_id: 'f1' }],
+      data: [{
+        reminder_id: 'r1',
+        event_title: '회의',
+        event_start: '2026-04-05T10:00:00Z',
+        is_all_day: false,
+        family_id: 'f1',
+      }],
       error: null,
     }
 
@@ -93,9 +99,83 @@ describe('POST /api/cron/send-reminders', () => {
     expect(mockSendNotification).toHaveBeenCalledTimes(1)
   })
 
+  it('리마인더 본문은 Asia/Tokyo 기준으로 일정 시간을 표시한다', async () => {
+    mockRpcResult = {
+      data: [{
+        reminder_id: 'r1',
+        event_title: '椅子届け',
+        event_start: '2026-04-22T23:00:00Z',
+        is_all_day: false,
+        family_id: 'f1',
+      }],
+      error: null,
+    }
+
+    mockFrom.mockImplementationOnce(() => ({
+      select: jest.fn().mockReturnThis(),
+      in: jest.fn().mockResolvedValue({ data: [{ user_id: 'u1', family_id: 'f1' }] }),
+    }))
+    mockFrom.mockImplementationOnce(() => ({
+      select: jest.fn().mockReturnThis(),
+      in: jest.fn().mockResolvedValue({
+        data: [{ id: 'sub1', endpoint: 'https://ep', p256dh: 'k', auth: 'a', user_id: 'u1' }],
+      }),
+    }))
+    mockFrom.mockImplementationOnce(() => ({
+      update: jest.fn().mockReturnThis(),
+      in: jest.fn().mockResolvedValue({ error: null }),
+    }))
+    mockSendNotification.mockResolvedValue({ statusCode: 201 })
+
+    await POST(makeRequest())
+
+    const payload = JSON.parse(mockSendNotification.mock.calls[0][1] as string)
+    expect(payload.body).toBe('4월 23일 08:00 일정이 있습니다')
+  })
+
+  it('종일 일정 리마인더 본문에는 시간을 표시하지 않는다', async () => {
+    mockRpcResult = {
+      data: [{
+        reminder_id: 'r1',
+        event_title: '楽天トラベルキャンセル〆',
+        event_start: '2026-04-23T15:00:00Z',
+        is_all_day: true,
+        family_id: 'f1',
+      }],
+      error: null,
+    }
+
+    mockFrom.mockImplementationOnce(() => ({
+      select: jest.fn().mockReturnThis(),
+      in: jest.fn().mockResolvedValue({ data: [{ user_id: 'u1', family_id: 'f1' }] }),
+    }))
+    mockFrom.mockImplementationOnce(() => ({
+      select: jest.fn().mockReturnThis(),
+      in: jest.fn().mockResolvedValue({
+        data: [{ id: 'sub1', endpoint: 'https://ep', p256dh: 'k', auth: 'a', user_id: 'u1' }],
+      }),
+    }))
+    mockFrom.mockImplementationOnce(() => ({
+      update: jest.fn().mockReturnThis(),
+      in: jest.fn().mockResolvedValue({ error: null }),
+    }))
+    mockSendNotification.mockResolvedValue({ statusCode: 201 })
+
+    await POST(makeRequest())
+
+    const payload = JSON.parse(mockSendNotification.mock.calls[0][1] as string)
+    expect(payload.body).toBe('4월 24일 종일 일정이 있습니다')
+  })
+
   it('만료된 구독(410)은 삭제된다', async () => {
     mockRpcResult = {
-      data: [{ reminder_id: 'r1', event_title: '회의', event_start: '2026-04-05T10:00:00Z', family_id: 'f1' }],
+      data: [{
+        reminder_id: 'r1',
+        event_title: '회의',
+        event_start: '2026-04-05T10:00:00Z',
+        is_all_day: false,
+        family_id: 'f1',
+      }],
       error: null,
     }
 

--- a/src/app/api/cron/send-reminders/route.ts
+++ b/src/app/api/cron/send-reminders/route.ts
@@ -2,9 +2,25 @@ import { NextRequest, NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase-admin'
 import { dispatchPushNotifications } from '@/lib/push-utils'
 
-function formatReminderBody(eventStart: string): string {
+const REMINDER_TIME_ZONE = 'Asia/Tokyo'
+
+export function formatReminderBody(eventStart: string, isAllDay: boolean): string {
   const d = new Date(eventStart)
-  return `${d.toLocaleDateString('ko-KR', { month: 'long', day: 'numeric' })} ${d.toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })} 일정이 있습니다`
+  const dateStr = d.toLocaleDateString('ko-KR', {
+    month: 'long',
+    day: 'numeric',
+    timeZone: REMINDER_TIME_ZONE,
+  })
+
+  if (isAllDay) return `${dateStr} 종일 일정이 있습니다`
+
+  const timeStr = d.toLocaleTimeString('ko-KR', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+    timeZone: REMINDER_TIME_ZONE,
+  })
+  return `${dateStr} ${timeStr} 일정이 있습니다`
 }
 
 export async function POST(req: NextRequest) {
@@ -58,7 +74,7 @@ export async function POST(req: NextRequest) {
       const familySubs = subs.filter((s) => s.user_id && memberUserIds.has(s.user_id))
       const payload = JSON.stringify({
         title: reminder.event_title,
-        body: formatReminderBody(reminder.event_start),
+        body: formatReminderBody(reminder.event_start, reminder.is_all_day),
         url: '/',
       })
 

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -670,6 +670,7 @@ export type Database = {
           reminder_id: string
           event_title: string
           event_start: string
+          is_all_day: boolean
           family_id: string
         }[]
       }

--- a/supabase/migrations/20260422000000_include_all_day_in_due_reminders.sql
+++ b/supabase/migrations/20260422000000_include_all_day_in_due_reminders.sql
@@ -1,6 +1,8 @@
 -- Include all-day metadata in due reminder payloads so notification text can
 -- format all-day events without misleading UTC times.
-create or replace function get_and_mark_due_reminders()
+drop function if exists get_and_mark_due_reminders();
+
+create function get_and_mark_due_reminders()
 returns table (
   reminder_id  uuid,
   event_title  text,

--- a/supabase/migrations/20260422000000_include_all_day_in_due_reminders.sql
+++ b/supabase/migrations/20260422000000_include_all_day_in_due_reminders.sql
@@ -1,0 +1,24 @@
+-- Include all-day metadata in due reminder payloads so notification text can
+-- format all-day events without misleading UTC times.
+create or replace function get_and_mark_due_reminders()
+returns table (
+  reminder_id  uuid,
+  event_title  text,
+  event_start  timestamptz,
+  is_all_day    boolean,
+  family_id    uuid
+)
+security definer
+language plpgsql as $$
+begin
+  return query
+    update event_reminders er
+    set sent_at = now()
+    from events e
+    where er.event_id = e.id
+      and er.sent_at is null
+      and (e.start_at - (er.remind_minutes_before * interval '1 minute'))
+          between now() - interval '65 seconds' and now() + interval '5 seconds'
+    returning er.id, e.title, e.start_at, e.is_all_day, e.family_id;
+end;
+$$;


### PR DESCRIPTION
## Summary
- 리마인더 알림 본문을 서버 기본 시간대가 아니라 Asia/Tokyo 기준으로 포맷하도록 수정했습니다.
- 시간 표기는 환경별 locale 차이를 피하기 위해 24시간제로 고정했습니다. 예: `4월 23일 08:00 일정이 있습니다`
- 종일 일정은 알림 본문에서 시간을 표시하지 않고 `종일 일정`으로 표시합니다. 예: `4월 24일 종일 일정이 있습니다`
- `get_and_mark_due_reminders` RPC가 `is_all_day`를 반환하도록 migration과 타입을 업데이트했습니다.
- Postgres 반환 타입 변경 제한을 피하기 위해 migration에서 기존 `get_and_mark_due_reminders()` 함수를 drop 후 재생성합니다.
- 실제 제보 케이스인 JST timed 일정과 all-day 일정에 대한 회귀 테스트를 추가했습니다.

## Testing
- `npm run test -- --runTestsByPath src/__tests__/api/push/send-reminders.test.ts`
- `npx tsc --noEmit`
- `npm run lint` (이번 변경과 무관한 기존 warning만 남아 있습니다)

## Notes
- 기존 이벤트와 리마인더 저장값은 UTC 기준으로 정상이라 데이터 수정은 필요 없습니다.

## Manual Verification
- [ ] 4/23 08:00 JST 일정의 1일 전 리마인더가 `4월 23일 08:00`으로 표시되는지 확인합니다.
- [ ] 4/24 종일 일정의 리마인더가 `4월 24일 종일 일정`으로 표시되는지 확인합니다.