### PR TITLE
fix: constrain shopping detail scrolling

### DIFF
--- a/src/__tests__/shopping/ShoppingDetailView.test.tsx
+++ b/src/__tests__/shopping/ShoppingDetailView.test.tsx
@@ -1,11 +1,14 @@
-import { render, screen, waitFor, act } from '@testing-library/react'
+import { render, screen, waitFor, act, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { User } from '@supabase/supabase-js'
 import { ShoppingDetailView } from '@/components/shopping/ShoppingDetailView'
 import { getShoppingItems, getShoppingList } from '@/lib/shopping'
 
 const mockBroadcast = jest.fn()
-const mockUseRealtimeSync = jest.fn((_c: unknown, _r: unknown, _o: unknown) => mockBroadcast)
+const mockUseRealtimeSync = jest.fn((...args: unknown[]) => {
+  void args
+  return mockBroadcast
+})
 const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
 
 jest.mock('@/hooks/useRealtimeSync', () => ({
@@ -185,5 +188,39 @@ describe('ShoppingDetailView', () => {
         expect.arrayContaining([expect.objectContaining({ id: 'item-1', name: '우유' })])
       )
     })
+  })
+
+  it('아이템이 많아도 목록만 스크롤되고 추가 입력란은 화면 안에 유지된다', async () => {
+    mockGetShoppingItems.mockResolvedValueOnce(
+      Array.from({ length: 40 }, (_, index) => ({
+        id: `item-${index + 1}`,
+        list_id: 'list-1',
+        created_by: 'user-1',
+        name: `아이템 ${index + 1}`,
+        is_checked: false,
+        checked_by: null,
+        checked_at: null,
+        sort_order: index,
+        created_at: '2026-01-01T00:00:00Z',
+      })) as never
+    )
+
+    render(
+      <ShoppingDetailView
+        listId="list-1"
+        user={mockUser}
+        onClose={onClose}
+        onPreviewItemsChange={onPreviewItemsChange}
+      />
+    )
+
+    expect(await screen.findByText('아이템 40')).toBeInTheDocument()
+    expect(screen.getByTestId('shopping-detail-overlay')).toHaveClass('overflow-hidden')
+    expect(screen.getByTestId('shopping-detail-shell')).toHaveClass('h-full', 'min-h-0', 'flex', 'flex-col')
+    expect(screen.getByTestId('shopping-detail-scroll')).toHaveClass('flex-1', 'min-h-0', 'overflow-y-auto')
+
+    const footer = screen.getByTestId('shopping-detail-footer')
+    expect(footer).toHaveClass('shrink-0')
+    expect(within(footer).getByPlaceholderText('아이템 추가...')).toBeInTheDocument()
   })
 })

--- a/src/components/shopping/ShoppingDetailView.tsx
+++ b/src/components/shopping/ShoppingDetailView.tsx
@@ -293,9 +293,12 @@ export function ShoppingDetailView({
   )
 
   return (
-    <div className="fixed inset-0 z-[55] bg-white dark:bg-stone-950">
+    <div
+      data-testid="shopping-detail-overlay"
+      className="fixed inset-0 z-[55] overflow-hidden bg-white dark:bg-stone-950"
+    >
       {status === 'loading' ? (
-        <div className="flex items-center justify-center min-h-screen">
+        <div className="flex h-full items-center justify-center">
           <div className="w-8 h-8 rounded-full border-2 border-accent-300 border-t-accent-500 animate-spin" />
         </div>
       ) : status === 'not-found' ? (
@@ -315,7 +318,10 @@ export function ShoppingDetailView({
           onSecondaryAction={onClose}
         />
       ) : (
-        <div className="max-w-lg mx-auto min-h-screen flex flex-col bg-white dark:bg-stone-950">
+        <div
+          data-testid="shopping-detail-shell"
+          className="max-w-lg mx-auto h-full min-h-0 flex flex-col bg-white dark:bg-stone-950"
+        >
           <div className="flex items-center gap-3 px-4 py-5 border-b border-stone-100 dark:border-stone-800">
             <button
               onClick={onClose}
@@ -338,7 +344,7 @@ export function ShoppingDetailView({
             </div>
           </div>
 
-          <div className="flex-1 overflow-y-auto py-2">
+          <div data-testid="shopping-detail-scroll" className="flex-1 min-h-0 overflow-y-auto py-2">
             {mutationError && (
               <div className="px-4 pt-2">
                 <div className="rounded-xl border border-red-100 bg-red-50 px-4 py-3 text-sm text-red-500 dark:border-red-900/40 dark:bg-red-950/30 dark:text-red-400">
@@ -395,7 +401,10 @@ export function ShoppingDetailView({
             )}
           </div>
 
-          <div className="border-t border-stone-100 dark:border-stone-800 bg-white dark:bg-stone-950 pb-safe">
+          <div
+            data-testid="shopping-detail-footer"
+            className="shrink-0 border-t border-stone-100 dark:border-stone-800 bg-white dark:bg-stone-950 pb-safe"
+          >
             <AddItemInput onAdd={handleAdd} />
           </div>
         </div>
@@ -422,7 +431,7 @@ function DetailStateShell({
   onSecondaryAction,
 }: DetailStateShellProps) {
   return (
-    <div className="max-w-lg mx-auto min-h-screen flex flex-col bg-white dark:bg-stone-950">
+    <div className="max-w-lg mx-auto h-full min-h-0 flex flex-col bg-white dark:bg-stone-950">
       <div className="flex items-center gap-3 px-4 py-5 border-b border-stone-100 dark:border-stone-800">
         <button
           onClick={onSecondaryAction ?? onAction}
@@ -437,7 +446,7 @@ function DetailStateShell({
         </div>
       </div>
 
-      <div className="flex-1 flex flex-col items-center justify-center px-6 text-center">
+      <div className="flex-1 min-h-0 flex flex-col items-center justify-center px-6 text-center">
         <div className="text-5xl mb-4">🧺</div>
         <p className="text-stone-600 dark:text-stone-300 font-medium">{title}</p>
         <p className="text-sm text-stone-400 dark:text-stone-500 mt-2">{description}</p>


### PR DESCRIPTION
## Summary
- Constrain the shopping detail overlay to the viewport so long item lists scroll inside the content area.
- Keep the add-item footer from being pushed off-screen on mobile and desktop.
- Add a regression test for long shopping lists preserving the scroll region and footer.

## Testing
- [x] npm run test -- --runTestsByPath src/__tests__/shopping/ShoppingDetailView.test.tsx
- [x] npx tsc --noEmit
- [x] npm run lint

## Manual Verification
- [ ] On mobile, open a shopping list with many items and verify the list scrolls while the add-item input stays visible.
- [ ] On desktop/PWA, open a shopping list with many items and verify drag handles work while the add-item input stays visible.