### PR TITLE
fix: lock reminder cron rpc execution

### DIFF
--- a/supabase/migrations/20260422010000_lock_due_reminders_rpc.sql
+++ b/supabase/migrations/20260422010000_lock_due_reminders_rpc.sql
@@ -1,0 +1,35 @@
+-- Restrict the cron-only reminder RPC to service-role execution.
+-- The function marks reminders as sent, so client roles must not be able to
+-- call it directly through Supabase RPC.
+
+drop function if exists public.get_and_mark_due_reminders();
+
+create function public.get_and_mark_due_reminders()
+returns table (
+  reminder_id  uuid,
+  event_title  text,
+  event_start  timestamptz,
+  is_all_day    boolean,
+  family_id    uuid
+)
+security definer
+set search_path = public, pg_temp
+language plpgsql as $$
+begin
+  return query
+    update event_reminders er
+    set sent_at = now()
+    from events e
+    where er.event_id = e.id
+      and er.sent_at is null
+      and (e.start_at - (er.remind_minutes_before * interval '1 minute'))
+          between now() - interval '65 seconds' and now() + interval '5 seconds'
+    returning er.id, e.title, e.start_at, e.is_all_day, e.family_id;
+end;
+$$;
+
+revoke execute on function public.get_and_mark_due_reminders()
+from public, anon, authenticated;
+
+grant execute on function public.get_and_mark_due_reminders()
+to service_role;


### PR DESCRIPTION
## Summary
- `get_and_mark_due_reminders()` 함수의 `search_path`를 `public, pg_temp`로 고정하는 마이그레이션을 추가했습니다.
- 클라이언트 role인 `public`, `anon`, `authenticated`에서 이 RPC를 실행할 수 없도록 `EXECUTE` 권한을 제거했습니다.
- cron route가 사용하는 `service_role`에는 `EXECUTE` 권한을 명시적으로 부여했습니다.
- linked Supabase DB에 마이그레이션을 적용하고 실제 권한 상태를 확인했습니다.

## Testing
- [x] `npm run test -- --runTestsByPath src/__tests__/api/push/send-reminders.test.ts`
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `supabase db query --linked --file supabase/migrations/20260422010000_lock_due_reminders_rpc.sql`
- [x] `supabase migration repair 20260422010000 --status applied --linked --yes`
- [x] `get_and_mark_due_reminders()` 권한 확인: `public/anon/authenticated EXECUTE=false`, `service_role EXECUTE=true`, `search_path=public, pg_temp`

## Manual Verification
- [ ] 배포 후 예정된 알림 cron이 due reminder를 정상 발송하는지 확인