### PR TITLE
polish: redesign event form layout

### DIFF
--- a/src/__tests__/components/EventFormModal.test.tsx
+++ b/src/__tests__/components/EventFormModal.test.tsx
@@ -231,17 +231,16 @@ describe('EventFormModal', () => {
     expect(screen.getAllByText(/2026년 3월 31일 \(화\)/).length).toBeGreaterThan(0)
   })
 
-  it('날짜 버튼 클릭 시 showPicker()를 호출한다', () => {
+  it('날짜 input은 보이는 날짜 버튼 영역 안에서 직접 클릭을 받는다', () => {
     render(<EventFormModal {...defaultProps} initialDate={new Date('2026-03-31')} />)
     const dateInputs = document.querySelectorAll('input[type="date"]')
-    const showPickerMock = jest.fn()
-    ;(dateInputs[0] as HTMLInputElement).showPicker = showPickerMock
-    ;(dateInputs[1] as HTMLInputElement).showPicker = showPickerMock
 
-    fireEvent.click(screen.getByTestId('start-date-button'))
-    fireEvent.click(screen.getByTestId('end-date-button'))
-
-    expect(showPickerMock).toHaveBeenCalledTimes(2)
+    expect(screen.getByTestId('start-date-button')).toContainElement(dateInputs[0] as HTMLElement)
+    expect(screen.getByTestId('end-date-button')).toContainElement(dateInputs[1] as HTMLElement)
+    expect(dateInputs[0]).toHaveClass('absolute')
+    expect(dateInputs[0]).toHaveClass('inset-0')
+    expect(dateInputs[0]).toHaveClass('cursor-pointer')
+    expect(dateInputs[1]).toHaveClass('cursor-pointer')
   })
 
   it('종일 모드 날짜 버튼은 absolute input의 기준점이 되도록 relative class를 유지한다', () => {
@@ -251,14 +250,16 @@ describe('EventFormModal', () => {
     expect(screen.getByTestId('end-date-button')).toHaveClass('relative')
   })
 
-  it('날짜 input은 보이지 않는 클릭 영역을 만들지 않는다', () => {
+  it('날짜 input은 키보드와 보조기기 접근성을 위해 focus 가능하게 유지한다', () => {
     render(<EventFormModal {...defaultProps} initialDate={new Date('2026-03-31')} />)
     const dateInputs = document.querySelectorAll('input[type="date"]')
 
-    expect(dateInputs[0]).toHaveClass('pointer-events-none')
-    expect(dateInputs[1]).toHaveClass('pointer-events-none')
-    expect(dateInputs[0]).toHaveAttribute('tabindex', '-1')
-    expect(dateInputs[1]).toHaveAttribute('tabindex', '-1')
+    expect(dateInputs[0]).not.toHaveClass('pointer-events-none')
+    expect(dateInputs[1]).not.toHaveClass('pointer-events-none')
+    expect(dateInputs[0]).not.toHaveAttribute('tabindex', '-1')
+    expect(dateInputs[1]).not.toHaveAttribute('tabindex', '-1')
+    expect(dateInputs[0]).toHaveAccessibleName(/시작 날짜/)
+    expect(dateInputs[1]).toHaveAccessibleName(/종료 날짜/)
   })
 
   it('모바일 기본 제목 크기를 컴팩트하게 유지한다', () => {
@@ -268,34 +269,17 @@ describe('EventFormModal', () => {
     expect(screen.getByPlaceholderText('제목')).toHaveClass('sm:text-[2rem]')
   })
 
-  it('시간 지정 모드에서는 모바일 날짜 표기를 짧게 표시한다', () => {
-    render(<EventFormModal {...defaultProps} initialDate={new Date('2026-11-30')} />)
-
-    fireEvent.click(screen.getByRole('button', { name: '종일' }))
-
-    expect(screen.getAllByText('11/30 (월)').length).toBeGreaterThan(0)
-    expect(screen.getAllByText('2026년 11월 30일 (월)').length).toBeGreaterThan(0)
-  })
-
   it('showPicker()가 없는 브라우저에서 날짜 버튼 클릭 시 예외가 발생하지 않는다', () => {
     render(<EventFormModal {...defaultProps} initialDate={new Date('2026-03-31')} />)
     const dateInputs = document.querySelectorAll('input[type="date"]')
-    const focusMock = jest.fn()
-    const clickMock = jest.fn()
     // showPicker 메서드가 없는 환경 시뮬레이션
     Object.defineProperty(dateInputs[0], 'showPicker', { value: undefined, configurable: true })
     Object.defineProperty(dateInputs[1], 'showPicker', { value: undefined, configurable: true })
-    Object.defineProperty(dateInputs[0], 'focus', { value: focusMock, configurable: true })
-    Object.defineProperty(dateInputs[1], 'focus', { value: focusMock, configurable: true })
-    Object.defineProperty(dateInputs[0], 'click', { value: clickMock, configurable: true })
-    Object.defineProperty(dateInputs[1], 'click', { value: clickMock, configurable: true })
 
     expect(() => {
-      fireEvent.click(screen.getByTestId('start-date-button'))
-      fireEvent.click(screen.getByTestId('end-date-button'))
+      fireEvent.click(dateInputs[0])
+      fireEvent.click(dateInputs[1])
     }).not.toThrow()
-    expect(focusMock).toHaveBeenCalledTimes(2)
-    expect(clickMock).toHaveBeenCalledTimes(2)
   })
 
   it('시간 버튼 클릭 시 wheel picker가 나타난다', () => {

--- a/src/__tests__/components/EventFormModal.test.tsx
+++ b/src/__tests__/components/EventFormModal.test.tsx
@@ -257,7 +257,7 @@ describe('EventFormModal', () => {
   it('모바일 기본 제목 크기를 컴팩트하게 유지한다', () => {
     render(<EventFormModal {...defaultProps} initialDate={new Date('2026-03-31')} />)
 
-    expect(screen.getByPlaceholderText('제목')).toHaveClass('text-[1.875rem]')
+    expect(screen.getByPlaceholderText('제목')).toHaveClass('text-[1.625rem]')
     expect(screen.getByPlaceholderText('제목')).toHaveClass('sm:text-[2rem]')
   })
 

--- a/src/__tests__/components/EventFormModal.test.tsx
+++ b/src/__tests__/components/EventFormModal.test.tsx
@@ -237,6 +237,13 @@ describe('EventFormModal', () => {
     expect(showPickerMock).toHaveBeenCalledTimes(2)
   })
 
+  it('종일 모드 날짜 버튼은 absolute input의 기준점이 되도록 relative class를 유지한다', () => {
+    render(<EventFormModal {...defaultProps} initialDate={new Date('2026-03-31')} />)
+
+    expect(screen.getByTestId('start-date-button')).toHaveClass('relative')
+    expect(screen.getByTestId('end-date-button')).toHaveClass('relative')
+  })
+
   it('showPicker()가 없는 브라우저에서 날짜 버튼 클릭 시 예외가 발생하지 않는다', () => {
     render(<EventFormModal {...defaultProps} initialDate={new Date('2026-03-31')} />)
     const dateInputs = document.querySelectorAll('input[type="date"]')

--- a/src/__tests__/components/EventFormModal.test.tsx
+++ b/src/__tests__/components/EventFormModal.test.tsx
@@ -254,6 +254,13 @@ describe('EventFormModal', () => {
     expect(dateInputs[1]).toHaveAttribute('tabindex', '-1')
   })
 
+  it('모바일 기본 제목 크기를 컴팩트하게 유지한다', () => {
+    render(<EventFormModal {...defaultProps} initialDate={new Date('2026-03-31')} />)
+
+    expect(screen.getByPlaceholderText('제목')).toHaveClass('text-[1.875rem]')
+    expect(screen.getByPlaceholderText('제목')).toHaveClass('sm:text-[2rem]')
+  })
+
   it('showPicker()가 없는 브라우저에서 날짜 버튼 클릭 시 예외가 발생하지 않는다', () => {
     render(<EventFormModal {...defaultProps} initialDate={new Date('2026-03-31')} />)
     const dateInputs = document.querySelectorAll('input[type="date"]')

--- a/src/__tests__/components/EventFormModal.test.tsx
+++ b/src/__tests__/components/EventFormModal.test.tsx
@@ -72,6 +72,12 @@ describe('EventFormModal', () => {
     expect(root.className).toMatch(/inset-0/)
   })
 
+  it('시트 컨테이너에 safe-area 상단 패딩을 적용한다', () => {
+    const { container } = render(<EventFormModal {...defaultProps} />)
+    const sheet = container.querySelector('.h-dvh') as HTMLElement
+    expect(sheet).toHaveStyle({ paddingTop: 'env(safe-area-inset-top, 0px)' })
+  })
+
   it('종일 모드에서 날짜 input만 렌더링된다', () => {
     render(<EventFormModal {...defaultProps} />)
     const dateInputs = screen.getAllByDisplayValue(/\d{4}-\d{2}-\d{2}/)
@@ -232,9 +238,8 @@ describe('EventFormModal', () => {
     ;(dateInputs[0] as HTMLInputElement).showPicker = showPickerMock
     ;(dateInputs[1] as HTMLInputElement).showPicker = showPickerMock
 
-    const dateBtns = document.querySelectorAll('input[type="date"]')
-    fireEvent.click(dateBtns[0].parentElement!)
-    fireEvent.click(dateBtns[1].parentElement!)
+    fireEvent.click(screen.getByTestId('start-date-button'))
+    fireEvent.click(screen.getByTestId('end-date-button'))
 
     expect(showPickerMock).toHaveBeenCalledTimes(2)
   })
@@ -263,17 +268,34 @@ describe('EventFormModal', () => {
     expect(screen.getByPlaceholderText('제목')).toHaveClass('sm:text-[2rem]')
   })
 
+  it('시간 지정 모드에서는 모바일 날짜 표기를 짧게 표시한다', () => {
+    render(<EventFormModal {...defaultProps} initialDate={new Date('2026-11-30')} />)
+
+    fireEvent.click(screen.getByRole('button', { name: '종일' }))
+
+    expect(screen.getAllByText('11/30 (월)').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('2026년 11월 30일 (월)').length).toBeGreaterThan(0)
+  })
+
   it('showPicker()가 없는 브라우저에서 날짜 버튼 클릭 시 예외가 발생하지 않는다', () => {
     render(<EventFormModal {...defaultProps} initialDate={new Date('2026-03-31')} />)
     const dateInputs = document.querySelectorAll('input[type="date"]')
+    const focusMock = jest.fn()
+    const clickMock = jest.fn()
     // showPicker 메서드가 없는 환경 시뮬레이션
     Object.defineProperty(dateInputs[0], 'showPicker', { value: undefined, configurable: true })
     Object.defineProperty(dateInputs[1], 'showPicker', { value: undefined, configurable: true })
+    Object.defineProperty(dateInputs[0], 'focus', { value: focusMock, configurable: true })
+    Object.defineProperty(dateInputs[1], 'focus', { value: focusMock, configurable: true })
+    Object.defineProperty(dateInputs[0], 'click', { value: clickMock, configurable: true })
+    Object.defineProperty(dateInputs[1], 'click', { value: clickMock, configurable: true })
 
     expect(() => {
-      fireEvent.click(dateInputs[0].parentElement!)
-      fireEvent.click(dateInputs[1].parentElement!)
+      fireEvent.click(screen.getByTestId('start-date-button'))
+      fireEvent.click(screen.getByTestId('end-date-button'))
     }).not.toThrow()
+    expect(focusMock).toHaveBeenCalledTimes(2)
+    expect(clickMock).toHaveBeenCalledTimes(2)
   })
 
   it('시간 버튼 클릭 시 wheel picker가 나타난다', () => {

--- a/src/__tests__/components/EventFormModal.test.tsx
+++ b/src/__tests__/components/EventFormModal.test.tsx
@@ -114,6 +114,8 @@ describe('EventFormModal', () => {
       screen.getByText('종료'),
       screen.getByText('라벨'),
       screen.getByText('알람'),
+      screen.getByPlaceholderText('메모 (선택)'),
+      screen.getByText('반복'),
     ]
 
     orderedNodes.slice(1).forEach((node, index) => {

--- a/src/__tests__/components/EventFormModal.test.tsx
+++ b/src/__tests__/components/EventFormModal.test.tsx
@@ -244,6 +244,16 @@ describe('EventFormModal', () => {
     expect(screen.getByTestId('end-date-button')).toHaveClass('relative')
   })
 
+  it('날짜 input은 보이지 않는 클릭 영역을 만들지 않는다', () => {
+    render(<EventFormModal {...defaultProps} initialDate={new Date('2026-03-31')} />)
+    const dateInputs = document.querySelectorAll('input[type="date"]')
+
+    expect(dateInputs[0]).toHaveClass('pointer-events-none')
+    expect(dateInputs[1]).toHaveClass('pointer-events-none')
+    expect(dateInputs[0]).toHaveAttribute('tabindex', '-1')
+    expect(dateInputs[1]).toHaveAttribute('tabindex', '-1')
+  })
+
   it('showPicker()가 없는 브라우저에서 날짜 버튼 클릭 시 예외가 발생하지 않는다', () => {
     render(<EventFormModal {...defaultProps} initialDate={new Date('2026-03-31')} />)
     const dateInputs = document.querySelectorAll('input[type="date"]')

--- a/src/__tests__/components/EventFormModal.test.tsx
+++ b/src/__tests__/components/EventFormModal.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, act } from '@testing-library/react'
+import { render, screen, fireEvent, act, createEvent } from '@testing-library/react'
 import { EventFormModal } from '@/components/calendar/EventFormModal'
 import type { Calendar } from '@/lib/calendar'
 
@@ -323,17 +323,23 @@ describe('EventFormModal', () => {
     expect(screen.getByPlaceholderText('제목')).toHaveClass('sm:text-[2rem]')
   })
 
-  it('showPicker()가 없는 브라우저에서 날짜 버튼 클릭 시 예외가 발생하지 않는다', () => {
+  it('showPicker()가 없는 브라우저에서는 native 날짜 input 기본 동작을 막지 않는다', () => {
     render(<EventFormModal {...defaultProps} initialDate={new Date('2026-03-31')} />)
     const dateInputs = document.querySelectorAll('input[type="date"]')
     // showPicker 메서드가 없는 환경 시뮬레이션
     Object.defineProperty(dateInputs[0], 'showPicker', { value: undefined, configurable: true })
     Object.defineProperty(dateInputs[1], 'showPicker', { value: undefined, configurable: true })
 
-    expect(() => {
-      fireEvent.click(screen.getByTestId('start-date-button'))
-      fireEvent.click(screen.getByTestId('end-date-button'))
-    }).not.toThrow()
+    const startClick = createEvent.click(screen.getByTestId('start-date-button'))
+    const endClick = createEvent.click(screen.getByTestId('end-date-button'))
+    const startPreventDefault = jest.spyOn(startClick, 'preventDefault')
+    const endPreventDefault = jest.spyOn(endClick, 'preventDefault')
+
+    fireEvent(screen.getByTestId('start-date-button'), startClick)
+    fireEvent(screen.getByTestId('end-date-button'), endClick)
+
+    expect(startPreventDefault).not.toHaveBeenCalled()
+    expect(endPreventDefault).not.toHaveBeenCalled()
   })
 
   it('시간 버튼 클릭 시 wheel picker가 나타난다', () => {

--- a/src/__tests__/components/EventFormModal.test.tsx
+++ b/src/__tests__/components/EventFormModal.test.tsx
@@ -301,6 +301,21 @@ describe('EventFormModal', () => {
     expect(dateInputs[1]).toHaveAccessibleName(/종료 날짜/)
   })
 
+  it('보이는 날짜 버튼 클릭 시 데스크톱 날짜 picker를 연다', () => {
+    render(<EventFormModal {...defaultProps} initialDate={new Date('2026-03-31')} />)
+    const dateInputs = document.querySelectorAll('input[type="date"]')
+    const startShowPicker = jest.fn()
+    const endShowPicker = jest.fn()
+    Object.defineProperty(dateInputs[0], 'showPicker', { value: startShowPicker, configurable: true })
+    Object.defineProperty(dateInputs[1], 'showPicker', { value: endShowPicker, configurable: true })
+
+    fireEvent.click(screen.getByTestId('start-date-button'))
+    fireEvent.click(screen.getByTestId('end-date-button'))
+
+    expect(startShowPicker).toHaveBeenCalledTimes(1)
+    expect(endShowPicker).toHaveBeenCalledTimes(1)
+  })
+
   it('모바일 기본 제목 크기를 컴팩트하게 유지한다', () => {
     render(<EventFormModal {...defaultProps} initialDate={new Date('2026-03-31')} />)
 
@@ -316,8 +331,8 @@ describe('EventFormModal', () => {
     Object.defineProperty(dateInputs[1], 'showPicker', { value: undefined, configurable: true })
 
     expect(() => {
-      fireEvent.click(dateInputs[0])
-      fireEvent.click(dateInputs[1])
+      fireEvent.click(screen.getByTestId('start-date-button'))
+      fireEvent.click(screen.getByTestId('end-date-button'))
     }).not.toThrow()
   })
 

--- a/src/__tests__/components/EventFormModal.test.tsx
+++ b/src/__tests__/components/EventFormModal.test.tsx
@@ -177,6 +177,19 @@ describe('EventFormModal', () => {
     expect(defaultProps.onSave).toHaveBeenCalled()
   })
 
+  it('시작 날짜가 종료 날짜보다 뒤로 바뀌면 종료 날짜를 시작 날짜로 보정한다', () => {
+    render(<EventFormModal {...defaultProps} initialDate={new Date('2026-03-31')} />)
+
+    const dateInputs = document.querySelectorAll('input[type="date"]')
+    const startDateInput = dateInputs[0] as HTMLInputElement
+    const endDateInput = dateInputs[1] as HTMLInputElement
+
+    fireEvent.change(startDateInput, { target: { value: '2026-04-02' } })
+
+    expect(startDateInput.value).toBe('2026-04-02')
+    expect(endDateInput.value).toBe('2026-04-02')
+  })
+
   it('종료 시간이 시작보다 이르면 시작 시간으로 복귀된다', () => {
     render(<EventFormModal {...defaultProps} initialDate={new Date('2026-03-31')} />)
 
@@ -192,6 +205,32 @@ describe('EventFormModal', () => {
 
     // 종료 시간이 시작 시간(09:00)으로 복귀 → wheel hours 값이 9가 되어야 함
     expect(hoursInput.value).toBe('9')
+  })
+
+  it('시작 시간이 종료 시간보다 뒤로 바뀌면 종료 시간을 시작 시간으로 보정한다', async () => {
+    render(<EventFormModal {...defaultProps} initialDate={new Date('2026-03-31')} />)
+
+    fireEvent.click(screen.getByRole('button', { name: '종일' }))
+    fireEvent.click(screen.getByText('09:00'))
+
+    const hoursInput = screen.getByTestId('wheel-hours') as HTMLInputElement
+    fireEvent.change(hoursInput, { target: { value: '11' } })
+
+    expect(screen.getAllByText('11:00')).toHaveLength(2)
+
+    fireEvent.change(screen.getByPlaceholderText('제목'), { target: { value: '시간 일정' } })
+    await act(async () => {
+      fireEvent.click(screen.getByText('저장'))
+    })
+
+    expect(defaultProps.onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        startAt: expect.any(String),
+        endAt: expect.any(String),
+      })
+    )
+    const savedParams = defaultProps.onSave.mock.calls[0][0]
+    expect(savedParams.endAt).toBe(savedParams.startAt)
   })
 
   it('X 버튼 클릭 시 애니메이션 후 onClose가 호출된다', () => {

--- a/src/__tests__/components/EventFormModal.test.tsx
+++ b/src/__tests__/components/EventFormModal.test.tsx
@@ -82,8 +82,7 @@ describe('EventFormModal', () => {
 
   it('종일 해제 시 시간 버튼이 나타난다', () => {
     render(<EventFormModal {...defaultProps} />)
-    const allToggle = document.querySelector('button.w-11') as HTMLElement
-    fireEvent.click(allToggle)
+    fireEvent.click(screen.getByRole('button', { name: '종일' }))
 
     // 시간 버튼(HH:MM 형태)이 나타나야 함
     expect(screen.getByText('09:00')).toBeInTheDocument()
@@ -102,6 +101,26 @@ describe('EventFormModal', () => {
     fireEvent.change(titleInput, { target: { value: '테스트 일정' } })
     const saveBtn = screen.getByText('저장')
     expect(saveBtn).not.toBeDisabled()
+  })
+
+  it('레퍼런스 레이아웃 순서로 주요 항목을 표시한다', () => {
+    render(<EventFormModal {...defaultProps} />)
+
+    const orderedNodes = [
+      screen.getByPlaceholderText('제목'),
+      screen.getByText('가족'),
+      screen.getByText('종일'),
+      screen.getByText('시작'),
+      screen.getByText('종료'),
+      screen.getByText('라벨'),
+      screen.getByText('알람'),
+    ]
+
+    orderedNodes.slice(1).forEach((node, index) => {
+      expect(
+        orderedNodes[index].compareDocumentPosition(node) & Node.DOCUMENT_POSITION_FOLLOWING
+      ).toBeTruthy()
+    })
   })
 
   it('저장 시 onSave가 startAt, endAt, isAllDay를 포함해 호출된다', async () => {
@@ -129,8 +148,7 @@ describe('EventFormModal', () => {
     render(<EventFormModal {...defaultProps} initialDate={new Date('2026-03-31')} />)
 
     // 종일 해제
-    const allToggle = document.querySelector('button.w-11') as HTMLElement
-    fireEvent.click(allToggle)
+    fireEvent.click(screen.getByRole('button', { name: '종일' }))
 
     // 시작: 2026-03-31 09:00 (기본)
     // 종료 날짜를 이전 날짜로 변경
@@ -155,8 +173,7 @@ describe('EventFormModal', () => {
     render(<EventFormModal {...defaultProps} initialDate={new Date('2026-03-31')} />)
 
     // 종일 해제
-    const allToggle = document.querySelector('button.w-11') as HTMLElement
-    fireEvent.click(allToggle)
+    fireEvent.click(screen.getByRole('button', { name: '종일' }))
 
     // 종료 시간 picker 열기
     fireEvent.click(screen.getByText('10:00'))
@@ -171,8 +188,7 @@ describe('EventFormModal', () => {
 
   it('X 버튼 클릭 시 애니메이션 후 onClose가 호출된다', () => {
     render(<EventFormModal {...defaultProps} />)
-    const closeButton = document.querySelector('button.p-1.text-stone-400') as HTMLElement
-    fireEvent.click(closeButton)
+    fireEvent.click(screen.getByRole('button', { name: '닫기' }))
     act(() => {
       jest.advanceTimersByTime(300)
     })
@@ -198,13 +214,13 @@ describe('EventFormModal', () => {
       updated_at: '',
     }
     render(<EventFormModal {...defaultProps} initial={initial} />)
-    expect(screen.getByText('일정 편집')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('기존 일정')).toBeInTheDocument()
   })
 
   it('날짜 버튼에 요일이 표시된다', () => {
     render(<EventFormModal {...defaultProps} initialDate={new Date('2026-03-31')} />)
     // 2026-03-31은 화요일
-    expect(screen.getAllByText(/2026\/03\/31\(화\)/).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/2026년 3월 31일 \(화\)/).length).toBeGreaterThan(0)
   })
 
   it('날짜 버튼 클릭 시 showPicker()를 호출한다', () => {
@@ -237,8 +253,7 @@ describe('EventFormModal', () => {
   it('시간 버튼 클릭 시 wheel picker가 나타난다', () => {
     render(<EventFormModal {...defaultProps} />)
     // 종일 해제
-    const allToggle = document.querySelector('button.w-11') as HTMLElement
-    fireEvent.click(allToggle)
+    fireEvent.click(screen.getByRole('button', { name: '종일' }))
 
     expect(screen.queryByTestId('time-wheel-picker')).not.toBeInTheDocument()
 
@@ -364,7 +379,7 @@ describe('라벨 색상', () => {
 
   it('라벨 색상 버튼 클릭 시 팔레트가 열린다', () => {
     render(<EventFormModal {...defaultProps} />)
-    fireEvent.click(screen.getByText('라벨 색상'))
+    fireEvent.click(screen.getByText('라벨'))
     expect(screen.getByTitle('주황색')).toBeInTheDocument()
   })
 
@@ -382,7 +397,7 @@ describe('라벨 색상', () => {
   it('null 선택 시 onSave에 labelColor: null이 포함된다', async () => {
     render(<EventFormModal {...defaultProps} defaultLabelColor="#f97316" />)
     // 팔레트 열기
-    fireEvent.click(screen.getByText('라벨 색상'))
+    fireEvent.click(screen.getByText('라벨'))
     // null 선택 (캘린더 색상 사용)
     fireEvent.click(screen.getByTitle('캘린더 색상 사용'))
     fireEvent.change(screen.getByPlaceholderText('제목'), { target: { value: '테스트' } })

--- a/src/components/calendar/EventFormModal.tsx
+++ b/src/components/calendar/EventFormModal.tsx
@@ -160,37 +160,50 @@ export function EventFormModal({
     setActiveTimePicker((prev) => (prev === which ? null : which))
   }
 
-  const handleEndDateChange = (value: string) => {
-    const start = isAllDay
-      ? new Date(startDate + 'T00:00:00')
-      : new Date(`${startDate}T${startTime}`)
-    const newEnd = isAllDay
-      ? new Date(value + 'T00:00:00')
-      : new Date(`${value}T${endTime}`)
+  const keepEndAtOrAfterStart = (
+    nextStartDate: string,
+    nextStartTime: string,
+    nextEndDate = endDate,
+    nextEndTime = endTime,
+    nextIsAllDay = isAllDay
+  ) => {
+    const start = nextIsAllDay
+      ? new Date(nextStartDate + 'T00:00:00')
+      : new Date(`${nextStartDate}T${nextStartTime}`)
+    const end = nextIsAllDay
+      ? new Date(nextEndDate + 'T00:00:00')
+      : new Date(`${nextEndDate}T${nextEndTime}`)
 
-    if (newEnd < start) {
-      setEndDate(startDate)
-      if (!isAllDay) setEndTime(startTime)
+    if (end < start) {
+      setEndDate(nextStartDate)
+      if (!nextIsAllDay) setEndTime(nextStartTime)
       triggerShake()
-    } else {
+      return false
+    }
+
+    return true
+  }
+
+  const handleStartDateChange = (value: string) => {
+    setStartDate(value)
+    keepEndAtOrAfterStart(value, startTime)
+  }
+
+  const handleEndDateChange = (value: string) => {
+    if (keepEndAtOrAfterStart(startDate, startTime, value)) {
       setEndDate(value)
     }
   }
 
   const handleStartTimeChange = (h: number, m: number) => {
-    setStartTime(buildTime(h, m))
+    const newStartTime = buildTime(h, m)
+    setStartTime(newStartTime)
+    keepEndAtOrAfterStart(startDate, newStartTime)
   }
 
   const handleEndTimeChange = (h: number, m: number) => {
     const newEndTime = buildTime(h, m)
-    const start = new Date(`${startDate}T${startTime}`)
-    const end = new Date(`${endDate}T${newEndTime}`)
-
-    if (end < start) {
-      setEndDate(startDate)
-      setEndTime(startTime)
-      triggerShake()
-    } else {
+    if (keepEndAtOrAfterStart(startDate, startTime, endDate, newEndTime, false)) {
       setEndTime(newEndTime)
     }
   }
@@ -373,7 +386,7 @@ export function EventFormModal({
                       value={startDate}
                       disabled={!canEditOccurrenceDate}
                       aria-label={`시작 날짜 ${formatDateWithDOW(startDate)}`}
-                      onChange={(e) => setStartDate(e.target.value)}
+                      onChange={(e) => handleStartDateChange(e.target.value)}
                       className={`absolute inset-0 h-full w-full opacity-0 ${canEditOccurrenceDate ? 'cursor-pointer' : 'cursor-default'}`}
                     />
                   </div>

--- a/src/components/calendar/EventFormModal.tsx
+++ b/src/components/calendar/EventFormModal.tsx
@@ -17,6 +17,12 @@ function formatDateWithDOW(dateStr: string): string {
   return `${d.getFullYear()}년 ${d.getMonth() + 1}월 ${d.getDate()}일 (${DOW_KR[d.getDay()]})`
 }
 
+function formatShortDateWithDOW(dateStr: string): string {
+  if (!dateStr) return ''
+  const d = new Date(dateStr + 'T00:00:00')
+  return `${d.getMonth() + 1}/${d.getDate()} (${DOW_KR[d.getDay()]})`
+}
+
 function buildTime(h: number, m: number): string {
   return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`
 }
@@ -160,6 +166,16 @@ export function EventFormModal({
     setActiveTimePicker((prev) => (prev === which ? null : which))
   }
 
+  const openDatePicker = (input: HTMLInputElement | null) => {
+    if (!canEditOccurrenceDate || !input) return
+    if (typeof input.showPicker === 'function') {
+      input.showPicker()
+      return
+    }
+    input.focus()
+    input.click()
+  }
+
   const handleEndDateChange = (value: string) => {
     const start = isAllDay
       ? new Date(startDate + 'T00:00:00')
@@ -254,7 +270,10 @@ export function EventFormModal({
 
   return (
     <div className={`fixed inset-0 z-[70] bg-stone-950/40 dark:bg-black flex items-end sm:items-center justify-center sm:p-6 ${isClosing ? 'modal-slide-down' : 'modal-slide-up'}`}>
-      <div className="flex h-dvh w-full flex-col overflow-hidden rounded-t-[1.75rem] bg-stone-50 shadow-2xl dark:bg-[#090909] sm:h-[min(860px,calc(100dvh-48px))] sm:w-[min(920px,calc(100vw-48px))] sm:max-w-none sm:rounded-[2rem]">
+      <div
+        className="flex h-dvh w-full flex-col overflow-hidden rounded-t-[1.75rem] bg-stone-50 shadow-2xl dark:bg-[#090909] sm:h-[min(860px,calc(100dvh-48px))] sm:w-[min(920px,calc(100vw-48px))] sm:max-w-none sm:rounded-[2rem]"
+        style={{ paddingTop: 'env(safe-area-inset-top, 0px)' }}
+      >
       <div className="mx-auto mt-2 h-1 w-12 shrink-0 rounded-full bg-stone-300/60 dark:bg-stone-700/70" />
 
       {/* 헤더 */}
@@ -359,12 +378,24 @@ export function EventFormModal({
               <div className="grid grid-cols-[3.25rem_minmax(0,1fr)] items-center gap-y-2.5 sm:grid-cols-[4.5rem_minmax(0,1fr)] sm:gap-y-5">
                 <span className="text-base font-medium text-stone-800 dark:text-stone-100 sm:text-lg">시작</span>
                 <div className={`flex justify-end gap-2 ${isAllDay ? '' : 'min-w-0'}`}>
-                  <div
-                    data-testid="start-date-button"
-                    className={`${isAllDay ? 'w-full max-w-[18rem]' : 'flex-1'} ${dateBtnCls}`}
-                    onClick={() => { if (canEditOccurrenceDate) startDateInputRef.current?.showPicker?.() }}
-                  >
-                    <span className="relative z-10 pointer-events-none whitespace-nowrap">{formatDateWithDOW(startDate)}</span>
+                  <div className={isAllDay ? 'relative w-full max-w-[18rem]' : 'relative flex-1'}>
+                    <button
+                      type="button"
+                      data-testid="start-date-button"
+                      aria-label={`시작 날짜 ${formatDateWithDOW(startDate)}`}
+                      disabled={!canEditOccurrenceDate}
+                      className={`w-full ${dateBtnCls}`}
+                      onClick={() => openDatePicker(startDateInputRef.current)}
+                    >
+                      {isAllDay ? (
+                        <span className="relative z-10 pointer-events-none whitespace-nowrap">{formatDateWithDOW(startDate)}</span>
+                      ) : (
+                        <>
+                          <span className="relative z-10 pointer-events-none whitespace-nowrap sm:hidden">{formatShortDateWithDOW(startDate)}</span>
+                          <span className="relative z-10 pointer-events-none hidden whitespace-nowrap sm:inline">{formatDateWithDOW(startDate)}</span>
+                        </>
+                      )}
+                    </button>
                     <input
                       ref={startDateInputRef}
                       type="date"
@@ -397,12 +428,24 @@ export function EventFormModal({
 
                 <span className="text-base font-medium text-stone-800 dark:text-stone-100 sm:text-lg">종료</span>
                 <div className={`flex justify-end gap-2 ${endShake ? 'shake' : ''}`}>
-                  <div
-                    data-testid="end-date-button"
-                    className={`${isAllDay ? 'w-full max-w-[18rem]' : 'flex-1'} ${dateBtnCls}`}
-                    onClick={() => { if (canEditOccurrenceDate) endDateInputRef.current?.showPicker?.() }}
-                  >
-                    <span className="relative z-10 pointer-events-none whitespace-nowrap">{formatDateWithDOW(endDate)}</span>
+                  <div className={isAllDay ? 'relative w-full max-w-[18rem]' : 'relative flex-1'}>
+                    <button
+                      type="button"
+                      data-testid="end-date-button"
+                      aria-label={`종료 날짜 ${formatDateWithDOW(endDate)}`}
+                      disabled={!canEditOccurrenceDate}
+                      className={`w-full ${dateBtnCls}`}
+                      onClick={() => openDatePicker(endDateInputRef.current)}
+                    >
+                      {isAllDay ? (
+                        <span className="relative z-10 pointer-events-none whitespace-nowrap">{formatDateWithDOW(endDate)}</span>
+                      ) : (
+                        <>
+                          <span className="relative z-10 pointer-events-none whitespace-nowrap sm:hidden">{formatShortDateWithDOW(endDate)}</span>
+                          <span className="relative z-10 pointer-events-none hidden whitespace-nowrap sm:inline">{formatDateWithDOW(endDate)}</span>
+                        </>
+                      )}
+                    </button>
                     <input
                       ref={endDateInputRef}
                       type="date"

--- a/src/components/calendar/EventFormModal.tsx
+++ b/src/components/calendar/EventFormModal.tsx
@@ -370,8 +370,9 @@ export function EventFormModal({
                       type="date"
                       value={startDate}
                       disabled={!canEditOccurrenceDate}
+                      tabIndex={-1}
                       onChange={(e) => setStartDate(e.target.value)}
-                      className={`absolute inset-0 opacity-0 w-full h-full ${canEditOccurrenceDate ? 'cursor-pointer' : 'cursor-default'}`}
+                      className="pointer-events-none absolute inset-0 h-full w-full opacity-0"
                     />
                   </div>
                   {!isAllDay && (
@@ -407,8 +408,9 @@ export function EventFormModal({
                       type="date"
                       value={endDate}
                       disabled={!canEditOccurrenceDate}
+                      tabIndex={-1}
                       onChange={(e) => handleEndDateChange(e.target.value)}
-                      className={`absolute inset-0 opacity-0 w-full h-full ${canEditOccurrenceDate ? 'cursor-pointer' : 'cursor-default'}`}
+                      className="pointer-events-none absolute inset-0 h-full w-full opacity-0"
                     />
                   </div>
                   {!isAllDay && (

--- a/src/components/calendar/EventFormModal.tsx
+++ b/src/components/calendar/EventFormModal.tsx
@@ -238,13 +238,13 @@ export function EventFormModal({
   }
 
   const timeBtnCls = (active: boolean) =>
-    `min-w-[4.5rem] px-3 py-2 rounded-2xl text-sm font-semibold text-center transition-colors shrink-0 sm:min-w-20 sm:px-4 sm:py-2.5 ${
+    `min-w-[4.25rem] rounded-xl px-3 py-1.5 text-sm font-semibold text-center transition-colors shrink-0 sm:min-w-20 sm:rounded-2xl sm:px-4 sm:py-2.5 ${
       active
         ? 'bg-accent-400 text-white'
         : 'bg-stone-100 dark:bg-stone-800/95 text-stone-700 dark:text-stone-100'
     }`
 
-  const dateBtnCls = 'relative overflow-hidden min-w-0 px-3 py-2 rounded-2xl bg-stone-100 dark:bg-stone-800/95 text-sm font-semibold text-stone-700 dark:text-stone-100 text-center sm:px-4 sm:py-2.5'
+  const dateBtnCls = 'relative overflow-hidden min-w-0 rounded-xl bg-stone-100 px-3 py-1.5 text-center text-sm font-semibold text-stone-700 dark:bg-stone-800/95 dark:text-stone-100 sm:rounded-2xl sm:px-4 sm:py-2.5'
   const reminderLabel = reminderMinutes.size > 0
     ? REMINDER_OPTIONS
       .filter((opt) => reminderMinutes.has(opt.minutes))
@@ -254,37 +254,37 @@ export function EventFormModal({
 
   return (
     <div className={`fixed inset-0 z-[70] bg-stone-950/40 dark:bg-black flex items-end sm:items-center justify-center sm:p-6 ${isClosing ? 'modal-slide-down' : 'modal-slide-up'}`}>
-      <div className="flex h-dvh w-full flex-col overflow-hidden rounded-t-[2rem] bg-stone-50 shadow-2xl dark:bg-[#090909] sm:h-[min(860px,calc(100dvh-48px))] sm:w-[min(920px,calc(100vw-48px))] sm:max-w-none sm:rounded-[2rem]">
+      <div className="flex h-dvh w-full flex-col overflow-hidden rounded-t-[1.75rem] bg-stone-50 shadow-2xl dark:bg-[#090909] sm:h-[min(860px,calc(100dvh-48px))] sm:w-[min(920px,calc(100vw-48px))] sm:max-w-none sm:rounded-[2rem]">
       <div className="mx-auto mt-2 h-1 w-12 shrink-0 rounded-full bg-stone-300/60 dark:bg-stone-700/70" />
 
       {/* 헤더 */}
-      <div className="flex items-center justify-between px-5 pb-5 pt-4 shrink-0 sm:pb-4 sm:pt-5">
+      <div className="flex items-center justify-between px-4 pb-4 pt-3 shrink-0 sm:px-5 sm:pb-4 sm:pt-5">
         <button
           onClick={handleClose}
-          className="flex h-11 w-11 items-center justify-center rounded-full text-accent-500 transition-colors hover:bg-stone-100 dark:text-accent-300 dark:hover:bg-stone-900"
+          className="flex h-10 w-10 items-center justify-center rounded-full text-accent-500 transition-colors hover:bg-stone-100 dark:text-accent-300 dark:hover:bg-stone-900 sm:h-11 sm:w-11"
           aria-label="닫기"
         >
-          <X size={28} strokeWidth={1.8} />
+          <X size={26} strokeWidth={1.8} />
         </button>
         <button
           onClick={handleSave}
           disabled={!title.trim() || !startDate || saving}
-          className="rounded-full border border-stone-200 bg-stone-50 px-8 py-2.5 text-sm font-bold text-stone-800 transition-colors hover:bg-stone-100 disabled:opacity-40 dark:border-stone-800 dark:bg-stone-950 dark:text-stone-100 dark:hover:bg-stone-900"
+          className="rounded-full border border-stone-200 bg-stone-50 px-7 py-2 text-sm font-bold text-stone-800 transition-colors hover:bg-stone-100 disabled:opacity-40 dark:border-stone-800 dark:bg-stone-950 dark:text-stone-100 dark:hover:bg-stone-900 sm:px-8 sm:py-2.5"
         >
           저장
         </button>
       </div>
 
-      <div className="flex-1 overflow-y-auto pb-10">
+      <div className="flex-1 overflow-y-auto pb-8 sm:pb-10">
         {/* 제목 */}
-        <div className="px-6 pb-6 sm:px-8 sm:pb-5">
+        <div className="px-5 pb-4 sm:px-8 sm:pb-5">
           <input
             ref={titleInputRef}
             type="text"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
             placeholder="제목"
-            className="w-full bg-transparent text-[1.875rem] font-extrabold leading-tight tracking-normal text-stone-900 placeholder:text-stone-400 focus:outline-none dark:text-stone-100 dark:placeholder:text-stone-600 sm:text-[2rem]"
+            className="w-full bg-transparent text-[1.625rem] font-extrabold leading-tight tracking-normal text-stone-900 placeholder:text-stone-400 focus:outline-none dark:text-stone-100 dark:placeholder:text-stone-600 sm:text-[2rem]"
           />
         </div>
 
@@ -294,20 +294,20 @@ export function EventFormModal({
 
         <div className="border-y border-stone-200/70 dark:border-stone-900">
           {/* 캘린더 선택 */}
-          <div className="grid min-h-16 grid-cols-[3.75rem_1fr] items-center border-b border-stone-200/70 dark:border-stone-900 sm:min-h-[4.75rem] sm:grid-cols-[4.5rem_1fr]">
+          <div className="grid min-h-14 grid-cols-[3.25rem_1fr] items-center border-b border-stone-200/70 dark:border-stone-900 sm:min-h-[4.75rem] sm:grid-cols-[4.5rem_1fr]">
             <div className="flex justify-center text-accent-500 dark:text-accent-300">
-              <CalendarDays size={26} strokeWidth={1.8} />
+              <CalendarDays size={22} strokeWidth={1.8} />
             </div>
-            <div className="min-w-0 pr-5">
+            <div className="min-w-0 pr-4 sm:pr-5">
               {calendars.length > 0 ? (
-                <div className="flex flex-wrap gap-2 py-3">
+                <div className="flex flex-wrap gap-2 py-2 sm:py-3">
                   {calendars.map((cal) => {
                     const active = calendarId === cal.id
                     return (
                       <button
                         key={cal.id}
                         onClick={() => setCalendarId(cal.id)}
-                        className="flex items-center gap-2 rounded-2xl px-3 py-1.5 text-sm font-semibold transition-all sm:px-3.5 sm:py-2 sm:text-base"
+                        className="flex items-center gap-2 rounded-xl px-3 py-1.5 text-sm font-semibold transition-all sm:rounded-2xl sm:px-3.5 sm:py-2 sm:text-base"
                         style={
                           active
                             ? { backgroundColor: cal.color, color: '#fff' }
@@ -330,33 +330,33 @@ export function EventFormModal({
           </div>
 
           {/* 종일 토글 */}
-          <div className="grid min-h-16 grid-cols-[3.75rem_1fr_auto] items-center border-b border-stone-200/70 dark:border-stone-900 sm:min-h-[4.75rem] sm:grid-cols-[4.5rem_1fr_auto]">
+          <div className="grid min-h-14 grid-cols-[3.25rem_1fr_auto] items-center border-b border-stone-200/70 dark:border-stone-900 sm:min-h-[4.75rem] sm:grid-cols-[4.5rem_1fr_auto]">
             <div className="flex justify-center text-accent-500 dark:text-accent-300">
-              <Clock3 size={25} strokeWidth={1.8} />
+              <Clock3 size={22} strokeWidth={1.8} />
             </div>
-            <span className="text-lg font-semibold text-stone-900 dark:text-stone-100 sm:text-xl">종일</span>
+            <span className="text-base font-semibold text-stone-900 dark:text-stone-100 sm:text-xl">종일</span>
             <button
               onClick={() => toggleAllDay(!isAllDay)}
-              className={`relative mr-5 h-8 w-[4.25rem] rounded-full transition-colors ${isAllDay ? 'bg-accent-400' : 'bg-stone-300 dark:bg-stone-700'}`}
+              className={`relative mr-4 h-7 w-14 rounded-full transition-colors sm:mr-5 sm:h-8 sm:w-[4.25rem] ${isAllDay ? 'bg-accent-400' : 'bg-stone-300 dark:bg-stone-700'}`}
               aria-label="종일"
             >
               <span
-                className={`absolute left-1 top-1 h-6 w-6 rounded-full bg-white shadow transition-transform ${isAllDay ? 'translate-x-9' : 'translate-x-0'}`}
+                className={`absolute left-1 top-1 h-5 w-5 rounded-full bg-white shadow transition-transform sm:h-6 sm:w-6 ${isAllDay ? 'translate-x-7 sm:translate-x-9' : 'translate-x-0'}`}
               />
             </button>
           </div>
 
           {/* 날짜/시간 */}
-          <div className="grid grid-cols-[3.75rem_1fr] border-b border-stone-200/70 dark:border-stone-900 sm:grid-cols-[4.5rem_1fr]">
+          <div className="grid grid-cols-[3.25rem_1fr] border-b border-stone-200/70 dark:border-stone-900 sm:grid-cols-[4.5rem_1fr]">
             <div />
-            <div className="py-4 pr-5 sm:py-5">
+            <div className="py-3 pr-4 sm:py-5 sm:pr-5">
               {isScopedRecurringEdit && (
                 <p className="mb-3 rounded-2xl bg-stone-100 px-4 py-3 text-sm text-stone-500 dark:bg-stone-900 dark:text-stone-400">
                   이 범위에서는 날짜 이동 없이 시간과 내용만 변경할 수 있어요.
                 </p>
               )}
 
-              <div className="grid grid-cols-[3.75rem_minmax(0,1fr)] items-center gap-y-3 sm:grid-cols-[4.5rem_minmax(0,1fr)] sm:gap-y-5">
+              <div className="grid grid-cols-[3.25rem_minmax(0,1fr)] items-center gap-y-2.5 sm:grid-cols-[4.5rem_minmax(0,1fr)] sm:gap-y-5">
                 <span className="text-base font-medium text-stone-800 dark:text-stone-100 sm:text-lg">시작</span>
                 <div className={`flex justify-end gap-2 ${isAllDay ? '' : 'min-w-0'}`}>
                   <div
@@ -440,17 +440,17 @@ export function EventFormModal({
           <button
             type="button"
             onClick={() => setLabelPickerOpen((v) => !v)}
-            className="grid min-h-16 w-full grid-cols-[3.75rem_1fr_auto] items-center border-b border-stone-200/70 text-left dark:border-stone-900 sm:min-h-[4.75rem] sm:grid-cols-[4.5rem_1fr_auto]"
+            className="grid min-h-14 w-full grid-cols-[3.25rem_1fr_auto] items-center border-b border-stone-200/70 text-left dark:border-stone-900 sm:min-h-[4.75rem] sm:grid-cols-[4.5rem_1fr_auto]"
           >
             <div className="flex justify-center text-accent-500 dark:text-accent-300">
-              <Tag size={25} strokeWidth={1.8} />
+              <Tag size={22} strokeWidth={1.8} />
             </div>
-            <span className="text-lg font-semibold text-stone-900 dark:text-stone-100 sm:text-xl">라벨</span>
-            <div className="mr-5 flex items-center gap-2 text-right">
+            <span className="text-base font-semibold text-stone-900 dark:text-stone-100 sm:text-xl">라벨</span>
+            <div className="mr-4 flex items-center gap-2 text-right sm:mr-5">
               {labelColor ? (
                 <>
                   <span
-                    className="h-6 w-6 rounded-full shrink-0"
+                    className="h-5 w-5 rounded-full shrink-0 sm:h-6 sm:w-6"
                     style={{ backgroundColor: toDisplayColor(labelColor) }}
                   />
                   <span className="text-sm font-semibold text-stone-500 dark:text-stone-400">
@@ -502,23 +502,23 @@ export function EventFormModal({
           )}
 
           {/* 알림 */}
-          <div className="grid grid-cols-[3.75rem_1fr] border-b border-stone-200/70 dark:border-stone-900 sm:grid-cols-[4.5rem_1fr]">
-            <div className="flex justify-center pt-5 text-accent-500 dark:text-accent-300 sm:pt-6">
-              <Bell size={25} strokeWidth={1.8} />
+          <div className="grid grid-cols-[3.25rem_1fr] border-b border-stone-200/70 dark:border-stone-900 sm:grid-cols-[4.5rem_1fr]">
+            <div className="flex justify-center pt-4 text-accent-500 dark:text-accent-300 sm:pt-6">
+              <Bell size={22} strokeWidth={1.8} />
             </div>
-            <div className="py-4 pr-5 sm:py-5">
-              <div className="mb-3 flex items-center justify-between gap-3">
-                <span className="text-lg font-semibold text-stone-900 dark:text-stone-100 sm:text-xl">알람</span>
+            <div className="py-3 pr-4 sm:py-5 sm:pr-5">
+              <div className="mb-2 flex items-center justify-between gap-3 sm:mb-3">
+                <span className="text-base font-semibold text-stone-900 dark:text-stone-100 sm:text-xl">알람</span>
                 <span className="max-w-[55%] truncate text-sm font-semibold text-stone-400">{reminderLabel}</span>
               </div>
-              <div className="flex flex-wrap gap-2">
+              <div className="flex flex-wrap gap-1.5 sm:gap-2">
                 {REMINDER_OPTIONS.map((opt) => {
                   const active = reminderMinutes.has(opt.minutes)
                   return (
                     <button
                       key={opt.minutes}
                       onClick={() => toggleReminder(opt.minutes)}
-                      className={`rounded-full px-3.5 py-1.5 text-sm font-semibold transition-colors sm:px-4 sm:py-2 ${
+                      className={`rounded-xl px-3 py-1.5 text-xs font-semibold transition-colors sm:rounded-full sm:px-4 sm:py-2 sm:text-sm ${
                         active
                           ? 'bg-accent-400 text-white'
                           : 'bg-stone-200 text-stone-600 dark:bg-stone-800 dark:text-stone-300'
@@ -533,27 +533,27 @@ export function EventFormModal({
           </div>
 
           {/* 보조 기능 */}
-          <div className="grid grid-cols-[3.75rem_1fr] sm:grid-cols-[4.5rem_1fr]">
-            <div className="flex justify-center pt-5 text-accent-500 dark:text-accent-300 sm:pt-6">
-              <AlignLeft size={25} strokeWidth={1.8} />
+          <div className="grid grid-cols-[3.25rem_1fr] sm:grid-cols-[4.5rem_1fr]">
+            <div className="flex justify-center pt-4 text-accent-500 dark:text-accent-300 sm:pt-6">
+              <AlignLeft size={22} strokeWidth={1.8} />
             </div>
-            <div className="space-y-3 py-4 pr-5 sm:py-5">
+            <div className="space-y-2.5 py-3 pr-4 sm:space-y-3 sm:py-5 sm:pr-5">
               <textarea
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
                 placeholder="메모 (선택)"
                 rows={2}
-                className="w-full resize-none rounded-2xl bg-stone-100 px-4 py-3 text-base text-stone-800 placeholder:text-stone-400 focus:outline-none focus:ring-2 focus:ring-accent-400 dark:bg-stone-900 dark:text-stone-100"
+                className="w-full resize-none rounded-xl bg-stone-100 px-3 py-2.5 text-sm text-stone-800 placeholder:text-stone-400 focus:outline-none focus:ring-2 focus:ring-accent-400 dark:bg-stone-900 dark:text-stone-100 sm:rounded-2xl sm:px-4 sm:py-3 sm:text-base"
               />
 
               {isNewEvent && (
                 <button
                   onClick={() => setRecurrenceModal('picker')}
-                  className="flex min-h-12 w-full items-center justify-between rounded-2xl bg-stone-100 px-4 text-left dark:bg-stone-900"
+                  className="flex min-h-11 w-full items-center justify-between rounded-xl bg-stone-100 px-3 text-left dark:bg-stone-900 sm:min-h-12 sm:rounded-2xl sm:px-4"
                 >
                   <div className="flex items-center gap-3">
                     <RefreshCw size={18} className="text-accent-500 dark:text-accent-300" />
-                    <span className="text-base font-semibold text-stone-800 dark:text-stone-100">반복</span>
+                    <span className="text-sm font-semibold text-stone-800 dark:text-stone-100 sm:text-base">반복</span>
                   </div>
                   <div className="flex items-center gap-1 text-sm font-semibold text-stone-400">
                     <span>{recurrence ? buildRecurrenceLabel(recurrence) : '안 함'}</span>

--- a/src/components/calendar/EventFormModal.tsx
+++ b/src/components/calendar/EventFormModal.tsx
@@ -238,13 +238,13 @@ export function EventFormModal({
   }
 
   const timeBtnCls = (active: boolean) =>
-    `min-w-20 px-4 py-2.5 rounded-2xl text-sm font-semibold text-center transition-colors shrink-0 ${
+    `min-w-[4.5rem] px-3 py-2 rounded-2xl text-sm font-semibold text-center transition-colors shrink-0 sm:min-w-20 sm:px-4 sm:py-2.5 ${
       active
         ? 'bg-accent-400 text-white'
         : 'bg-stone-100 dark:bg-stone-800/95 text-stone-700 dark:text-stone-100'
     }`
 
-  const dateBtnCls = 'relative overflow-hidden min-w-0 px-4 py-2.5 rounded-2xl bg-stone-100 dark:bg-stone-800/95 text-sm font-semibold text-stone-700 dark:text-stone-100 text-center'
+  const dateBtnCls = 'relative overflow-hidden min-w-0 px-3 py-2 rounded-2xl bg-stone-100 dark:bg-stone-800/95 text-sm font-semibold text-stone-700 dark:text-stone-100 text-center sm:px-4 sm:py-2.5'
   const reminderLabel = reminderMinutes.size > 0
     ? REMINDER_OPTIONS
       .filter((opt) => reminderMinutes.has(opt.minutes))
@@ -258,7 +258,7 @@ export function EventFormModal({
       <div className="mx-auto mt-2 h-1 w-12 shrink-0 rounded-full bg-stone-300/60 dark:bg-stone-700/70" />
 
       {/* 헤더 */}
-      <div className="flex items-center justify-between px-5 pb-8 pt-6 shrink-0 sm:pb-4 sm:pt-5">
+      <div className="flex items-center justify-between px-5 pb-5 pt-4 shrink-0 sm:pb-4 sm:pt-5">
         <button
           onClick={handleClose}
           className="flex h-11 w-11 items-center justify-center rounded-full text-accent-500 transition-colors hover:bg-stone-100 dark:text-accent-300 dark:hover:bg-stone-900"
@@ -277,14 +277,14 @@ export function EventFormModal({
 
       <div className="flex-1 overflow-y-auto pb-10">
         {/* 제목 */}
-        <div className="px-8 pb-9 sm:pb-5">
+        <div className="px-6 pb-6 sm:px-8 sm:pb-5">
           <input
             ref={titleInputRef}
             type="text"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
             placeholder="제목"
-            className="w-full bg-transparent text-[2.35rem] font-extrabold leading-tight tracking-normal text-stone-900 placeholder:text-stone-400 focus:outline-none dark:text-stone-100 dark:placeholder:text-stone-600 sm:text-[2rem]"
+            className="w-full bg-transparent text-[1.875rem] font-extrabold leading-tight tracking-normal text-stone-900 placeholder:text-stone-400 focus:outline-none dark:text-stone-100 dark:placeholder:text-stone-600 sm:text-[2rem]"
           />
         </div>
 
@@ -294,7 +294,7 @@ export function EventFormModal({
 
         <div className="border-y border-stone-200/70 dark:border-stone-900">
           {/* 캘린더 선택 */}
-          <div className="grid min-h-[4.75rem] grid-cols-[4.5rem_1fr] items-center border-b border-stone-200/70 dark:border-stone-900">
+          <div className="grid min-h-16 grid-cols-[3.75rem_1fr] items-center border-b border-stone-200/70 dark:border-stone-900 sm:min-h-[4.75rem] sm:grid-cols-[4.5rem_1fr]">
             <div className="flex justify-center text-accent-500 dark:text-accent-300">
               <CalendarDays size={26} strokeWidth={1.8} />
             </div>
@@ -307,7 +307,7 @@ export function EventFormModal({
                       <button
                         key={cal.id}
                         onClick={() => setCalendarId(cal.id)}
-                        className="flex items-center gap-2 rounded-2xl px-3.5 py-2 text-base font-semibold transition-all"
+                        className="flex items-center gap-2 rounded-2xl px-3 py-1.5 text-sm font-semibold transition-all sm:px-3.5 sm:py-2 sm:text-base"
                         style={
                           active
                             ? { backgroundColor: cal.color, color: '#fff' }
@@ -324,17 +324,17 @@ export function EventFormModal({
                   })}
                 </div>
               ) : (
-                <span className="text-lg font-semibold text-stone-500 dark:text-stone-400">캘린더 없음</span>
+                <span className="text-base font-semibold text-stone-500 dark:text-stone-400 sm:text-lg">캘린더 없음</span>
               )}
             </div>
           </div>
 
           {/* 종일 토글 */}
-          <div className="grid min-h-[4.75rem] grid-cols-[4.5rem_1fr_auto] items-center border-b border-stone-200/70 dark:border-stone-900">
+          <div className="grid min-h-16 grid-cols-[3.75rem_1fr_auto] items-center border-b border-stone-200/70 dark:border-stone-900 sm:min-h-[4.75rem] sm:grid-cols-[4.5rem_1fr_auto]">
             <div className="flex justify-center text-accent-500 dark:text-accent-300">
               <Clock3 size={25} strokeWidth={1.8} />
             </div>
-            <span className="text-xl font-semibold text-stone-900 dark:text-stone-100">종일</span>
+            <span className="text-lg font-semibold text-stone-900 dark:text-stone-100 sm:text-xl">종일</span>
             <button
               onClick={() => toggleAllDay(!isAllDay)}
               className={`relative mr-5 h-8 w-[4.25rem] rounded-full transition-colors ${isAllDay ? 'bg-accent-400' : 'bg-stone-300 dark:bg-stone-700'}`}
@@ -347,17 +347,17 @@ export function EventFormModal({
           </div>
 
           {/* 날짜/시간 */}
-          <div className="grid grid-cols-[4.5rem_1fr] border-b border-stone-200/70 dark:border-stone-900">
+          <div className="grid grid-cols-[3.75rem_1fr] border-b border-stone-200/70 dark:border-stone-900 sm:grid-cols-[4.5rem_1fr]">
             <div />
-            <div className="py-5 pr-5">
+            <div className="py-4 pr-5 sm:py-5">
               {isScopedRecurringEdit && (
                 <p className="mb-3 rounded-2xl bg-stone-100 px-4 py-3 text-sm text-stone-500 dark:bg-stone-900 dark:text-stone-400">
                   이 범위에서는 날짜 이동 없이 시간과 내용만 변경할 수 있어요.
                 </p>
               )}
 
-              <div className="grid grid-cols-[4.5rem_minmax(0,1fr)] items-center gap-y-5">
-                <span className="text-lg font-medium text-stone-800 dark:text-stone-100">시작</span>
+              <div className="grid grid-cols-[3.75rem_minmax(0,1fr)] items-center gap-y-3 sm:grid-cols-[4.5rem_minmax(0,1fr)] sm:gap-y-5">
+                <span className="text-base font-medium text-stone-800 dark:text-stone-100 sm:text-lg">시작</span>
                 <div className={`flex justify-end gap-2 ${isAllDay ? '' : 'min-w-0'}`}>
                   <div
                     data-testid="start-date-button"
@@ -395,7 +395,7 @@ export function EventFormModal({
                   </div>
                 )}
 
-                <span className="text-lg font-medium text-stone-800 dark:text-stone-100">종료</span>
+                <span className="text-base font-medium text-stone-800 dark:text-stone-100 sm:text-lg">종료</span>
                 <div className={`flex justify-end gap-2 ${endShake ? 'shake' : ''}`}>
                   <div
                     data-testid="end-date-button"
@@ -440,12 +440,12 @@ export function EventFormModal({
           <button
             type="button"
             onClick={() => setLabelPickerOpen((v) => !v)}
-            className="grid min-h-[4.75rem] w-full grid-cols-[4.5rem_1fr_auto] items-center border-b border-stone-200/70 text-left dark:border-stone-900"
+            className="grid min-h-16 w-full grid-cols-[3.75rem_1fr_auto] items-center border-b border-stone-200/70 text-left dark:border-stone-900 sm:min-h-[4.75rem] sm:grid-cols-[4.5rem_1fr_auto]"
           >
             <div className="flex justify-center text-accent-500 dark:text-accent-300">
               <Tag size={25} strokeWidth={1.8} />
             </div>
-            <span className="text-xl font-semibold text-stone-900 dark:text-stone-100">라벨</span>
+            <span className="text-lg font-semibold text-stone-900 dark:text-stone-100 sm:text-xl">라벨</span>
             <div className="mr-5 flex items-center gap-2 text-right">
               {labelColor ? (
                 <>
@@ -502,13 +502,13 @@ export function EventFormModal({
           )}
 
           {/* 알림 */}
-          <div className="grid grid-cols-[4.5rem_1fr] border-b border-stone-200/70 dark:border-stone-900">
-            <div className="flex justify-center pt-6 text-accent-500 dark:text-accent-300">
+          <div className="grid grid-cols-[3.75rem_1fr] border-b border-stone-200/70 dark:border-stone-900 sm:grid-cols-[4.5rem_1fr]">
+            <div className="flex justify-center pt-5 text-accent-500 dark:text-accent-300 sm:pt-6">
               <Bell size={25} strokeWidth={1.8} />
             </div>
-            <div className="py-5 pr-5">
+            <div className="py-4 pr-5 sm:py-5">
               <div className="mb-3 flex items-center justify-between gap-3">
-                <span className="text-xl font-semibold text-stone-900 dark:text-stone-100">알람</span>
+                <span className="text-lg font-semibold text-stone-900 dark:text-stone-100 sm:text-xl">알람</span>
                 <span className="max-w-[55%] truncate text-sm font-semibold text-stone-400">{reminderLabel}</span>
               </div>
               <div className="flex flex-wrap gap-2">
@@ -518,7 +518,7 @@ export function EventFormModal({
                     <button
                       key={opt.minutes}
                       onClick={() => toggleReminder(opt.minutes)}
-                      className={`rounded-full px-4 py-2 text-sm font-semibold transition-colors ${
+                      className={`rounded-full px-3.5 py-1.5 text-sm font-semibold transition-colors sm:px-4 sm:py-2 ${
                         active
                           ? 'bg-accent-400 text-white'
                           : 'bg-stone-200 text-stone-600 dark:bg-stone-800 dark:text-stone-300'
@@ -533,11 +533,11 @@ export function EventFormModal({
           </div>
 
           {/* 보조 기능 */}
-          <div className="grid grid-cols-[4.5rem_1fr]">
-            <div className="flex justify-center pt-6 text-accent-500 dark:text-accent-300">
+          <div className="grid grid-cols-[3.75rem_1fr] sm:grid-cols-[4.5rem_1fr]">
+            <div className="flex justify-center pt-5 text-accent-500 dark:text-accent-300 sm:pt-6">
               <AlignLeft size={25} strokeWidth={1.8} />
             </div>
-            <div className="space-y-3 py-5 pr-5">
+            <div className="space-y-3 py-4 pr-5 sm:py-5">
               <textarea
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}

--- a/src/components/calendar/EventFormModal.tsx
+++ b/src/components/calendar/EventFormModal.tsx
@@ -17,12 +17,6 @@ function formatDateWithDOW(dateStr: string): string {
   return `${d.getFullYear()}년 ${d.getMonth() + 1}월 ${d.getDate()}일 (${DOW_KR[d.getDay()]})`
 }
 
-function formatShortDateWithDOW(dateStr: string): string {
-  if (!dateStr) return ''
-  const d = new Date(dateStr + 'T00:00:00')
-  return `${d.getMonth() + 1}/${d.getDate()} (${DOW_KR[d.getDay()]})`
-}
-
 function buildTime(h: number, m: number): string {
   return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`
 }
@@ -164,16 +158,6 @@ export function EventFormModal({
 
   const toggleTimePicker = (which: 'start' | 'end') => {
     setActiveTimePicker((prev) => (prev === which ? null : which))
-  }
-
-  const openDatePicker = (input: HTMLInputElement | null) => {
-    if (!canEditOccurrenceDate || !input) return
-    if (typeof input.showPicker === 'function') {
-      input.showPicker()
-      return
-    }
-    input.focus()
-    input.click()
   }
 
   const handleEndDateChange = (value: string) => {
@@ -378,32 +362,19 @@ export function EventFormModal({
               <div className="grid grid-cols-[3.25rem_minmax(0,1fr)] items-center gap-y-2.5 sm:grid-cols-[4.5rem_minmax(0,1fr)] sm:gap-y-5">
                 <span className="text-base font-medium text-stone-800 dark:text-stone-100 sm:text-lg">시작</span>
                 <div className={`flex justify-end gap-2 ${isAllDay ? '' : 'min-w-0'}`}>
-                  <div className={isAllDay ? 'relative w-full max-w-[18rem]' : 'relative flex-1'}>
-                    <button
-                      type="button"
+                  <div
                       data-testid="start-date-button"
-                      aria-label={`시작 날짜 ${formatDateWithDOW(startDate)}`}
-                      disabled={!canEditOccurrenceDate}
-                      className={`w-full ${dateBtnCls}`}
-                      onClick={() => openDatePicker(startDateInputRef.current)}
+                    className={`${isAllDay ? 'w-full max-w-[18rem]' : 'flex-1'} ${dateBtnCls}`}
                     >
-                      {isAllDay ? (
-                        <span className="relative z-10 pointer-events-none whitespace-nowrap">{formatDateWithDOW(startDate)}</span>
-                      ) : (
-                        <>
-                          <span className="relative z-10 pointer-events-none whitespace-nowrap sm:hidden">{formatShortDateWithDOW(startDate)}</span>
-                          <span className="relative z-10 pointer-events-none hidden whitespace-nowrap sm:inline">{formatDateWithDOW(startDate)}</span>
-                        </>
-                      )}
-                    </button>
+                    <span className="relative z-10 pointer-events-none whitespace-nowrap">{formatDateWithDOW(startDate)}</span>
                     <input
                       ref={startDateInputRef}
                       type="date"
                       value={startDate}
                       disabled={!canEditOccurrenceDate}
-                      tabIndex={-1}
+                      aria-label={`시작 날짜 ${formatDateWithDOW(startDate)}`}
                       onChange={(e) => setStartDate(e.target.value)}
-                      className="pointer-events-none absolute inset-0 h-full w-full opacity-0"
+                      className={`absolute inset-0 h-full w-full opacity-0 ${canEditOccurrenceDate ? 'cursor-pointer' : 'cursor-default'}`}
                     />
                   </div>
                   {!isAllDay && (
@@ -428,32 +399,19 @@ export function EventFormModal({
 
                 <span className="text-base font-medium text-stone-800 dark:text-stone-100 sm:text-lg">종료</span>
                 <div className={`flex justify-end gap-2 ${endShake ? 'shake' : ''}`}>
-                  <div className={isAllDay ? 'relative w-full max-w-[18rem]' : 'relative flex-1'}>
-                    <button
-                      type="button"
+                  <div
                       data-testid="end-date-button"
-                      aria-label={`종료 날짜 ${formatDateWithDOW(endDate)}`}
-                      disabled={!canEditOccurrenceDate}
-                      className={`w-full ${dateBtnCls}`}
-                      onClick={() => openDatePicker(endDateInputRef.current)}
+                    className={`${isAllDay ? 'w-full max-w-[18rem]' : 'flex-1'} ${dateBtnCls}`}
                     >
-                      {isAllDay ? (
-                        <span className="relative z-10 pointer-events-none whitespace-nowrap">{formatDateWithDOW(endDate)}</span>
-                      ) : (
-                        <>
-                          <span className="relative z-10 pointer-events-none whitespace-nowrap sm:hidden">{formatShortDateWithDOW(endDate)}</span>
-                          <span className="relative z-10 pointer-events-none hidden whitespace-nowrap sm:inline">{formatDateWithDOW(endDate)}</span>
-                        </>
-                      )}
-                    </button>
+                    <span className="relative z-10 pointer-events-none whitespace-nowrap">{formatDateWithDOW(endDate)}</span>
                     <input
                       ref={endDateInputRef}
                       type="date"
                       value={endDate}
                       disabled={!canEditOccurrenceDate}
-                      tabIndex={-1}
+                      aria-label={`종료 날짜 ${formatDateWithDOW(endDate)}`}
                       onChange={(e) => handleEndDateChange(e.target.value)}
-                      className="pointer-events-none absolute inset-0 h-full w-full opacity-0"
+                      className={`absolute inset-0 h-full w-full opacity-0 ${canEditOccurrenceDate ? 'cursor-pointer' : 'cursor-default'}`}
                     />
                   </div>
                   {!isAllDay && (

--- a/src/components/calendar/EventFormModal.tsx
+++ b/src/components/calendar/EventFormModal.tsx
@@ -258,7 +258,7 @@ export function EventFormModal({
       <div className="mx-auto mt-2 h-1 w-12 shrink-0 rounded-full bg-stone-300/60 dark:bg-stone-700/70" />
 
       {/* 헤더 */}
-      <div className="flex items-center justify-between px-5 pb-8 pt-6 shrink-0">
+      <div className="flex items-center justify-between px-5 pb-8 pt-6 shrink-0 sm:pb-4 sm:pt-5">
         <button
           onClick={handleClose}
           className="flex h-11 w-11 items-center justify-center rounded-full text-accent-500 transition-colors hover:bg-stone-100 dark:text-accent-300 dark:hover:bg-stone-900"
@@ -277,14 +277,14 @@ export function EventFormModal({
 
       <div className="flex-1 overflow-y-auto pb-10">
         {/* 제목 */}
-        <div className="px-8 pb-9">
+        <div className="px-8 pb-9 sm:pb-5">
           <input
             ref={titleInputRef}
             type="text"
             value={title}
             onChange={(e) => setTitle(e.target.value)}
             placeholder="제목"
-            className="w-full bg-transparent text-[2.35rem] font-extrabold leading-tight tracking-normal text-stone-900 placeholder:text-stone-400 focus:outline-none dark:text-stone-100 dark:placeholder:text-stone-600"
+            className="w-full bg-transparent text-[2.35rem] font-extrabold leading-tight tracking-normal text-stone-900 placeholder:text-stone-400 focus:outline-none dark:text-stone-100 dark:placeholder:text-stone-600 sm:text-[2rem]"
           />
         </div>
 

--- a/src/components/calendar/EventFormModal.tsx
+++ b/src/components/calendar/EventFormModal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useRef, useEffect } from 'react'
+import { useState, useRef, useEffect, type MouseEvent } from 'react'
 import { X, Bell, RefreshCw, Check, Tag, CalendarDays, Clock3, ChevronRight, AlignLeft } from 'lucide-react'
 import { REMINDER_OPTIONS, LABEL_COLORS, LABEL_COLOR_NAMES, type Calendar, type CalendarEvent } from '@/lib/calendar'
 import { toDisplayColor } from '@/lib/label-colors'
@@ -158,6 +158,17 @@ export function EventFormModal({
 
   const toggleTimePicker = (which: 'start' | 'end') => {
     setActiveTimePicker((prev) => (prev === which ? null : which))
+  }
+
+  const openDatePicker = (input: HTMLInputElement | null) => {
+    if (!input || input.disabled) return
+    input.focus({ preventScroll: true })
+    input.showPicker?.()
+  }
+
+  const handleDateButtonClick = (event: MouseEvent<HTMLLabelElement>, input: HTMLInputElement | null) => {
+    event.preventDefault()
+    openDatePicker(input)
   }
 
   const keepEndAtOrAfterStart = (
@@ -375,10 +386,11 @@ export function EventFormModal({
               <div className="grid grid-cols-[3.25rem_minmax(0,1fr)] items-center gap-y-2.5 sm:grid-cols-[4.5rem_minmax(0,1fr)] sm:gap-y-5">
                 <span className="text-base font-medium text-stone-800 dark:text-stone-100 sm:text-lg">시작</span>
                 <div className={`flex justify-end gap-2 ${isAllDay ? '' : 'min-w-0'}`}>
-                  <div
-                      data-testid="start-date-button"
+                  <label
+                    data-testid="start-date-button"
+                    onClick={(event) => handleDateButtonClick(event, startDateInputRef.current)}
                     className={`${isAllDay ? 'w-full max-w-[18rem]' : 'flex-1'} ${dateBtnCls}`}
-                    >
+                  >
                     <span className="relative z-10 pointer-events-none whitespace-nowrap">{formatDateWithDOW(startDate)}</span>
                     <input
                       ref={startDateInputRef}
@@ -389,7 +401,7 @@ export function EventFormModal({
                       onChange={(e) => handleStartDateChange(e.target.value)}
                       className={`absolute inset-0 h-full w-full opacity-0 ${canEditOccurrenceDate ? 'cursor-pointer' : 'cursor-default'}`}
                     />
-                  </div>
+                  </label>
                   {!isAllDay && (
                     <button
                       onClick={() => toggleTimePicker('start')}
@@ -412,10 +424,11 @@ export function EventFormModal({
 
                 <span className="text-base font-medium text-stone-800 dark:text-stone-100 sm:text-lg">종료</span>
                 <div className={`flex justify-end gap-2 ${endShake ? 'shake' : ''}`}>
-                  <div
-                      data-testid="end-date-button"
+                  <label
+                    data-testid="end-date-button"
+                    onClick={(event) => handleDateButtonClick(event, endDateInputRef.current)}
                     className={`${isAllDay ? 'w-full max-w-[18rem]' : 'flex-1'} ${dateBtnCls}`}
-                    >
+                  >
                     <span className="relative z-10 pointer-events-none whitespace-nowrap">{formatDateWithDOW(endDate)}</span>
                     <input
                       ref={endDateInputRef}
@@ -426,7 +439,7 @@ export function EventFormModal({
                       onChange={(e) => handleEndDateChange(e.target.value)}
                       className={`absolute inset-0 h-full w-full opacity-0 ${canEditOccurrenceDate ? 'cursor-pointer' : 'cursor-default'}`}
                     />
-                  </div>
+                  </label>
                   {!isAllDay && (
                     <button
                       onClick={() => toggleTimePicker('end')}

--- a/src/components/calendar/EventFormModal.tsx
+++ b/src/components/calendar/EventFormModal.tsx
@@ -160,13 +160,13 @@ export function EventFormModal({
     setActiveTimePicker((prev) => (prev === which ? null : which))
   }
 
-  const openDatePicker = (input: HTMLInputElement | null) => {
-    if (!input || input.disabled) return
+  const openDatePicker = (input: HTMLInputElement) => {
     input.focus({ preventScroll: true })
-    input.showPicker?.()
+    input.showPicker()
   }
 
   const handleDateButtonClick = (event: MouseEvent<HTMLLabelElement>, input: HTMLInputElement | null) => {
+    if (!input || input.disabled || typeof input.showPicker !== 'function') return
     event.preventDefault()
     openDatePicker(input)
   }

--- a/src/components/calendar/EventFormModal.tsx
+++ b/src/components/calendar/EventFormModal.tsx
@@ -360,7 +360,8 @@ export function EventFormModal({
                 <span className="text-lg font-medium text-stone-800 dark:text-stone-100">시작</span>
                 <div className={`flex justify-end gap-2 ${isAllDay ? '' : 'min-w-0'}`}>
                   <div
-                    className={`${isAllDay ? 'w-full max-w-[18rem]' : 'flex-1 '}${dateBtnCls}`}
+                    data-testid="start-date-button"
+                    className={`${isAllDay ? 'w-full max-w-[18rem]' : 'flex-1'} ${dateBtnCls}`}
                     onClick={() => { if (canEditOccurrenceDate) startDateInputRef.current?.showPicker?.() }}
                   >
                     <span className="relative z-10 pointer-events-none whitespace-nowrap">{formatDateWithDOW(startDate)}</span>
@@ -396,7 +397,8 @@ export function EventFormModal({
                 <span className="text-lg font-medium text-stone-800 dark:text-stone-100">종료</span>
                 <div className={`flex justify-end gap-2 ${endShake ? 'shake' : ''}`}>
                   <div
-                    className={`${isAllDay ? 'w-full max-w-[18rem]' : 'flex-1 '}${dateBtnCls}`}
+                    data-testid="end-date-button"
+                    className={`${isAllDay ? 'w-full max-w-[18rem]' : 'flex-1'} ${dateBtnCls}`}
                     onClick={() => { if (canEditOccurrenceDate) endDateInputRef.current?.showPicker?.() }}
                   >
                     <span className="relative z-10 pointer-events-none whitespace-nowrap">{formatDateWithDOW(endDate)}</span>

--- a/src/components/calendar/EventFormModal.tsx
+++ b/src/components/calendar/EventFormModal.tsx
@@ -254,7 +254,7 @@ export function EventFormModal({
 
   return (
     <div className={`fixed inset-0 z-[70] bg-stone-950/40 dark:bg-black flex items-end sm:items-center justify-center sm:p-6 ${isClosing ? 'modal-slide-down' : 'modal-slide-up'}`}>
-      <div className="flex h-dvh w-full flex-col overflow-hidden rounded-t-[2rem] bg-stone-50 shadow-2xl dark:bg-[#090909] sm:h-[min(860px,calc(100dvh-48px))] sm:max-w-xl sm:rounded-[2rem]">
+      <div className="flex h-dvh w-full flex-col overflow-hidden rounded-t-[2rem] bg-stone-50 shadow-2xl dark:bg-[#090909] sm:h-[min(860px,calc(100dvh-48px))] sm:w-[min(920px,calc(100vw-48px))] sm:max-w-none sm:rounded-[2rem]">
       <div className="mx-auto mt-2 h-1 w-12 shrink-0 rounded-full bg-stone-300/60 dark:bg-stone-700/70" />
 
       {/* 헤더 */}

--- a/src/components/calendar/EventFormModal.tsx
+++ b/src/components/calendar/EventFormModal.tsx
@@ -532,12 +532,12 @@ export function EventFormModal({
             </div>
           </div>
 
-          {/* 보조 기능 */}
-          <div className="grid grid-cols-[3.25rem_1fr] sm:grid-cols-[4.5rem_1fr]">
+          {/* 메모 */}
+          <div className="grid grid-cols-[3.25rem_1fr] border-b border-stone-200/70 dark:border-stone-900 sm:grid-cols-[4.5rem_1fr]">
             <div className="flex justify-center pt-4 text-accent-500 dark:text-accent-300 sm:pt-6">
               <AlignLeft size={22} strokeWidth={1.8} />
             </div>
-            <div className="space-y-2.5 py-3 pr-4 sm:space-y-3 sm:py-5 sm:pr-5">
+            <div className="py-3 pr-4 sm:py-5 sm:pr-5">
               <textarea
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
@@ -545,24 +545,26 @@ export function EventFormModal({
                 rows={2}
                 className="w-full resize-none rounded-xl bg-stone-100 px-3 py-2.5 text-sm text-stone-800 placeholder:text-stone-400 focus:outline-none focus:ring-2 focus:ring-accent-400 dark:bg-stone-900 dark:text-stone-100 sm:rounded-2xl sm:px-4 sm:py-3 sm:text-base"
               />
-
-              {isNewEvent && (
-                <button
-                  onClick={() => setRecurrenceModal('picker')}
-                  className="flex min-h-11 w-full items-center justify-between rounded-xl bg-stone-100 px-3 text-left dark:bg-stone-900 sm:min-h-12 sm:rounded-2xl sm:px-4"
-                >
-                  <div className="flex items-center gap-3">
-                    <RefreshCw size={18} className="text-accent-500 dark:text-accent-300" />
-                    <span className="text-sm font-semibold text-stone-800 dark:text-stone-100 sm:text-base">반복</span>
-                  </div>
-                  <div className="flex items-center gap-1 text-sm font-semibold text-stone-400">
-                    <span>{recurrence ? buildRecurrenceLabel(recurrence) : '안 함'}</span>
-                    <ChevronRight size={18} />
-                  </div>
-                </button>
-              )}
             </div>
           </div>
+
+          {/* 반복 */}
+          {isNewEvent && (
+            <button
+              type="button"
+              onClick={() => setRecurrenceModal('picker')}
+              className="grid min-h-14 w-full grid-cols-[3.25rem_1fr_auto] items-center text-left sm:min-h-[4.75rem] sm:grid-cols-[4.5rem_1fr_auto]"
+            >
+              <div className="flex justify-center text-accent-500 dark:text-accent-300">
+                <RefreshCw size={22} strokeWidth={1.8} />
+              </div>
+              <span className="text-base font-semibold text-stone-900 dark:text-stone-100 sm:text-xl">반복</span>
+              <div className="mr-4 flex items-center gap-1 text-sm font-semibold text-stone-400 sm:mr-5">
+                <span>{recurrence ? buildRecurrenceLabel(recurrence) : '안 함'}</span>
+                <ChevronRight size={18} />
+              </div>
+            </button>
+          )}
         </div>
       </div>
 

--- a/src/components/calendar/EventFormModal.tsx
+++ b/src/components/calendar/EventFormModal.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useRef, useEffect } from 'react'
-import { X, Bell, RefreshCw, Check, Tag } from 'lucide-react'
+import { X, Bell, RefreshCw, Check, Tag, CalendarDays, Clock3, ChevronRight, AlignLeft } from 'lucide-react'
 import { REMINDER_OPTIONS, LABEL_COLORS, LABEL_COLOR_NAMES, type Calendar, type CalendarEvent } from '@/lib/calendar'
 import { toDisplayColor } from '@/lib/label-colors'
 import { TimeWheelPicker } from './TimeWheelPicker'
@@ -14,7 +14,7 @@ const DOW_KR = ['일', '월', '화', '수', '목', '금', '토']
 function formatDateWithDOW(dateStr: string): string {
   if (!dateStr) return ''
   const d = new Date(dateStr + 'T00:00:00')
-  return `${d.getFullYear()}/${String(d.getMonth() + 1).padStart(2, '0')}/${String(d.getDate()).padStart(2, '0')}(${DOW_KR[d.getDay()]})`
+  return `${d.getFullYear()}년 ${d.getMonth() + 1}월 ${d.getDate()}일 (${DOW_KR[d.getDay()]})`
 }
 
 function buildTime(h: number, m: number): string {
@@ -238,109 +238,236 @@ export function EventFormModal({
   }
 
   const timeBtnCls = (active: boolean) =>
-    `w-24 px-3 py-2.5 rounded-xl text-sm font-semibold text-center transition-colors shrink-0 ${
+    `min-w-20 px-4 py-2.5 rounded-2xl text-sm font-semibold text-center transition-colors shrink-0 ${
       active
         ? 'bg-accent-400 text-white'
-        : 'bg-stone-100 dark:bg-stone-800 text-stone-700 dark:text-stone-200'
+        : 'bg-stone-100 dark:bg-stone-800/95 text-stone-700 dark:text-stone-100'
     }`
 
-  const dateBtnCls = 'relative overflow-hidden px-3 py-2.5 rounded-xl bg-stone-100 dark:bg-stone-800 text-sm font-medium text-stone-700 dark:text-stone-200 text-left'
+  const dateBtnCls = 'relative overflow-hidden min-w-0 px-4 py-2.5 rounded-2xl bg-stone-100 dark:bg-stone-800/95 text-sm font-semibold text-stone-700 dark:text-stone-100 text-center'
+  const reminderLabel = reminderMinutes.size > 0
+    ? REMINDER_OPTIONS
+      .filter((opt) => reminderMinutes.has(opt.minutes))
+      .map((opt) => opt.label)
+      .join(', ')
+    : '없음'
 
   return (
-    <div className={`fixed inset-0 z-[70] bg-white dark:bg-stone-900 flex flex-col ${isClosing ? 'modal-slide-down' : 'modal-slide-up'}`}>
+    <div className={`fixed inset-0 z-[70] bg-stone-950/40 dark:bg-black flex items-end sm:items-center justify-center sm:p-6 ${isClosing ? 'modal-slide-down' : 'modal-slide-up'}`}>
+      <div className="flex h-dvh w-full flex-col overflow-hidden rounded-t-[2rem] bg-stone-50 shadow-2xl dark:bg-[#090909] sm:h-[min(860px,calc(100dvh-48px))] sm:max-w-xl sm:rounded-[2rem]">
+      <div className="mx-auto mt-2 h-1 w-12 shrink-0 rounded-full bg-stone-300/60 dark:bg-stone-700/70" />
+
       {/* 헤더 */}
-      <div className="flex items-center justify-between px-5 py-4 border-b border-stone-100 dark:border-stone-800 shrink-0 pt-safe">
-        <h2 className="text-base font-bold text-stone-800 dark:text-stone-100">
-          {initial ? '일정 편집' : '새 일정'}
-        </h2>
-        <button onClick={handleClose} className="p-1 text-stone-400">
-          <X size={20} />
+      <div className="flex items-center justify-between px-5 pb-8 pt-6 shrink-0">
+        <button
+          onClick={handleClose}
+          className="flex h-11 w-11 items-center justify-center rounded-full text-accent-500 transition-colors hover:bg-stone-100 dark:text-accent-300 dark:hover:bg-stone-900"
+          aria-label="닫기"
+        >
+          <X size={28} strokeWidth={1.8} />
+        </button>
+        <button
+          onClick={handleSave}
+          disabled={!title.trim() || !startDate || saving}
+          className="rounded-full border border-stone-200 bg-stone-50 px-8 py-2.5 text-sm font-bold text-stone-800 transition-colors hover:bg-stone-100 disabled:opacity-40 dark:border-stone-800 dark:bg-stone-950 dark:text-stone-100 dark:hover:bg-stone-900"
+        >
+          저장
         </button>
       </div>
 
-      <div className="overflow-y-auto flex-1 px-5 py-4 space-y-4">
-        {/* 캘린더 선택 */}
-        {calendars.length > 0 && (
-          <div className="flex gap-2 flex-wrap">
-            {calendars.map((cal) => (
-              <button
-                key={cal.id}
-                onClick={() => setCalendarId(cal.id)}
-                className="flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold border transition-all"
-                style={
-                  calendarId === cal.id
-                    ? { backgroundColor: cal.color, borderColor: cal.color, color: '#fff' }
-                    : { borderColor: cal.color, color: cal.color }
-                }
-              >
-                {cal.name}
-              </button>
-            ))}
-          </div>
-        )}
-
+      <div className="flex-1 overflow-y-auto pb-10">
         {/* 제목 */}
-        <input
-          ref={titleInputRef}
-          type="text"
-          value={title}
-          onChange={(e) => setTitle(e.target.value)}
-          placeholder="제목"
-          className="w-full px-3 py-2.5 rounded-xl border border-stone-200 dark:border-stone-700 bg-stone-50 dark:bg-stone-800 text-stone-800 dark:text-stone-100 placeholder:text-stone-400 focus:outline-none focus:ring-2 focus:ring-accent-400 text-base"
-        />
-
-        {saveError && (
-          <p className="text-xs text-red-500 -mt-2">{saveError}</p>
-        )}
-
-        {/* 종일 토글 */}
-        <div className="flex items-center justify-between">
-          <span className="text-sm text-stone-600 dark:text-stone-300">종일</span>
-          <button
-            onClick={() => toggleAllDay(!isAllDay)}
-            className={`relative w-11 h-6 rounded-full transition-colors ${isAllDay ? 'bg-accent-400' : 'bg-stone-200 dark:bg-stone-700'}`}
-          >
-            <span
-              className={`absolute top-0.5 left-0.5 w-5 h-5 bg-white rounded-full shadow transition-transform ${isAllDay ? 'translate-x-5' : 'translate-x-0'}`}
-            />
-          </button>
+        <div className="px-8 pb-9">
+          <input
+            ref={titleInputRef}
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="제목"
+            className="w-full bg-transparent text-[2.35rem] font-extrabold leading-tight tracking-normal text-stone-900 placeholder:text-stone-400 focus:outline-none dark:text-stone-100 dark:placeholder:text-stone-600"
+          />
         </div>
 
-        {/* 라벨 색상 */}
-        <div>
+        {saveError && (
+          <p className="mx-6 mb-3 rounded-2xl bg-red-50 px-4 py-3 text-sm text-red-500 dark:bg-red-950/30 dark:text-red-300">{saveError}</p>
+        )}
+
+        <div className="border-y border-stone-200/70 dark:border-stone-900">
+          {/* 캘린더 선택 */}
+          <div className="grid min-h-[4.75rem] grid-cols-[4.5rem_1fr] items-center border-b border-stone-200/70 dark:border-stone-900">
+            <div className="flex justify-center text-accent-500 dark:text-accent-300">
+              <CalendarDays size={26} strokeWidth={1.8} />
+            </div>
+            <div className="min-w-0 pr-5">
+              {calendars.length > 0 ? (
+                <div className="flex flex-wrap gap-2 py-3">
+                  {calendars.map((cal) => {
+                    const active = calendarId === cal.id
+                    return (
+                      <button
+                        key={cal.id}
+                        onClick={() => setCalendarId(cal.id)}
+                        className="flex items-center gap-2 rounded-2xl px-3.5 py-2 text-base font-semibold transition-all"
+                        style={
+                          active
+                            ? { backgroundColor: cal.color, color: '#fff' }
+                            : { backgroundColor: 'transparent', color: cal.color }
+                        }
+                      >
+                        <span
+                          className="h-2.5 w-2.5 rounded-full"
+                          style={{ backgroundColor: active ? '#fff' : cal.color }}
+                        />
+                        {cal.name}
+                      </button>
+                    )
+                  })}
+                </div>
+              ) : (
+                <span className="text-lg font-semibold text-stone-500 dark:text-stone-400">캘린더 없음</span>
+              )}
+            </div>
+          </div>
+
+          {/* 종일 토글 */}
+          <div className="grid min-h-[4.75rem] grid-cols-[4.5rem_1fr_auto] items-center border-b border-stone-200/70 dark:border-stone-900">
+            <div className="flex justify-center text-accent-500 dark:text-accent-300">
+              <Clock3 size={25} strokeWidth={1.8} />
+            </div>
+            <span className="text-xl font-semibold text-stone-900 dark:text-stone-100">종일</span>
+            <button
+              onClick={() => toggleAllDay(!isAllDay)}
+              className={`relative mr-5 h-8 w-[4.25rem] rounded-full transition-colors ${isAllDay ? 'bg-accent-400' : 'bg-stone-300 dark:bg-stone-700'}`}
+              aria-label="종일"
+            >
+              <span
+                className={`absolute left-1 top-1 h-6 w-6 rounded-full bg-white shadow transition-transform ${isAllDay ? 'translate-x-9' : 'translate-x-0'}`}
+              />
+            </button>
+          </div>
+
+          {/* 날짜/시간 */}
+          <div className="grid grid-cols-[4.5rem_1fr] border-b border-stone-200/70 dark:border-stone-900">
+            <div />
+            <div className="py-5 pr-5">
+              {isScopedRecurringEdit && (
+                <p className="mb-3 rounded-2xl bg-stone-100 px-4 py-3 text-sm text-stone-500 dark:bg-stone-900 dark:text-stone-400">
+                  이 범위에서는 날짜 이동 없이 시간과 내용만 변경할 수 있어요.
+                </p>
+              )}
+
+              <div className="grid grid-cols-[4.5rem_minmax(0,1fr)] items-center gap-y-5">
+                <span className="text-lg font-medium text-stone-800 dark:text-stone-100">시작</span>
+                <div className={`flex justify-end gap-2 ${isAllDay ? '' : 'min-w-0'}`}>
+                  <div
+                    className={`${isAllDay ? 'w-full max-w-[18rem]' : 'flex-1 '}${dateBtnCls}`}
+                    onClick={() => { if (canEditOccurrenceDate) startDateInputRef.current?.showPicker?.() }}
+                  >
+                    <span className="relative z-10 pointer-events-none whitespace-nowrap">{formatDateWithDOW(startDate)}</span>
+                    <input
+                      ref={startDateInputRef}
+                      type="date"
+                      value={startDate}
+                      disabled={!canEditOccurrenceDate}
+                      onChange={(e) => setStartDate(e.target.value)}
+                      className={`absolute inset-0 opacity-0 w-full h-full ${canEditOccurrenceDate ? 'cursor-pointer' : 'cursor-default'}`}
+                    />
+                  </div>
+                  {!isAllDay && (
+                    <button
+                      onClick={() => toggleTimePicker('start')}
+                      className={timeBtnCls(activeTimePicker === 'start')}
+                    >
+                      {startTime}
+                    </button>
+                  )}
+                </div>
+
+                {!isAllDay && activeTimePicker === 'start' && (
+                  <div className="col-span-2">
+                    <TimeWheelPicker
+                      hours={parseInt(startTime.split(':')[0])}
+                      minutes={parseInt(startTime.split(':')[1])}
+                      onChange={handleStartTimeChange}
+                    />
+                  </div>
+                )}
+
+                <span className="text-lg font-medium text-stone-800 dark:text-stone-100">종료</span>
+                <div className={`flex justify-end gap-2 ${endShake ? 'shake' : ''}`}>
+                  <div
+                    className={`${isAllDay ? 'w-full max-w-[18rem]' : 'flex-1 '}${dateBtnCls}`}
+                    onClick={() => { if (canEditOccurrenceDate) endDateInputRef.current?.showPicker?.() }}
+                  >
+                    <span className="relative z-10 pointer-events-none whitespace-nowrap">{formatDateWithDOW(endDate)}</span>
+                    <input
+                      ref={endDateInputRef}
+                      type="date"
+                      value={endDate}
+                      disabled={!canEditOccurrenceDate}
+                      onChange={(e) => handleEndDateChange(e.target.value)}
+                      className={`absolute inset-0 opacity-0 w-full h-full ${canEditOccurrenceDate ? 'cursor-pointer' : 'cursor-default'}`}
+                    />
+                  </div>
+                  {!isAllDay && (
+                    <button
+                      onClick={() => toggleTimePicker('end')}
+                      className={timeBtnCls(activeTimePicker === 'end')}
+                    >
+                      {endTime}
+                    </button>
+                  )}
+                </div>
+
+                {!isAllDay && activeTimePicker === 'end' && (
+                  <div className="col-span-2">
+                    <TimeWheelPicker
+                      hours={parseInt(endTime.split(':')[0])}
+                      minutes={parseInt(endTime.split(':')[1])}
+                      onChange={handleEndTimeChange}
+                    />
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* 라벨 색상 */}
           <button
             type="button"
             onClick={() => setLabelPickerOpen((v) => !v)}
-            className="flex items-center justify-between w-full py-2.5"
+            className="grid min-h-[4.75rem] w-full grid-cols-[4.5rem_1fr_auto] items-center border-b border-stone-200/70 text-left dark:border-stone-900"
           >
-            <div className="flex items-center gap-2">
-              <Tag size={14} className="text-stone-400" />
-              <span className="text-sm text-stone-600 dark:text-stone-300">라벨 색상</span>
+            <div className="flex justify-center text-accent-500 dark:text-accent-300">
+              <Tag size={25} strokeWidth={1.8} />
             </div>
-            <div className="flex items-center gap-2">
+            <span className="text-xl font-semibold text-stone-900 dark:text-stone-100">라벨</span>
+            <div className="mr-5 flex items-center gap-2 text-right">
               {labelColor ? (
                 <>
                   <span
-                    className="w-4 h-4 rounded-full shrink-0"
-                    style={{ backgroundColor: labelColor }}
+                    className="h-6 w-6 rounded-full shrink-0"
+                    style={{ backgroundColor: toDisplayColor(labelColor) }}
                   />
-                  <span className="text-xs text-stone-500 dark:text-stone-400">
+                  <span className="text-sm font-semibold text-stone-500 dark:text-stone-400">
                     {LABEL_COLOR_NAMES[labelColor] ?? labelColor}
                   </span>
                 </>
               ) : (
-                <span className="text-xs text-stone-400">캘린더 색상 사용</span>
+                <span className="text-sm font-semibold text-stone-400">
+                  캘린더 색상 사용
+                </span>
               )}
             </div>
           </button>
 
           {labelPickerOpen && (
-            <div className="mt-2 mb-1">
-              <div className="flex flex-wrap gap-2.5 px-1">
+            <div className="border-b border-stone-200/70 px-6 py-4 dark:border-stone-900">
+              <div className="flex flex-wrap gap-3 pl-[3.25rem]">
                 <button
                   type="button"
                   onClick={() => { setLabelColor(null); setLabelPickerOpen(false) }}
-                  className={`w-7 h-7 rounded-full border-2 flex items-center justify-center transition-all ${
+                  className={`w-9 h-9 rounded-full border-2 flex items-center justify-center transition-all ${
                     labelColor === null
                       ? 'border-stone-400 dark:border-stone-300'
                       : 'border-stone-200 dark:border-stone-700'
@@ -355,7 +482,7 @@ export function EventFormModal({
                     key={color}
                     type="button"
                     onClick={() => { setLabelColor(color); setLabelPickerOpen(false) }}
-                    className={`w-7 h-7 rounded-full border-2 flex items-center justify-center transition-all ${
+                    className={`w-9 h-9 rounded-full border-2 flex items-center justify-center transition-all ${
                       labelColor === color
                         ? 'border-stone-800 dark:border-white scale-110'
                         : 'border-transparent'
@@ -369,156 +496,70 @@ export function EventFormModal({
               </div>
             </div>
           )}
-        </div>
 
-        {/* 날짜/시간 */}
-        <div className="space-y-3">
-          {isScopedRecurringEdit && (
-            <p className="text-xs text-stone-500 dark:text-stone-400">
-              이 범위에서는 날짜 이동 없이 시간과 내용만 변경할 수 있어요.
-            </p>
-          )}
-          {/* 시작 */}
-          <div>
-            <label className="text-xs text-stone-500 mb-1.5 block">시작</label>
-            <div className="flex gap-2">
-              <div
-                className={`${isAllDay ? '' : 'flex-1 '}${dateBtnCls}`}
-                onClick={() => { if (canEditOccurrenceDate) startDateInputRef.current?.showPicker?.() }}
-              >
-                <span className="relative z-10 pointer-events-none">{formatDateWithDOW(startDate)}</span>
-                <input
-                  ref={startDateInputRef}
-                  type="date"
-                  value={startDate}
-                  disabled={!canEditOccurrenceDate}
-                  onChange={(e) => setStartDate(e.target.value)}
-                  className={`absolute inset-0 opacity-0 w-full h-full ${canEditOccurrenceDate ? 'cursor-pointer' : 'cursor-default'}`}
-                />
+          {/* 알림 */}
+          <div className="grid grid-cols-[4.5rem_1fr] border-b border-stone-200/70 dark:border-stone-900">
+            <div className="flex justify-center pt-6 text-accent-500 dark:text-accent-300">
+              <Bell size={25} strokeWidth={1.8} />
+            </div>
+            <div className="py-5 pr-5">
+              <div className="mb-3 flex items-center justify-between gap-3">
+                <span className="text-xl font-semibold text-stone-900 dark:text-stone-100">알람</span>
+                <span className="max-w-[55%] truncate text-sm font-semibold text-stone-400">{reminderLabel}</span>
               </div>
-              {!isAllDay && (
+              <div className="flex flex-wrap gap-2">
+                {REMINDER_OPTIONS.map((opt) => {
+                  const active = reminderMinutes.has(opt.minutes)
+                  return (
+                    <button
+                      key={opt.minutes}
+                      onClick={() => toggleReminder(opt.minutes)}
+                      className={`rounded-full px-4 py-2 text-sm font-semibold transition-colors ${
+                        active
+                          ? 'bg-accent-400 text-white'
+                          : 'bg-stone-200 text-stone-600 dark:bg-stone-800 dark:text-stone-300'
+                      }`}
+                    >
+                      {opt.label}
+                    </button>
+                  )
+                })}
+              </div>
+            </div>
+          </div>
+
+          {/* 보조 기능 */}
+          <div className="grid grid-cols-[4.5rem_1fr]">
+            <div className="flex justify-center pt-6 text-accent-500 dark:text-accent-300">
+              <AlignLeft size={25} strokeWidth={1.8} />
+            </div>
+            <div className="space-y-3 py-5 pr-5">
+              <textarea
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                placeholder="메모 (선택)"
+                rows={2}
+                className="w-full resize-none rounded-2xl bg-stone-100 px-4 py-3 text-base text-stone-800 placeholder:text-stone-400 focus:outline-none focus:ring-2 focus:ring-accent-400 dark:bg-stone-900 dark:text-stone-100"
+              />
+
+              {isNewEvent && (
                 <button
-                  onClick={() => toggleTimePicker('start')}
-                  className={timeBtnCls(activeTimePicker === 'start')}
+                  onClick={() => setRecurrenceModal('picker')}
+                  className="flex min-h-12 w-full items-center justify-between rounded-2xl bg-stone-100 px-4 text-left dark:bg-stone-900"
                 >
-                  {startTime}
+                  <div className="flex items-center gap-3">
+                    <RefreshCw size={18} className="text-accent-500 dark:text-accent-300" />
+                    <span className="text-base font-semibold text-stone-800 dark:text-stone-100">반복</span>
+                  </div>
+                  <div className="flex items-center gap-1 text-sm font-semibold text-stone-400">
+                    <span>{recurrence ? buildRecurrenceLabel(recurrence) : '안 함'}</span>
+                    <ChevronRight size={18} />
+                  </div>
                 </button>
               )}
             </div>
           </div>
-
-          {/* 시작 시간 wheel picker */}
-          {!isAllDay && activeTimePicker === 'start' && (
-            <TimeWheelPicker
-              hours={parseInt(startTime.split(':')[0])}
-              minutes={parseInt(startTime.split(':')[1])}
-              onChange={handleStartTimeChange}
-            />
-          )}
-
-          {/* 종료 */}
-          <div className={endShake ? 'shake' : ''}>
-            <label className="text-xs text-stone-500 mb-1.5 block">종료</label>
-            <div className="flex gap-2">
-              <div
-                className={`${isAllDay ? '' : 'flex-1 '}${dateBtnCls}`}
-                onClick={() => { if (canEditOccurrenceDate) endDateInputRef.current?.showPicker?.() }}
-              >
-                <span className="relative z-10 pointer-events-none">{formatDateWithDOW(endDate)}</span>
-                <input
-                  ref={endDateInputRef}
-                  type="date"
-                  value={endDate}
-                  disabled={!canEditOccurrenceDate}
-                  onChange={(e) => handleEndDateChange(e.target.value)}
-                  className={`absolute inset-0 opacity-0 w-full h-full ${canEditOccurrenceDate ? 'cursor-pointer' : 'cursor-default'}`}
-                />
-              </div>
-              {!isAllDay && (
-                <button
-                  onClick={() => toggleTimePicker('end')}
-                  className={timeBtnCls(activeTimePicker === 'end')}
-                >
-                  {endTime}
-                </button>
-              )}
-            </div>
-          </div>
-
-          {/* 종료 시간 wheel picker */}
-          {!isAllDay && activeTimePicker === 'end' && (
-            <TimeWheelPicker
-              hours={parseInt(endTime.split(':')[0])}
-              minutes={parseInt(endTime.split(':')[1])}
-              onChange={handleEndTimeChange}
-            />
-          )}
         </div>
-
-        {/* 메모 */}
-        <textarea
-          value={description}
-          onChange={(e) => setDescription(e.target.value)}
-          placeholder="메모 (선택)"
-          rows={2}
-          className="w-full px-3 py-2.5 rounded-xl border border-stone-200 dark:border-stone-700 bg-stone-50 dark:bg-stone-800 text-stone-800 dark:text-stone-100 placeholder:text-stone-400 focus:outline-none focus:ring-2 focus:ring-accent-400 text-base resize-none"
-        />
-
-        {/* 반복 (새 일정만) */}
-        {isNewEvent && (
-          <button
-            onClick={() => setRecurrenceModal('picker')}
-            className="flex items-center justify-between w-full py-2.5"
-          >
-            <div className="flex items-center gap-1.5">
-              <RefreshCw size={14} className="text-stone-400" />
-              <span className="text-xs text-stone-500">반복</span>
-            </div>
-            <span className="text-xs text-stone-500 dark:text-stone-400">
-              {recurrence ? buildRecurrenceLabel(recurrence) : '안 함'}
-            </span>
-          </button>
-        )}
-
-        {/* 알림 */}
-        <div>
-          <div className="flex items-center gap-1.5 mb-2">
-            <Bell size={14} className="text-stone-400" />
-            <span className="text-xs text-stone-500">알림</span>
-          </div>
-          <div className="flex flex-wrap gap-1.5">
-            {REMINDER_OPTIONS.map((opt) => {
-              const active = reminderMinutes.has(opt.minutes)
-              return (
-                <button
-                  key={opt.minutes}
-                  onClick={() => toggleReminder(opt.minutes)}
-                  className={`px-2.5 py-1 rounded-full text-xs font-medium border transition-colors ${
-                    active
-                      ? 'bg-accent-400 border-accent-400 text-white'
-                      : 'border-stone-200 dark:border-stone-700 text-stone-500 dark:text-stone-400'
-                  }`}
-                >
-                  {opt.label}
-                </button>
-              )
-            })}
-          </div>
-        </div>
-      </div>
-
-      {/* 저장 버튼 */}
-      <div
-        className="px-5 pt-3 border-t border-stone-100 dark:border-stone-800 shrink-0"
-        style={{ paddingBottom: 'max(12px, env(safe-area-inset-bottom))' }}
-      >
-        <button
-          onClick={handleSave}
-          disabled={!title.trim() || !startDate || saving}
-          className="w-full py-3 rounded-xl bg-accent-400 hover:bg-accent-500 disabled:opacity-40 text-white font-semibold text-sm transition-colors"
-        >
-          저장
-        </button>
       </div>
 
       {recurrenceModal === 'picker' && (
@@ -539,6 +580,7 @@ export function EventFormModal({
           onBack={() => setRecurrenceModal('picker')}
         />
       )}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- 일정 작성/수정 화면을 레퍼런스에 가까운 시트형 레이아웃으로 재구성했습니다.
- 주요 입력 순서를 `제목 → 캘린더 그룹 → 종일 → 시작 → 종료 → 라벨 → 알람 → 메모 → 반복` 순서로 정리했습니다.
- 모바일 PWA에서는 폰트, 행 높이, 아이콘, 날짜 버튼, 알림 칩을 더 컴팩트하게 조정했습니다.
- 데스크톱에서는 모달 폭을 화면에 맞춰 더 넓게 쓰도록 조정하고 상단 여백을 줄였습니다.
- 반복 설정을 메모의 종속 항목처럼 보이지 않도록 독립 row로 분리했습니다.
- 날짜 표시를 레퍼런스처럼 `2026년 3월 31일 (화)` 형식으로 변경했습니다.
- 시트 상단 safe-area padding을 복원하고, 날짜 선택은 데스크톱 `showPicker()`를 지원하되 미지원 환경에서는 네이티브 date input 기본 동작을 막지 않도록 유지했습니다.
- 시작 날짜/시간이 종료보다 뒤로 바뀌면 종료 값을 시작 값으로 보정해 잘못된 범위가 남지 않도록 수정했습니다.
- 날짜 picker 클릭 영역, 접근성, 시작/종료 보정, 레이아웃 순서, 모바일 제목 크기 기준으로 EventFormModal 테스트를 갱신했습니다.

## Testing
- [x] `npm run test -- --testPathPatterns=src/__tests__/components/EventFormModal.test.tsx`
- [x] `npx tsc --noEmit`
- [x] `npm run lint` (기존 warning 5개)
- [x] GitHub Actions `Lint & Test`
- [x] Vercel preview deployment

## Manual Verification
- [ ] 모바일 PWA에서 새 일정 화면이 레퍼런스처럼 컴팩트한 순서/간격/시트 형태로 보이는지 확인
- [ ] 모바일 PWA에서 종일 ON/OFF 시 시작/종료 날짜와 시간 버튼 표시가 자연스러운지 확인
- [ ] 모바일 PWA에서 시작/종료 날짜 버튼을 눌렀을 때 date picker가 열리는지 확인
- [ ] 데스크톱에서 시작/종료 날짜 버튼을 눌렀을 때 date picker가 열리는지 확인
- [ ] 데스크톱에서 일정 작성 화면이 화면 폭을 적절히 쓰고 상단 여백이 과하지 않은지 확인
- [ ] 시작 날짜/시간을 종료보다 뒤로 바꿨을 때 종료 값이 시작 값으로 보정되는지 확인
- [ ] 라벨 팔레트, 알람 선택, 반복 설정, 메모 입력이 기존처럼 동작하는지 확인
