### PR TITLE
fix: harden protected api auth

### DIFF
--- a/src/__tests__/api/check-allowed.test.ts
+++ b/src/__tests__/api/check-allowed.test.ts
@@ -7,7 +7,7 @@ import { NextRequest } from 'next/server'
 function makeChain(result: { data: unknown; error: unknown }) {
   const p = Promise.resolve(result)
   const chain: Record<string, unknown> = {}
-  ;['select', 'insert', 'eq', 'ilike'].forEach((m) => {
+  ;['select', 'insert', 'upsert', 'eq', 'ilike'].forEach((m) => {
     chain[m] = jest.fn().mockReturnValue(chain)
   })
   chain.maybeSingle = jest.fn().mockReturnValue(p)
@@ -18,12 +18,17 @@ function makeChain(result: { data: unknown; error: unknown }) {
 
 const mockFrom = jest.fn()
 const mockRpc = jest.fn()
+const mockGetAuthenticatedSessionUser = jest.fn()
 
 jest.mock('@supabase/supabase-js', () => ({
   createClient: () => ({
     from: (...args: unknown[]) => mockFrom(...args),
     rpc: (...args: unknown[]) => mockRpc(...args),
   }),
+}))
+
+jest.mock('@/lib/api-auth', () => ({
+  getAuthenticatedSessionUser: (...args: unknown[]) => mockGetAuthenticatedSessionUser(...args),
 }))
 
 function makeRequest(body: object) {
@@ -36,16 +41,19 @@ function makeRequest(body: object) {
 
 beforeEach(() => {
   jest.clearAllMocks()
+  mockGetAuthenticatedSessionUser.mockResolvedValue({ id: 'user-1', email: 'test@example.com' })
   process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://localhost'
   process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key'
 })
 
 describe('POST /api/auth/check-allowed', () => {
-  it('email이 없으면 400을 반환한다', async () => {
+  it('인증 사용자가 없으면 401을 반환한다', async () => {
+    mockGetAuthenticatedSessionUser.mockResolvedValue(null)
     const res = await POST(makeRequest({}))
-    expect(res.status).toBe(400)
+    expect(res.status).toBe(401)
     const body = await res.json()
-    expect(body.error).toBe('email is required')
+    expect(body.error).toBe('Unauthorized')
+    expect(body.allowed).toBe(false)
   })
 
   it('allowed_emails에 이메일이 있으면 allowed: true, needsOnboarding: false를 반환한다', async () => {
@@ -65,15 +73,49 @@ describe('POST /api/auth/check-allowed', () => {
   })
 
   it('유효한 inviteCode로 요청 시 allowed_emails에 추가하고 needsOnboarding: false를 반환한다', async () => {
+    const insertChain = makeChain({ data: null, error: null })
     mockFrom
       .mockReturnValueOnce(makeChain({ data: null, error: null }))            // allowed_emails select
       .mockReturnValueOnce(makeChain({ data: { id: 'fam-1' }, error: null })) // families select
-      .mockReturnValueOnce(makeChain({ data: null, error: null }))             // allowed_emails insert
+      .mockReturnValueOnce(insertChain)                                       // allowed_emails upsert
 
-    const res = await POST(makeRequest({ email: 'new@example.com', inviteCode: 'ABC123' }))
+    mockGetAuthenticatedSessionUser.mockResolvedValue({ id: 'user-1', email: 'new@example.com' })
+
+    const res = await POST(makeRequest({ inviteCode: 'ABC123' }))
     const body = await res.json()
     expect(body.allowed).toBe(true)
     expect(body.needsOnboarding).toBe(false)
+    expect(insertChain.upsert as jest.Mock).toHaveBeenCalledWith(
+      { email: 'new@example.com' },
+      { onConflict: 'email', ignoreDuplicates: true }
+    )
+  })
+
+  it('inviteCode 가족 조회 에러 시 500을 반환한다', async () => {
+    mockFrom
+      .mockReturnValueOnce(makeChain({ data: null, error: null })) // allowed_emails select
+      .mockReturnValueOnce(makeChain({ data: null, error: { message: 'DB error' } }))
+    mockGetAuthenticatedSessionUser.mockResolvedValue({ id: 'user-1', email: 'new@example.com' })
+
+    const res = await POST(makeRequest({ inviteCode: 'ABC123' }))
+
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    expect(body.allowed).toBe(false)
+  })
+
+  it('inviteCode로 allowed_emails 추가 실패 시 500을 반환한다', async () => {
+    mockFrom
+      .mockReturnValueOnce(makeChain({ data: null, error: null }))            // allowed_emails select
+      .mockReturnValueOnce(makeChain({ data: { id: 'fam-1' }, error: null })) // families select
+      .mockReturnValueOnce(makeChain({ data: null, error: { message: 'insert failed' } }))
+    mockGetAuthenticatedSessionUser.mockResolvedValue({ id: 'user-1', email: 'new@example.com' })
+
+    const res = await POST(makeRequest({ inviteCode: 'ABC123' }))
+
+    expect(res.status).toBe(500)
+    const body = await res.json()
+    expect(body.allowed).toBe(false)
   })
 
   it('잘못된 inviteCode이면 allowed: false를 반환한다', async () => {
@@ -81,7 +123,9 @@ describe('POST /api/auth/check-allowed', () => {
       .mockReturnValueOnce(makeChain({ data: null, error: null })) // allowed_emails select
       .mockReturnValueOnce(makeChain({ data: null, error: null })) // families select → null
 
-    const res = await POST(makeRequest({ email: 'new@example.com', inviteCode: 'INVALID' }))
+    mockGetAuthenticatedSessionUser.mockResolvedValue({ id: 'user-1', email: 'new@example.com' })
+
+    const res = await POST(makeRequest({ inviteCode: 'INVALID' }))
     const body = await res.json()
     expect(body.allowed).toBe(false)
   })
@@ -89,8 +133,9 @@ describe('POST /api/auth/check-allowed', () => {
   it('유효한 appInviteCode로 요청 시 consume_app_invite RPC를 호출하고 needsOnboarding: true를 반환한다', async () => {
     mockFrom.mockReturnValue(makeChain({ data: null, error: null })) // allowed_emails select
     mockRpc.mockResolvedValue({ data: true, error: null })
+    mockGetAuthenticatedSessionUser.mockResolvedValue({ id: 'user-1', email: 'new@example.com' })
 
-    const res = await POST(makeRequest({ email: 'new@example.com', appInviteCode: 'ABCD1234' }))
+    const res = await POST(makeRequest({ appInviteCode: 'ABCD1234' }))
     const body = await res.json()
     expect(body.allowed).toBe(true)
     expect(body.needsOnboarding).toBe(true)
@@ -103,8 +148,9 @@ describe('POST /api/auth/check-allowed', () => {
   it('이미 사용되었거나 만료된 appInviteCode이면 RPC가 false를 반환하고 allowed: false가 된다', async () => {
     mockFrom.mockReturnValue(makeChain({ data: null, error: null })) // allowed_emails select
     mockRpc.mockResolvedValue({ data: false, error: null })
+    mockGetAuthenticatedSessionUser.mockResolvedValue({ id: 'user-1', email: 'new@example.com' })
 
-    const res = await POST(makeRequest({ email: 'new@example.com', appInviteCode: 'EXPIRED1' }))
+    const res = await POST(makeRequest({ appInviteCode: 'EXPIRED1' }))
     const body = await res.json()
     expect(body.allowed).toBe(false)
   })
@@ -112,8 +158,9 @@ describe('POST /api/auth/check-allowed', () => {
   it('consume_app_invite RPC 에러 시 500을 반환한다', async () => {
     mockFrom.mockReturnValue(makeChain({ data: null, error: null })) // allowed_emails select
     mockRpc.mockResolvedValue({ data: null, error: { message: 'RPC error' } })
+    mockGetAuthenticatedSessionUser.mockResolvedValue({ id: 'user-1', email: 'new@example.com' })
 
-    const res = await POST(makeRequest({ email: 'new@example.com', appInviteCode: 'ABCD1234' }))
+    const res = await POST(makeRequest({ appInviteCode: 'ABCD1234' }))
     expect(res.status).toBe(500)
   })
 
@@ -126,7 +173,8 @@ describe('POST /api/auth/check-allowed', () => {
   it('이메일이 소문자로 정규화된다', async () => {
     const chain = makeChain({ data: { email: 'test@example.com' }, error: null })
     mockFrom.mockReturnValue(chain)
-    await POST(makeRequest({ email: 'TEST@EXAMPLE.COM' }))
+    mockGetAuthenticatedSessionUser.mockResolvedValue({ id: 'user-1', email: 'TEST@EXAMPLE.COM' })
+    await POST(makeRequest({}))
     expect((chain.eq as jest.Mock)).toHaveBeenCalledWith('email', 'test@example.com')
   })
 })

--- a/src/__tests__/api/events/delete.test.ts
+++ b/src/__tests__/api/events/delete.test.ts
@@ -20,11 +20,13 @@ jest.mock('@/lib/push-utils', () => ({
 
 const mockGetClaims = jest.fn()
 const mockRpc = jest.fn()
+const mockFrom = jest.fn()
 
 jest.mock('@/lib/supabase-admin', () => ({
   supabaseAdmin: {
     auth: { getClaims: (token: unknown) => mockGetClaims(token) },
     rpc: (fn: unknown, args: unknown) => mockRpc(fn, args),
+    from: (table: unknown) => mockFrom(table),
   },
 }))
 
@@ -38,6 +40,16 @@ const deletedResult = {
   calendar_id: CALENDAR_ID,
   title: '생일 파티',
   start_at: '2026-04-15T09:00:00.000Z',
+}
+
+function makeAllowedEmailChain() {
+  const p = Promise.resolve({ data: { app_role: 'member' }, error: null })
+  const chain = {
+    select: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    maybeSingle: jest.fn().mockReturnValue(p),
+  }
+  return chain
 }
 
 function makeRequest(token = 'valid-token') {
@@ -61,6 +73,7 @@ beforeEach(() => {
     error: null,
   })
   mockRpc.mockResolvedValue({ data: deletedResult, error: null })
+  mockFrom.mockReturnValue(makeAllowedEmailChain())
 })
 
 describe('DELETE /api/events/[id]', () => {

--- a/src/__tests__/api/events/patch.test.ts
+++ b/src/__tests__/api/events/patch.test.ts
@@ -20,11 +20,13 @@ jest.mock('@/lib/push-utils', () => ({
 
 const mockGetClaims = jest.fn()
 const mockRpc = jest.fn()
+const mockFrom = jest.fn()
 
 jest.mock('@/lib/supabase-admin', () => ({
   supabaseAdmin: {
     auth: { getClaims: (token: unknown) => mockGetClaims(token) },
     rpc: (fn: unknown, args: unknown) => mockRpc(fn, args),
+    from: (table: unknown) => mockFrom(table),
   },
 }))
 
@@ -39,6 +41,16 @@ const baseResult = {
   new_calendar_id: CALENDAR_ID,
   new_title: '기존 제목',
   new_start_at: '2026-04-15T09:00:00.000Z',
+}
+
+function makeAllowedEmailChain() {
+  const p = Promise.resolve({ data: { app_role: 'member' }, error: null })
+  const chain = {
+    select: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    maybeSingle: jest.fn().mockReturnValue(p),
+  }
+  return chain
 }
 
 function makeRequest(body: Record<string, unknown>, token = 'valid-token') {
@@ -63,6 +75,7 @@ beforeEach(() => {
     error: null,
   })
   mockRpc.mockResolvedValue({ data: baseResult, error: null })
+  mockFrom.mockReturnValue(makeAllowedEmailChain())
 })
 
 describe('PATCH /api/events/[id]', () => {

--- a/src/__tests__/api/events/post.test.ts
+++ b/src/__tests__/api/events/post.test.ts
@@ -20,11 +20,13 @@ jest.mock('@/lib/push-utils', () => ({
 
 const mockGetClaims = jest.fn()
 const mockRpc = jest.fn()
+const mockFrom = jest.fn()
 
 jest.mock('@/lib/supabase-admin', () => ({
   supabaseAdmin: {
     auth: { getClaims: (token: unknown) => mockGetClaims(token) },
     rpc: (fn: unknown, args: unknown) => mockRpc(fn, args),
+    from: (table: unknown) => mockFrom(table),
   },
 }))
 
@@ -32,6 +34,16 @@ const ACTOR_USER_ID = 'actor-user'
 const FAMILY_ID = 'fam-1'
 const CALENDAR_ID = 'cal-1'
 const CREATED_EVENT = { id: 'evt-1', title: '생일 파티', family_id: FAMILY_ID }
+
+function makeAllowedEmailChain() {
+  const p = Promise.resolve({ data: { app_role: 'member' }, error: null })
+  const chain = {
+    select: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    maybeSingle: jest.fn().mockReturnValue(p),
+  }
+  return chain
+}
 
 function makeRequest(body: Record<string, unknown>, token = 'valid-token') {
   return new NextRequest('http://localhost/api/events', {
@@ -61,6 +73,7 @@ beforeEach(() => {
     error: null,
   })
   mockRpc.mockResolvedValue({ data: [CREATED_EVENT], error: null })
+  mockFrom.mockReturnValue(makeAllowedEmailChain())
 })
 
 describe('POST /api/events', () => {

--- a/src/__tests__/api/events/recurring.test.ts
+++ b/src/__tests__/api/events/recurring.test.ts
@@ -35,6 +35,30 @@ const FAMILY_ID     = 'fam-1'
 const SERIES_ID     = 'series-1'
 const EVENT_ID      = 'evt-1'
 
+function makeAllowedEmailChain() {
+  const p = Promise.resolve({ data: { app_role: 'member' }, error: null })
+  const chain = {
+    select: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    maybeSingle: jest.fn().mockReturnValue(p),
+  }
+  return chain
+}
+
+function makeFirstEventChain() {
+  return {
+    select: () => ({
+      eq: () => ({
+        order: () => ({
+          limit: () => ({
+            single: () => Promise.resolve({ data: { family_id: FAMILY_ID, calendar_id: null }, error: null }),
+          }),
+        }),
+      }),
+    }),
+  }
+}
+
 function makeRequest(method: string, url: string, body?: Record<string, unknown>, token = 'valid-token') {
   return new NextRequest(url, {
     method,
@@ -56,6 +80,9 @@ beforeEach(() => {
     error: null,
   })
   mockSendEventNotification.mockResolvedValue(undefined)
+  mockFrom.mockImplementation((table: unknown) =>
+    table === 'allowed_emails' ? makeAllowedEmailChain() : makeFirstEventChain()
+  )
 })
 
 // ── POST: recurring ──────────────────────────────────────────
@@ -73,18 +100,9 @@ describe('POST /api/events (recurring)', () => {
   }
 
   beforeEach(() => {
-    // from().select().eq().order().limit().single() chain
-    mockFrom.mockReturnValue({
-      select: () => ({
-        eq: () => ({
-          order: () => ({
-            limit: () => ({
-              single: () => Promise.resolve({ data: { family_id: FAMILY_ID, calendar_id: null }, error: null }),
-            }),
-          }),
-        }),
-      }),
-    })
+    mockFrom.mockImplementation((table: unknown) =>
+      table === 'allowed_emails' ? makeAllowedEmailChain() : makeFirstEventChain()
+    )
   })
 
   it('create_recurring_series_authorized RPC를 호출한다', async () => {
@@ -301,17 +319,6 @@ describe('DELETE /api/events/[id] (series scope)', () => {
 
   it('scope=single이면 delete_series_authorized(single)을 호출한다', async () => {
     mockRpc.mockResolvedValue({ data: { ...seriesDeleteResult, scope: 'single' }, error: null })
-    // need from() for single scope pre-fetch
-    mockFrom.mockReturnValue({
-      select: () => ({
-        eq: () => ({
-          single: () => Promise.resolve({
-            data: { id: EVENT_ID, family_id: FAMILY_ID, calendar_id: null, title: '회의', start_at: '2026-04-17T09:00:00Z', series_id: SERIES_ID, created_by: ACTOR_USER_ID },
-            error: null,
-          }),
-        }),
-      }),
-    })
     const res = await DELETE(
       makeRequest('DELETE', `http://localhost/api/events/${EVENT_ID}?scope=single`),
       makeParams(EVENT_ID)

--- a/src/__tests__/api/family-me.test.ts
+++ b/src/__tests__/api/family-me.test.ts
@@ -76,7 +76,7 @@ describe('POST /api/family/me', () => {
     expect(body.appRole).toBe('admin')
   })
 
-  it('allowed_emails에 없으면 appRole이 member 기본값이다', async () => {
+  it('appRole 조회 결과가 없으면 member 기본값이다', async () => {
     mockFrom.mockReturnValue(makeChain({ data: null, error: null }))
     const res = await POST(makeRequest())
     const body = await res.json()

--- a/src/__tests__/api/push/test.test.ts
+++ b/src/__tests__/api/push/test.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @jest-environment node
+ */
+import { POST } from '@/app/api/push/test/route'
+import { NextRequest } from 'next/server'
+
+const mockGetAuthenticatedUser = jest.fn()
+const mockIsAppAdmin = jest.fn()
+const mockFrom = jest.fn()
+const mockSendNotification = jest.fn()
+
+jest.mock('@/lib/api-auth', () => ({
+  getAuthenticatedUser: (...args: unknown[]) => mockGetAuthenticatedUser(...args),
+  isAppAdmin: (...args: unknown[]) => mockIsAppAdmin(...args),
+}))
+
+jest.mock('@/lib/supabase-admin', () => ({
+  supabaseAdmin: { from: (...args: unknown[]) => mockFrom(...args) },
+}))
+
+jest.mock('@/lib/webpush', () => ({
+  __esModule: true,
+  default: { sendNotification: (...args: unknown[]) => mockSendNotification(...args) },
+}))
+
+function makeRequest(body: object = {}) {
+  return new NextRequest('http://localhost/api/push/test', {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function makeSubscriptionQuery(result: { data: unknown; error: unknown }) {
+  const p = Promise.resolve(result)
+  const chain: Record<string, unknown> = {}
+  ;['select', 'eq'].forEach((method) => {
+    chain[method] = jest.fn().mockReturnValue(chain)
+  })
+  ;(chain as { then: unknown }).then = p.then.bind(p)
+  ;(chain as { catch: unknown }).catch = p.catch.bind(p)
+  return chain
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockGetAuthenticatedUser.mockResolvedValue({ id: 'user-1', email: 'user@example.com' })
+  mockIsAppAdmin.mockResolvedValue(false)
+  mockFrom.mockReturnValue(makeSubscriptionQuery({
+    data: [{ endpoint: 'https://push.example', p256dh: 'p256dh', auth: 'auth' }],
+    error: null,
+  }))
+  mockSendNotification.mockResolvedValue(undefined)
+})
+
+describe('POST /api/push/test', () => {
+  it('인증 사용자가 없으면 401을 반환한다', async () => {
+    mockGetAuthenticatedUser.mockResolvedValue(null)
+
+    const res = await POST(makeRequest({ userId: 'user-1' }))
+
+    expect(res.status).toBe(401)
+    expect(mockFrom).not.toHaveBeenCalled()
+  })
+
+  it('다른 사용자의 테스트 알림은 앱 관리자만 보낼 수 있다', async () => {
+    const res = await POST(makeRequest({ userId: 'user-2' }))
+
+    expect(res.status).toBe(403)
+    expect(mockFrom).not.toHaveBeenCalled()
+  })
+
+  it('본인 구독에는 테스트 알림을 보낼 수 있다', async () => {
+    const res = await POST(makeRequest({ userId: 'user-1' }))
+
+    expect(res.status).toBe(200)
+    expect(mockFrom).toHaveBeenCalledWith('push_subscriptions')
+    expect(mockSendNotification).toHaveBeenCalledTimes(1)
+  })
+
+  it('앱 관리자는 다른 사용자 구독에도 테스트 알림을 보낼 수 있다', async () => {
+    mockIsAppAdmin.mockResolvedValue(true)
+
+    const res = await POST(makeRequest({ userId: 'user-2' }))
+
+    expect(res.status).toBe(200)
+    expect(mockSendNotification).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/__tests__/app/AuthCallbackPage.test.tsx
+++ b/src/__tests__/app/AuthCallbackPage.test.tsx
@@ -1,49 +1,110 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import AuthCallbackPage from '@/app/auth/callback/page'
 
 const mockReplace = jest.fn()
 let mockErrorParam: string | null = null
+let mockNextParam: string | null = null
 
 jest.mock('next/navigation', () => ({
   useRouter: () => ({ replace: mockReplace }),
   useSearchParams: () => ({
-    get: (key: string) => key === 'error' ? mockErrorParam : null,
+    get: (key: string) => {
+      if (key === 'error') return mockErrorParam
+      if (key === 'next') return mockNextParam
+      return null
+    },
   }),
 }))
+
+const mockGetSession = jest.fn()
+const mockOnAuthStateChange = jest.fn()
+const mockSignOut = jest.fn()
 
 jest.mock('@/lib/supabase', () => ({
   supabase: {
     auth: {
-      getSession: jest.fn().mockResolvedValue({ data: { session: null } }),
-      onAuthStateChange: jest.fn(() => ({
-        data: {
-          subscription: {
-            unsubscribe: jest.fn(),
-          },
-        },
-      })),
-      signOut: jest.fn(),
+      getSession: (...args: unknown[]) => mockGetSession(...args),
+      onAuthStateChange: (...args: unknown[]) => mockOnAuthStateChange(...args),
+      signOut: (...args: unknown[]) => mockSignOut(...args),
     },
   },
 }))
 
+const mockParseInviteCodeFromNext = jest.fn()
+
 jest.mock('@/lib/auth', () => ({
-  parseInviteCodeFromNext: jest.fn(() => null),
+  parseInviteCodeFromNext: (...args: unknown[]) => mockParseInviteCodeFromNext(...args),
 }))
 
+const mockPostJsonWithAuth = jest.fn()
+
 jest.mock('@/lib/api-client', () => ({
-  postJson: jest.fn(),
+  postJsonWithAuth: (...args: unknown[]) => mockPostJsonWithAuth(...args),
 }))
 
 describe('AuthCallbackPage', () => {
   beforeEach(() => {
-    mockReplace.mockClear()
+    jest.clearAllMocks()
     mockErrorParam = null
+    mockNextParam = null
+    mockParseInviteCodeFromNext.mockReturnValue(null)
+    mockPostJsonWithAuth.mockResolvedValue({ allowed: true, needsOnboarding: false })
+    mockGetSession.mockResolvedValue({
+      data: { session: { user: { email: 'test@example.com' } } },
+    })
+    mockOnAuthStateChange.mockReturnValue({
+      data: {
+        subscription: {
+          unsubscribe: jest.fn(),
+        },
+      },
+    })
   })
 
   it('callback 전이 단계에서는 시각적 splash를 렌더링하지 않는다', () => {
     render(<AuthCallbackPage />)
 
     expect(screen.queryByRole('status')).not.toBeInTheDocument()
+  })
+
+  it('앱 초대 next에서는 appInviteCode만 check-allowed에 보낸다', async () => {
+    mockNextParam = '/join-app?code=APP12345'
+    mockParseInviteCodeFromNext.mockReturnValue('APP12345')
+    render(<AuthCallbackPage />)
+
+    await waitFor(() => {
+      expect(mockPostJsonWithAuth).toHaveBeenCalledWith('/api/auth/check-allowed', {
+        inviteCode: undefined,
+        appInviteCode: 'APP12345',
+      })
+    })
+    expect(mockParseInviteCodeFromNext).toHaveBeenCalledWith('/join-app?code=APP12345')
+    expect(mockReplace).toHaveBeenCalledWith('/join-app?code=APP12345')
+  })
+
+  it('가족 초대 next에서는 inviteCode만 check-allowed에 보낸다', async () => {
+    mockNextParam = '/join?code=FAM123'
+    mockParseInviteCodeFromNext.mockReturnValue('FAM123')
+    render(<AuthCallbackPage />)
+
+    await waitFor(() => {
+      expect(mockPostJsonWithAuth).toHaveBeenCalledWith('/api/auth/check-allowed', {
+        inviteCode: 'FAM123',
+        appInviteCode: undefined,
+      })
+    })
+    expect(mockParseInviteCodeFromNext).toHaveBeenCalledWith('/join?code=FAM123')
+    expect(mockReplace).toHaveBeenCalledWith('/join?code=FAM123')
+  })
+
+  it('앱 초대 소비 후 onboarding이 필요하면 onboarding으로 보낸다', async () => {
+    mockNextParam = '/join-app?code=APP12345'
+    mockParseInviteCodeFromNext.mockReturnValue('APP12345')
+    mockPostJsonWithAuth.mockResolvedValue({ allowed: true, needsOnboarding: true })
+    render(<AuthCallbackPage />)
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith('/onboarding')
+    })
   })
 })

--- a/src/__tests__/lib/api-auth.test.ts
+++ b/src/__tests__/lib/api-auth.test.ts
@@ -1,0 +1,91 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server'
+import {
+  getAuthenticatedSessionUser,
+  getAuthenticatedUser,
+  isAppAdmin,
+} from '@/lib/api-auth'
+
+const mockGetClaims = jest.fn()
+const mockFrom = jest.fn()
+
+jest.mock('@/lib/supabase-admin', () => ({
+  supabaseAdmin: {
+    auth: { getClaims: (...args: unknown[]) => mockGetClaims(...args) },
+    from: (...args: unknown[]) => mockFrom(...args),
+  },
+}))
+
+function makeRequest(token = 'token-123') {
+  return new NextRequest('http://localhost/api/test', {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+}
+
+function makeAllowedEmailChain(result: { data: unknown; error: unknown }) {
+  const p = Promise.resolve(result)
+  const chain: Record<string, unknown> = {}
+  ;['select', 'eq'].forEach((method) => {
+    chain[method] = jest.fn().mockReturnValue(chain)
+  })
+  chain.maybeSingle = jest.fn().mockReturnValue(p)
+  return chain
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  jest.spyOn(console, 'error').mockImplementation(() => {})
+  mockGetClaims.mockResolvedValue({
+    data: { claims: { sub: 'user-1', email: 'TEST@EXAMPLE.COM' } },
+    error: null,
+  })
+  mockFrom.mockReturnValue(makeAllowedEmailChain({
+    data: { app_role: 'member' },
+    error: null,
+  }))
+})
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+describe('api-auth helpers', () => {
+  it('getAuthenticatedSessionUser는 JWT claims에서 사용자 정보를 읽는다', async () => {
+    await expect(getAuthenticatedSessionUser(makeRequest())).resolves.toEqual({
+      id: 'user-1',
+      email: 'TEST@EXAMPLE.COM',
+    })
+  })
+
+  it('getAuthenticatedUser는 allowed_emails에 없으면 null을 반환한다', async () => {
+    mockFrom.mockReturnValue(makeAllowedEmailChain({ data: null, error: null }))
+
+    await expect(getAuthenticatedUser(makeRequest())).resolves.toBeNull()
+  })
+
+  it('getAuthenticatedUser는 allowed_emails 조회 실패를 삼키지 않는다', async () => {
+    mockFrom.mockReturnValue(makeAllowedEmailChain({
+      data: null,
+      error: { message: 'DB unavailable' },
+    }))
+
+    await expect(getAuthenticatedUser(makeRequest())).rejects.toThrow(
+      'Allowed email lookup failed'
+    )
+    expect(console.error).toHaveBeenCalledWith(
+      '[api-auth] allowed email lookup failed:',
+      { message: 'DB unavailable' }
+    )
+  })
+
+  it('isAppAdmin은 app_role이 admin일 때만 true를 반환한다', async () => {
+    mockFrom.mockReturnValue(makeAllowedEmailChain({
+      data: { app_role: 'admin' },
+      error: null,
+    }))
+
+    await expect(isAppAdmin('admin@example.com')).resolves.toBe(true)
+  })
+})

--- a/src/app/api/auth/check-allowed/route.ts
+++ b/src/app/api/auth/check-allowed/route.ts
@@ -1,18 +1,19 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { getAuthenticatedSessionUser } from '@/lib/api-auth'
 import { supabaseAdmin } from '@/lib/supabase-admin'
 
 export async function POST(req: NextRequest) {
-  const { email, inviteCode, appInviteCode } = await req.json() as {
-    email?: string
+  const authUser = await getAuthenticatedSessionUser(req)
+  if (!authUser) {
+    return NextResponse.json({ error: 'Unauthorized', allowed: false }, { status: 401 })
+  }
+
+  const { inviteCode, appInviteCode } = await req.json() as {
     inviteCode?: string
     appInviteCode?: string
   }
 
-  if (!email) {
-    return NextResponse.json({ error: 'email is required' }, { status: 400 })
-  }
-
-  const normalizedEmail = email.toLowerCase()
+  const normalizedEmail = authUser.email.toLowerCase()
 
   // 1. allowed_emails 테이블에 있으면 바로 허용
   const { data: existing, error: dbError } = await supabaseAdmin
@@ -49,16 +50,26 @@ export async function POST(req: NextRequest) {
 
   // 3. 가족 초대 코드로 진입한 경우 → allowed_emails에 추가 후 허용 (가족 합류는 /join 페이지에서)
   if (inviteCode) {
-    const { data: family } = await supabaseAdmin
+    const { data: family, error: familyError } = await supabaseAdmin
       .from('families')
       .select('id')
       .ilike('invite_code', inviteCode)
       .maybeSingle()
 
+    if (familyError) {
+      console.error('[check-allowed] family invite lookup error:', familyError)
+      return NextResponse.json({ error: 'DB error', allowed: false }, { status: 500 })
+    }
+
     if (family) {
-      await supabaseAdmin
+      const { error: insertError } = await supabaseAdmin
         .from('allowed_emails')
-        .insert({ email: normalizedEmail })
+        .upsert({ email: normalizedEmail }, { onConflict: 'email', ignoreDuplicates: true })
+
+      if (insertError) {
+        console.error('[check-allowed] allowed email insert error:', insertError)
+        return NextResponse.json({ error: 'DB error', allowed: false }, { status: 500 })
+      }
 
       return NextResponse.json({ allowed: true, needsOnboarding: false })
     }

--- a/src/app/api/push/test/route.ts
+++ b/src/app/api/push/test/route.ts
@@ -1,11 +1,21 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { getAuthenticatedUser, isAppAdmin } from '@/lib/api-auth'
 import { supabaseAdmin } from '@/lib/supabase-admin'
 import webpush from '@/lib/webpush'
 
 export async function POST(req: NextRequest) {
+  const authUser = await getAuthenticatedUser(req)
+  if (!authUser) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
   const { userId } = await req.json()
   if (!userId) {
     return NextResponse.json({ error: 'userId required' }, { status: 400 })
+  }
+
+  if (userId !== authUser.id && !(await isAppAdmin(authUser.email))) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
   }
 
   const { data: subs, error } = await supabaseAdmin

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -4,7 +4,7 @@ import { Suspense, useEffect, useRef } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { supabase } from '@/lib/supabase'
 import { parseInviteCodeFromNext } from '@/lib/auth'
-import { postJson } from '@/lib/api-client'
+import { postJsonWithAuth } from '@/lib/api-client'
 
 function AuthCallbackInner() {
   const router = useRouter()
@@ -25,7 +25,7 @@ function AuthCallbackInner() {
       return
     }
 
-    const handleSession = async (email: string) => {
+    const handleSession = async () => {
       // 중복 실행 방지 (getSession + onAuthStateChange 둘 다 트리거될 수 있음)
       if (handledRef.current) return
       handledRef.current = true
@@ -41,10 +41,9 @@ function AuthCallbackInner() {
       let allowed = false
       let needsOnboarding = false
       try {
-        const body = await postJson<{ allowed: boolean; needsOnboarding?: boolean }>(
+        const body = await postJsonWithAuth<{ allowed: boolean; needsOnboarding?: boolean }>(
           '/api/auth/check-allowed',
           {
-            email,
             inviteCode: isAppInvite ? undefined : inviteCode,
             appInviteCode: isAppInvite ? inviteCode : undefined,
           }
@@ -68,7 +67,7 @@ function AuthCallbackInner() {
     // Supabase가 이미 세션을 처리한 경우 (effect 실행 전 자동 교환 완료)
     supabase.auth.getSession().then(({ data: { session } }) => {
       if (session && session.user?.email) {
-        handleSession(session.user.email)
+        handleSession()
         return
       }
 
@@ -80,7 +79,7 @@ function AuthCallbackInner() {
     // Supabase가 effect 실행 후 세션을 처리하는 경우
     const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
       if (event === 'SIGNED_IN' && session && session.user?.email) {
-        handleSession(session.user.email)
+        handleSession()
       } else if (event === 'SIGNED_OUT') {
         routeToLoginError('auth_callback_failed')
       }

--- a/src/lib/api-auth.ts
+++ b/src/lib/api-auth.ts
@@ -28,16 +28,27 @@ export async function getAuthenticatedUserId(req: NextRequest): Promise<string |
   return user?.id ?? null
 }
 
-export async function isAppAdmin(email: string): Promise<boolean> {
-  const { data } = await supabaseAdmin
+async function getAllowedEmailRecord(email: string): Promise<{ app_role: string } | null> {
+  const { data, error } = await supabaseAdmin
     .from('allowed_emails')
     .select('app_role')
     .eq('email', email.toLowerCase())
     .maybeSingle()
-  return data?.app_role === 'admin'
+
+  if (error) {
+    console.error('[api-auth] allowed email lookup failed:', error)
+    throw new Error('Allowed email lookup failed')
+  }
+
+  return data
 }
 
-export async function getAuthenticatedUser(
+export async function isAppAdmin(email: string): Promise<boolean> {
+  const record = await getAllowedEmailRecord(email)
+  return record?.app_role === 'admin'
+}
+
+export async function getAuthenticatedSessionUser(
   req: NextRequest
 ): Promise<{ id: string; email: string } | null> {
   const authorization = req.headers.get('authorization')
@@ -55,4 +66,16 @@ export async function getAuthenticatedUser(
   const { sub: id, email } = data.claims as { sub?: string; email?: string }
   if (!id || !email) return null
   return { id, email }
+}
+
+export async function getAuthenticatedUser(
+  req: NextRequest
+): Promise<{ id: string; email: string } | null> {
+  const user = await getAuthenticatedSessionUser(req)
+  if (!user) return null
+
+  const allowedEmail = await getAllowedEmailRecord(user.email)
+  if (!allowedEmail) return null
+
+  return user
 }


### PR DESCRIPTION
## Summary
- 보호 API 인증 헬퍼가 JWT 검증뿐 아니라 allowed_emails 등록 여부까지 확인하도록 강화했습니다.
- OAuth callback의 허용 여부 확인은 요청 body의 email을 신뢰하지 않고 인증된 세션 email을 사용하도록 변경했습니다.
- 가족 초대 allowlist 생성 실패를 무시하지 않고 500으로 처리하며, 중복 race는 upsert로 안전하게 허용했습니다.
- /api/push/test는 인증된 본인 또는 앱 관리자만 호출할 수 있도록 잠갔습니다.
- auth helper, callback 분기, check-allowed, push test 관련 테스트를 보강했습니다.

## Testing
- [x] npm run test
- [x] npx tsc --noEmit
- [x] GitHub Actions Lint & Test 통과
- [x] Vercel Preview 통과

## Notes
- allowed_emails에서 제거된 사용자는 기존 access token이 남아 있어도 보호 API를 사용할 수 없습니다.
- DB allowlist 조회 실패는 보안상 fail-closed로 처리하며, 운영 디버깅을 위해 서버 오류로 드러나게 했습니다.