### PR TITLE
feat: use KASI holiday API for Korean holidays

### DIFF
--- a/src/__tests__/api/holidays.test.ts
+++ b/src/__tests__/api/holidays.test.ts
@@ -1,0 +1,106 @@
+/**
+ * @jest-environment node
+ */
+import { GET } from '@/app/api/holidays/route'
+import { NextRequest } from 'next/server'
+import { clearKasiHolidayCache } from '@/lib/kasi-holidays'
+
+const mockGetAuthenticatedUser = jest.fn()
+
+jest.mock('@/lib/api-auth', () => ({
+  getAuthenticatedUser: (...args: unknown[]) => mockGetAuthenticatedUser(...args),
+}))
+
+function makeRequest(url: string) {
+  return new NextRequest(url, {
+    method: 'GET',
+    headers: { Authorization: 'Bearer token-123' },
+  })
+}
+
+beforeEach(() => {
+  jest.restoreAllMocks()
+  clearKasiHolidayCache()
+  mockGetAuthenticatedUser.mockResolvedValue({ id: 'user-1', email: 'test@example.com' })
+  global.fetch = jest.fn()
+  process.env.KASI_HOLIDAY_API_KEY = 'test-key'
+  process.env.KASI_HOLIDAY_API_KEY_EXPIRES_AT = '2028-04-23'
+})
+
+describe('GET /api/holidays', () => {
+  it('인증 사용자가 없으면 401을 반환한다', async () => {
+    mockGetAuthenticatedUser.mockResolvedValue(null)
+    const res = await GET(makeRequest('http://localhost/api/holidays?year=2026&month=4&countries=KR'))
+    expect(res.status).toBe(401)
+  })
+
+  it('year/month가 누락되면 400을 반환한다', async () => {
+    const res = await GET(makeRequest('http://localhost/api/holidays?countries=KR'))
+    expect(res.status).toBe(400)
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('year/month가 잘못되면 400을 반환한다', async () => {
+    const res = await GET(makeRequest('http://localhost/api/holidays?year=2026&month=12&countries=KR'))
+    expect(res.status).toBe(400)
+  })
+
+  it('지원하지 않는 연도는 400을 반환한다', async () => {
+    const res = await GET(makeRequest('http://localhost/api/holidays?year=2050&month=4&countries=KR'))
+    expect(res.status).toBe(400)
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('지원하지 않는 국가는 400을 반환한다', async () => {
+    const res = await GET(makeRequest('http://localhost/api/holidays?year=2026&month=4&countries=US'))
+    expect(res.status).toBe(400)
+    expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it('KASI KR 휴일을 정규화해서 반환한다', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        response: {
+          header: { resultCode: '00', resultMsg: 'NORMAL SERVICE.' },
+          body: {
+            items: {
+              item: [
+                { dateName: '노동절', isHoliday: 'Y', locdate: 20260501 },
+                { dateName: '기독탄신일', isHoliday: 'Y', locdate: 20261225 },
+                { dateName: '테스트', isHoliday: 'N', locdate: 20260502 },
+              ],
+            },
+          },
+        },
+      }),
+    } as Response)
+
+    const res = await GET(makeRequest('http://localhost/api/holidays?year=2026&month=4&countries=KR'))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+
+    expect(body.holidays).toContainEqual({
+      date: '2026-05-01',
+      localName: '노동절',
+      countryCode: 'KR',
+    })
+    expect(body.holidays).not.toContainEqual(expect.objectContaining({ date: '2026-05-02' }))
+  })
+
+  it('KASI 호출 실패 시 로컬 KR fallback을 반환한다', async () => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {})
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+    } as Response)
+
+    const res = await GET(makeRequest('http://localhost/api/holidays?year=2026&month=2&countries=KR'))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.holidays).toContainEqual(expect.objectContaining({
+      date: '2026-03-01',
+      countryCode: 'KR',
+    }))
+  })
+})

--- a/src/__tests__/hooks/useHolidays.test.ts
+++ b/src/__tests__/hooks/useHolidays.test.ts
@@ -1,8 +1,17 @@
-import { renderHook } from '@testing-library/react'
+import { renderHook, waitFor } from '@testing-library/react'
 import { useHolidays, clearHolidayCache } from '@/hooks/useHolidays'
+import { getJsonWithAuth } from '@/lib/api-client'
+
+jest.mock('@/lib/api-client', () => ({
+  getJsonWithAuth: jest.fn(),
+}))
+
+const mockGetJsonWithAuth = getJsonWithAuth as jest.MockedFunction<typeof getJsonWithAuth>
 
 beforeEach(() => {
   clearHolidayCache()
+  jest.restoreAllMocks()
+  mockGetJsonWithAuth.mockRejectedValue(new Error('network unavailable'))
 })
 
 describe('useHolidays', () => {
@@ -78,7 +87,7 @@ describe('useHolidays', () => {
       const { result } = renderHook(() => useHolidays(2026, 0, ['KR'])) // month=0 → January 2026
       const christmas = result.current.find((h) => h.date === '2025-12-25')
       expect(christmas).toBeDefined()
-      expect(christmas?.localName).toBe('기독탄신일')
+      expect(christmas?.localName).toBe('크리스마스')
     })
 
     it('12월 뷰에서 다음 연도 1월 元日(JP)이 반환된다 — 연도 경계', () => {
@@ -98,5 +107,20 @@ describe('useHolidays', () => {
     const { result } = renderHook(() => useHolidays(2026, 2, ['KR', 'JP'])) // March
     const codes = result.current.map((h) => h.countryCode)
     expect(codes).toContain('KR')
+  })
+
+  it('API 응답이 오면 KR 휴일을 서버 응답으로 갱신한다', async () => {
+    mockGetJsonWithAuth.mockResolvedValue({
+      holidays: [
+        { date: '2026-05-01', localName: '노동절', countryCode: 'KR' },
+        { date: '2026-05-05', localName: '어린이날', countryCode: 'KR' },
+      ],
+    })
+
+    const { result } = renderHook(() => useHolidays(2026, 4, ['KR']))
+
+    await waitFor(() => {
+      expect(result.current.some((h) => h.date === '2026-05-01' && h.localName === '노동절')).toBe(true)
+    })
   })
 })

--- a/src/__tests__/lib/api-client.test.ts
+++ b/src/__tests__/lib/api-client.test.ts
@@ -1,4 +1,10 @@
-import { ApiClientError, getAuthHeaders, postJson, postJsonWithAuth } from '@/lib/api-client'
+import {
+  ApiClientError,
+  getAuthHeaders,
+  getJsonWithAuth,
+  postJson,
+  postJsonWithAuth,
+} from '@/lib/api-client'
 
 const mockGetSession = jest.fn()
 
@@ -86,6 +92,25 @@ describe('postJsonWithAuth', () => {
         Authorization: 'Bearer token-123',
       },
       body: JSON.stringify({ inviteCode: 'ABC123' }),
+    })
+  })
+})
+
+describe('getJsonWithAuth', () => {
+  it('Authorization 헤더를 포함해 GET 요청한다', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ holidays: [] }),
+    } as Response)
+
+    await getJsonWithAuth('/api/holidays?year=2026&month=4&countries=KR')
+
+    expect(global.fetch).toHaveBeenCalledWith('/api/holidays?year=2026&month=4&countries=KR', {
+      method: 'GET',
+      headers: {
+        Authorization: 'Bearer token-123',
+      },
     })
   })
 })

--- a/src/__tests__/lib/holidays.test.ts
+++ b/src/__tests__/lib/holidays.test.ts
@@ -1,0 +1,37 @@
+import {
+  getFallbackHolidaysForRange,
+  normalizeHolidayName,
+} from '@/lib/holidays'
+import { getKasiApiKeyExpiryWarning, normalizeKasiServiceKey } from '@/lib/kasi-holidays'
+
+describe('holiday helpers', () => {
+  it('기독탄신일 표시명을 크리스마스로 정규화한다', () => {
+    expect(normalizeHolidayName('기독탄신일')).toBe('크리스마스')
+  })
+
+  it('fallback 휴일도 표시명 alias를 적용한다', () => {
+    const holidays = getFallbackHolidaysForRange(2026, 0, ['KR'])
+    const christmas = holidays.find((h) => h.date === '2025-12-25')
+    expect(christmas?.localName).toBe('크리스마스')
+  })
+
+  it('API 키 만료 90일 이내이면 경고 문구를 반환한다', () => {
+    const warning = getKasiApiKeyExpiryWarning(
+      '2028-04-23',
+      new Date('2028-01-24T00:00:00Z')
+    )
+    expect(warning).toContain('2028-04-23')
+    expect(warning).toContain('90 days left')
+  })
+
+  it('API 키 만료까지 90일보다 많이 남으면 경고하지 않는다', () => {
+    expect(getKasiApiKeyExpiryWarning(
+      '2028-04-23',
+      new Date('2028-01-23T00:00:00Z')
+    )).toBeNull()
+  })
+
+  it('URL-encoded KASI 인증키는 한 번 decode한다', () => {
+    expect(normalizeKasiServiceKey('abc%2Bdef%3D')).toBe('abc+def=')
+  })
+})

--- a/src/app/api/holidays/route.ts
+++ b/src/app/api/holidays/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getHolidaysForRange } from '@/lib/kasi-holidays'
+import { getAuthenticatedUser } from '@/lib/api-auth'
+
+const SUPPORTED_COUNTRIES = new Set(['KR', 'JP'])
+const MIN_YEAR = 2020
+const MAX_YEAR = 2035
+
+function parseIntegerParam(searchParams: URLSearchParams, name: string): number | null {
+  const raw = searchParams.get(name)
+  if (raw === null || raw.trim() === '') return null
+  if (!/^\d+$/.test(raw)) return null
+  return Number(raw)
+}
+
+export async function GET(request: NextRequest) {
+  const user = await getAuthenticatedUser(request)
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const searchParams = request.nextUrl.searchParams
+  const year = parseIntegerParam(searchParams, 'year')
+  const month = parseIntegerParam(searchParams, 'month')
+  const countries = (searchParams.get('countries') ?? '')
+    .split(',')
+    .map((code) => code.trim())
+    .filter(Boolean)
+
+  if (year === null || month === null || month < 0 || month > 11) {
+    return NextResponse.json({ error: 'Invalid year or month' }, { status: 400 })
+  }
+
+  if (year < MIN_YEAR || year > MAX_YEAR) {
+    return NextResponse.json({ error: 'Unsupported year' }, { status: 400 })
+  }
+
+  if (countries.length === 0) {
+    return NextResponse.json({ holidays: [] })
+  }
+
+  if (countries.some((country) => !SUPPORTED_COUNTRIES.has(country))) {
+    return NextResponse.json({ error: 'Unsupported holiday country' }, { status: 400 })
+  }
+
+  const holidays = await getHolidaysForRange(year, month, countries)
+  return NextResponse.json(
+    { holidays },
+    {
+      headers: {
+        'Cache-Control': 'private, max-age=86400, stale-while-revalidate=604800',
+      },
+    }
+  )
+}

--- a/src/components/calendar/CalendarGrid.tsx
+++ b/src/components/calendar/CalendarGrid.tsx
@@ -4,7 +4,7 @@ import { type CSSProperties, useEffect, useMemo, useRef, useState } from 'react'
 import KoreanLunarCalendar from 'korean-lunar-calendar'
 import type { Calendar, CalendarEvent } from '@/lib/calendar'
 import { toDisplayColor } from '@/lib/label-colors'
-import type { Holiday } from '@/hooks/useHolidays'
+import type { Holiday } from '@/lib/holidays'
 
 const DOW = ['일', '월', '화', '수', '목', '금', '토']
 const DATE_HEADER_HEIGHT = 28  // px – date circle (h-6=24) + mb-0.5 (2) + border (1) ≈ 28

--- a/src/hooks/useHolidays.ts
+++ b/src/hooks/useHolidays.ts
@@ -1,103 +1,21 @@
-import { useMemo } from 'react'
-import Holidays from 'date-holidays'
-
-export interface Holiday {
-  date: string        // "2026-03-01"
-  localName: string   // "삼일절" or "憲法記念日"
-  countryCode: string // "KR" or "JP"
-}
-
-const COUNTRY_LANGUAGE: Record<string, string> = {
-  KR: 'ko',
-  JP: 'ja',
-}
-
-// date-holidays does not calculate substitute holidays for these countries.
-// Custom logic is applied after fetching base holidays.
-const NEEDS_CUSTOM_SUBSTITUTE = new Set(['KR'])
-
-const SUBSTITUTE_NAME: Record<string, string> = {
-  KR: '대체공휴일',
-  JP: '振替休日',
-}
-
-// In-memory cache keyed by `${year}-${countryCode}`.
-// Holiday rules for a given year are stable, so no invalidation is needed.
-const cache = new Map<string, Holiday[]>()
+import { useEffect, useMemo, useState } from 'react'
+import {
+  clearFallbackHolidayCache,
+  getFallbackHolidaysForRange,
+  type Holiday,
+} from '@/lib/holidays'
+import { getJsonWithAuth } from '@/lib/api-client'
 
 /** Test utility: clears the in-memory cache between test cases. */
 export function clearHolidayCache() {
-  cache.clear()
+  clearFallbackHolidayCache()
+  apiCache.clear()
 }
 
-function toYMD(date: Date): string {
-  const y = date.getFullYear()
-  const m = String(date.getMonth() + 1).padStart(2, '0')
-  const d = String(date.getDate()).padStart(2, '0')
-  return `${y}-${m}-${d}`
-}
-
-/**
- * Calculate substitute holidays for KR (대체공휴일).
- * date-holidays does not include KR substitutes, so we derive them:
- * when a public holiday falls on Sunday, the next non-holiday weekday
- * (Mon–Sat excluded) becomes the substitute.
- */
-function calcKrSubstituteHolidays(holidays: Holiday[]): Holiday[] {
-  const substitutes: Holiday[] = []
-  const allDates = new Set(holidays.map((h) => h.date))
-
-  for (const holiday of holidays) {
-    const date = new Date(`${holiday.date}T00:00:00`)
-    if (date.getDay() !== 0) continue // only Sundays trigger a substitute
-
-    const candidate = new Date(date)
-    candidate.setDate(candidate.getDate() + 1)
-    while (
-      allDates.has(toYMD(candidate)) ||
-      candidate.getDay() === 0 ||
-      candidate.getDay() === 6
-    ) {
-      candidate.setDate(candidate.getDate() + 1)
-    }
-
-    const substituteDate = toYMD(candidate)
-    if (!allDates.has(substituteDate)) {
-      allDates.add(substituteDate) // prevent duplicate substitutes
-      substitutes.push({
-        date: substituteDate,
-        localName: SUBSTITUTE_NAME.KR,
-        countryCode: holiday.countryCode,
-      })
-    }
-  }
-
-  return substitutes
-}
-
-function getYearHolidays(year: number, countryCode: string): Holiday[] {
-  const key = `${year}-${countryCode}`
-  if (cache.has(key)) return cache.get(key)!
-
-  const lang = COUNTRY_LANGUAGE[countryCode] ?? 'en'
-  const hd = new Holidays(countryCode, { languages: [lang] })
-  const holidays: Holiday[] = hd.getHolidays(year)
-    .filter((h) => h.type === 'public')
-    .map((h) => ({
-      date: h.date.slice(0, 10),
-      // date-holidays returns substitute names as "原日名 (振替休日)" — normalize to just the substitute label
-      localName: h.substitute
-        ? (SUBSTITUTE_NAME[countryCode] ?? h.name)
-        : h.name,
-      countryCode,
-    }))
-
-  if (NEEDS_CUSTOM_SUBSTITUTE.has(countryCode)) {
-    holidays.push(...calcKrSubstituteHolidays(holidays))
-  }
-
-  cache.set(key, holidays)
-  return holidays
+const apiCache = new Map<string, Holiday[]>()
+interface ApiHolidayResult {
+  key: string
+  holidays: Holiday[]
 }
 
 export function useHolidays(
@@ -106,27 +24,40 @@ export function useHolidays(
   countryCodes: string[]
 ): Holiday[] {
   const countryKey = [...countryCodes].sort().join(',')
-  return useMemo(() => {
+  const fallbackHolidays = useMemo(() => {
     if (!countryKey) return []
-
-    const prevYear  = month === 0  ? year - 1 : year
-    const prevMonth = month === 0  ? 11       : month - 1
-    const nextYear  = month === 11 ? year + 1 : year
-    const nextMonth = month === 11 ? 0        : month + 1
-
-    const years = [...new Set([prevYear, year, nextYear])]
-    const codes = countryKey.split(',')
-
-    return codes
-      .flatMap((cc) => years.flatMap((y) => getYearHolidays(y, cc)))
-      .filter((h) => {
-        const [y, m] = h.date.split('-').map(Number)
-        const hMonth = m - 1
-        return (
-          (y === prevYear && hMonth === prevMonth) ||
-          (y === year     && hMonth === month)     ||
-          (y === nextYear && hMonth === nextMonth)
-        )
-      })
+    return getFallbackHolidaysForRange(year, month, countryKey.split(','))
   }, [year, month, countryKey])
+
+  const cacheKey = `${year}-${month}-${countryKey}`
+  const [apiResult, setApiResult] = useState<ApiHolidayResult | null>(null)
+
+  useEffect(() => {
+    if (!countryKey || apiCache.has(cacheKey)) return
+
+    const controller = new AbortController()
+    const params = new URLSearchParams({
+      year: String(year),
+      month: String(month),
+      countries: countryKey,
+    })
+
+    getJsonWithAuth<{ holidays?: Holiday[] }>(`/api/holidays?${params.toString()}`, {
+      signal: controller.signal,
+    })
+      .then((body) => {
+        const nextHolidays = Array.isArray(body.holidays) ? body.holidays : fallbackHolidays
+        apiCache.set(cacheKey, nextHolidays)
+        setApiResult({ key: cacheKey, holidays: nextHolidays })
+      })
+      .catch((error) => {
+        if (error instanceof DOMException && error.name === 'AbortError') return
+      })
+
+    return () => controller.abort()
+  }, [cacheKey, countryKey, fallbackHolidays, month, year])
+
+  return apiCache.get(cacheKey) ?? (apiResult?.key === cacheKey ? apiResult.holidays : fallbackHolidays)
 }
+
+export type { Holiday }

--- a/src/lib/api-client.ts
+++ b/src/lib/api-client.ts
@@ -93,6 +93,22 @@ export async function postJsonWithAuth<TResponse>(
   })
 }
 
+export async function getJsonWithAuth<TResponse>(
+  input: string,
+  init?: Omit<RequestInit, 'method'>
+): Promise<TResponse> {
+  const authHeaders = await getAuthHeaders()
+
+  return requestJson<TResponse>(input, {
+    ...init,
+    method: 'GET',
+    headers: {
+      ...(init?.headers ?? {}),
+      ...authHeaders,
+    },
+  })
+}
+
 export async function patchJsonWithAuth<TResponse>(
   input: string,
   body?: unknown,

--- a/src/lib/holidays.ts
+++ b/src/lib/holidays.ts
@@ -1,0 +1,138 @@
+import Holidays from 'date-holidays'
+
+export interface Holiday {
+  date: string
+  localName: string
+  countryCode: string
+}
+
+const COUNTRY_LANGUAGE: Record<string, string> = {
+  KR: 'ko',
+  JP: 'ja',
+}
+
+const NEEDS_CUSTOM_SUBSTITUTE = new Set(['KR'])
+
+const SUBSTITUTE_NAME: Record<string, string> = {
+  KR: '대체공휴일',
+  JP: '振替休日',
+}
+
+const DISPLAY_NAME_ALIAS: Record<string, string> = {
+  기독탄신일: '크리스마스',
+}
+
+const fallbackCache = new Map<string, Holiday[]>()
+
+export function clearFallbackHolidayCache() {
+  fallbackCache.clear()
+}
+
+export function normalizeHolidayName(name: string): string {
+  return DISPLAY_NAME_ALIAS[name] ?? name
+}
+
+export function toYMD(date: Date): string {
+  const y = date.getFullYear()
+  const m = String(date.getMonth() + 1).padStart(2, '0')
+  const d = String(date.getDate()).padStart(2, '0')
+  return `${y}-${m}-${d}`
+}
+
+function calcKrSubstituteHolidays(holidays: Holiday[]): Holiday[] {
+  const substitutes: Holiday[] = []
+  const allDates = new Set(holidays.map((h) => h.date))
+
+  for (const holiday of holidays) {
+    const date = new Date(`${holiday.date}T00:00:00`)
+    if (date.getDay() !== 0) continue
+
+    const candidate = new Date(date)
+    candidate.setDate(candidate.getDate() + 1)
+    while (
+      allDates.has(toYMD(candidate)) ||
+      candidate.getDay() === 0 ||
+      candidate.getDay() === 6
+    ) {
+      candidate.setDate(candidate.getDate() + 1)
+    }
+
+    const substituteDate = toYMD(candidate)
+    if (!allDates.has(substituteDate)) {
+      allDates.add(substituteDate)
+      substitutes.push({
+        date: substituteDate,
+        localName: SUBSTITUTE_NAME.KR,
+        countryCode: holiday.countryCode,
+      })
+    }
+  }
+
+  return substitutes
+}
+
+export function getFallbackYearHolidays(year: number, countryCode: string): Holiday[] {
+  const key = `${year}-${countryCode}`
+  if (fallbackCache.has(key)) return fallbackCache.get(key)!
+
+  const lang = COUNTRY_LANGUAGE[countryCode] ?? 'en'
+  const hd = new Holidays(countryCode, { languages: [lang] })
+  const holidays: Holiday[] = hd.getHolidays(year)
+    .filter((h) => h.type === 'public')
+    .map((h) => ({
+      date: h.date.slice(0, 10),
+      localName: normalizeHolidayName(
+        h.substitute ? (SUBSTITUTE_NAME[countryCode] ?? h.name) : h.name
+      ),
+      countryCode,
+    }))
+
+  if (NEEDS_CUSTOM_SUBSTITUTE.has(countryCode)) {
+    holidays.push(...calcKrSubstituteHolidays(holidays))
+  }
+
+  fallbackCache.set(key, holidays)
+  return holidays
+}
+
+export function getAdjacentMonths(year: number, month: number) {
+  const prevYear = month === 0 ? year - 1 : year
+  const prevMonth = month === 0 ? 11 : month - 1
+  const nextYear = month === 11 ? year + 1 : year
+  const nextMonth = month === 11 ? 0 : month + 1
+
+  return { prevYear, prevMonth, nextYear, nextMonth }
+}
+
+export function filterHolidaysForAdjacentMonths(
+  holidays: Holiday[],
+  year: number,
+  month: number
+): Holiday[] {
+  const { prevYear, prevMonth, nextYear, nextMonth } = getAdjacentMonths(year, month)
+
+  return holidays.filter((h) => {
+    const [y, m] = h.date.split('-').map(Number)
+    const hMonth = m - 1
+    return (
+      (y === prevYear && hMonth === prevMonth) ||
+      (y === year && hMonth === month) ||
+      (y === nextYear && hMonth === nextMonth)
+    )
+  })
+}
+
+export function getFallbackHolidaysForRange(
+  year: number,
+  month: number,
+  countryCodes: string[]
+): Holiday[] {
+  const { prevYear, nextYear } = getAdjacentMonths(year, month)
+  const years = [...new Set([prevYear, year, nextYear])]
+
+  return filterHolidaysForAdjacentMonths(
+    countryCodes.flatMap((cc) => years.flatMap((y) => getFallbackYearHolidays(y, cc))),
+    year,
+    month
+  )
+}

--- a/src/lib/kasi-holidays.ts
+++ b/src/lib/kasi-holidays.ts
@@ -1,0 +1,169 @@
+import {
+  filterHolidaysForAdjacentMonths,
+  getAdjacentMonths,
+  getFallbackHolidaysForRange,
+  normalizeHolidayName,
+  type Holiday,
+} from '@/lib/holidays'
+
+const KASI_ENDPOINT =
+  'https://apis.data.go.kr/B090041/openapi/service/SpcdeInfoService/getRestDeInfo'
+
+let hasWarnedAboutKeyExpiry = false
+const kasiYearCache = new Map<number, Promise<Holiday[]>>()
+
+export function clearKasiHolidayCache() {
+  kasiYearCache.clear()
+  hasWarnedAboutKeyExpiry = false
+}
+
+interface KasiHolidayItem {
+  dateName?: unknown
+  isHoliday?: unknown
+  locdate?: unknown
+}
+
+interface KasiHolidayResponse {
+  response?: {
+    header?: {
+      resultCode?: unknown
+      resultMsg?: unknown
+    }
+    body?: {
+      items?: {
+        item?: KasiHolidayItem | KasiHolidayItem[]
+      }
+    }
+  }
+}
+
+export function getKasiApiKeyExpiryWarning(
+  expiresAt: string | undefined,
+  now = new Date()
+): string | null {
+  if (!expiresAt) return null
+
+  const expiry = new Date(`${expiresAt}T00:00:00Z`)
+  if (Number.isNaN(expiry.getTime())) {
+    return 'KASI_HOLIDAY_API_KEY_EXPIRES_AT is invalid. Use YYYY-MM-DD.'
+  }
+
+  const today = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+  const daysLeft = Math.ceil((expiry.getTime() - today) / 86_400_000)
+
+  if (daysLeft < 0) {
+    return `KASI holiday API key expired on ${expiresAt}.`
+  }
+
+  if (daysLeft <= 90) {
+    return `KASI holiday API key expires on ${expiresAt} (${daysLeft} days left).`
+  }
+
+  return null
+}
+
+function warnIfKasiApiKeyExpiring() {
+  if (hasWarnedAboutKeyExpiry) return
+
+  const warning = getKasiApiKeyExpiryWarning(process.env.KASI_HOLIDAY_API_KEY_EXPIRES_AT)
+  if (warning) {
+    hasWarnedAboutKeyExpiry = true
+    console.warn(warning)
+  }
+}
+
+function normalizeLocdate(locdate: unknown): string | null {
+  const raw = String(locdate ?? '')
+  if (!/^\d{8}$/.test(raw)) return null
+  return `${raw.slice(0, 4)}-${raw.slice(4, 6)}-${raw.slice(6, 8)}`
+}
+
+function normalizeKasiItems(raw: KasiHolidayItem | KasiHolidayItem[] | undefined): KasiHolidayItem[] {
+  if (!raw) return []
+  return Array.isArray(raw) ? raw : [raw]
+}
+
+export function normalizeKasiServiceKey(key: string): string {
+  if (!/%[0-9A-Fa-f]{2}/.test(key)) return key
+
+  try {
+    return decodeURIComponent(key)
+  } catch {
+    return key
+  }
+}
+
+async function fetchKasiYearHolidaysUncached(year: number): Promise<Holiday[]> {
+  const rawKey = process.env.KASI_HOLIDAY_API_KEY
+  if (!rawKey) throw new Error('KASI_HOLIDAY_API_KEY is not configured')
+  const key = normalizeKasiServiceKey(rawKey)
+
+  warnIfKasiApiKeyExpiring()
+
+  const url = new URL(KASI_ENDPOINT)
+  url.searchParams.set('ServiceKey', key)
+  url.searchParams.set('solYear', String(year))
+  url.searchParams.set('numOfRows', '100')
+  url.searchParams.set('_type', 'json')
+
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(`KASI holiday API failed with status ${response.status}`)
+  }
+
+  const data = await response.json() as KasiHolidayResponse
+  const header = data.response?.header
+  if (header?.resultCode !== '00') {
+    throw new Error(`KASI holiday API error: ${String(header?.resultMsg ?? 'unknown')}`)
+  }
+
+  return normalizeKasiItems(data.response?.body?.items?.item)
+    .filter((item) => item.isHoliday === 'Y')
+    .map((item) => {
+      const date = normalizeLocdate(item.locdate)
+      const name = typeof item.dateName === 'string' ? item.dateName : ''
+      if (!date || !name) return null
+      return {
+        date,
+        localName: normalizeHolidayName(name),
+        countryCode: 'KR',
+      }
+    })
+    .filter((item): item is Holiday => item !== null)
+}
+
+export async function fetchKasiYearHolidays(year: number): Promise<Holiday[]> {
+  const cached = kasiYearCache.get(year)
+  if (cached) return cached
+
+  const request = fetchKasiYearHolidaysUncached(year).catch((error) => {
+    kasiYearCache.delete(year)
+    throw error
+  })
+  kasiYearCache.set(year, request)
+  return request
+}
+
+export async function getHolidaysForRange(
+  year: number,
+  month: number,
+  countryCodes: string[]
+): Promise<Holiday[]> {
+  const uniqueCountryCodes = [...new Set(countryCodes)]
+  const fallbackCountryCodes = uniqueCountryCodes.filter((cc) => cc !== 'KR')
+  const holidays = getFallbackHolidaysForRange(year, month, fallbackCountryCodes)
+
+  if (uniqueCountryCodes.includes('KR')) {
+    try {
+      const { prevYear, nextYear } = getAdjacentMonths(year, month)
+      const years = [...new Set([prevYear, year, nextYear])]
+      const krHolidays = (await Promise.all(years.map(fetchKasiYearHolidays))).flat()
+      holidays.push(...filterHolidaysForAdjacentMonths(krHolidays, year, month))
+    } catch (error) {
+      console.warn('Falling back to local KR holiday rules.', error)
+      holidays.push(...getFallbackHolidaysForRange(year, month, ['KR']))
+    }
+  }
+
+  return holidays.sort((a, b) => a.date.localeCompare(b.date) || a.countryCode.localeCompare(b.countryCode))
+}


### PR DESCRIPTION
## Summary
- 한국 휴일은 한국천문연구원(KASI) 공휴일 API를 우선 사용하도록 `/api/holidays` route를 추가했습니다.
- KASI API 실패 시 기존 `date-holidays` 기반 로컬 계산으로 fallback하고, KR 외 국가는 기존 계산 방식을 유지했습니다.
- `기독탄신일` 표시명을 `크리스마스`로 정규화하고, `KASI_HOLIDAY_API_KEY_EXPIRES_AT` 기준 API 키 만료 경고 로직을 추가했습니다.

## Testing
- [x] `npm run test -- --runTestsByPath src/__tests__/hooks/useHolidays.test.ts src/__tests__/lib/holidays.test.ts src/__tests__/api/holidays.test.ts src/__tests__/lib/api-client.test.ts`
- [x] `npx tsc --noEmit`
- [x] `npm run lint` (기존 warning 5개)
- [x] `npm run test`
- [x] GitHub Actions `Lint & Test`
- [x] Vercel preview deployment

## Manual Verification
- [ ] Vercel preview에서 `KASI_HOLIDAY_API_KEY`, `KASI_HOLIDAY_API_KEY_EXPIRES_AT` 환경변수가 설정된 상태인지 확인
- [ ] 로그인하지 않은 상태에서 `/api/holidays`를 직접 호출하면 401이 반환되는지 확인
- [ ] 2026년 5월 KR 휴일 표시에서 `노동절`, `어린이날`, `부처님오신날`, `대체공휴일(부처님오신날)`이 보이는지 확인
- [ ] 2026년 12월 KR 휴일 표시에서 `크리스마스`가 보이는지 확인
- [ ] KASI API 장애 또는 키 누락 시 캘린더가 기존 fallback 휴일 표시로 깨지지 않는지 확인
