### PR TITLE
fix: avoid all-day lane gaps in month grid

### DIFF
--- a/src/__tests__/components/CalendarGrid.test.tsx
+++ b/src/__tests__/components/CalendarGrid.test.tsx
@@ -5,6 +5,7 @@ import {
   isMultiDayAllDay,
   isEventOnDate,
   computeSegments,
+  computeLaneHeightsByColumn,
   getSingleEventDisplayBudget,
 } from '@/components/calendar/CalendarGrid'
 import type { Calendar, CalendarEvent } from '@/lib/calendar'
@@ -276,6 +277,42 @@ describe('computeSegments', () => {
     // 긴 이벤트(a-long)가 먼저
     expect(segs[0].event.id).toBe('a-long')
     expect(segs[1].event.id).toBe('z-short')
+  })
+})
+
+describe('computeLaneHeightsByColumn', () => {
+  it('이벤트가 걸친 날짜만 lane 높이를 예약하고 다른 날짜는 0으로 둔다', () => {
+    const row = makeRow(2026, 4, 24) // 2026-05-24 ~ 2026-05-30
+    const segs = computeSegments(row, [
+      makeEvent({
+        id: 'trip',
+        is_all_day: true,
+        start_at: '2026-05-28T00:00:00Z',
+        end_at: '2026-06-02T00:00:00Z',
+      }),
+    ])
+
+    expect(computeLaneHeightsByColumn(segs)).toEqual([0, 0, 0, 0, 18, 18, 18])
+  })
+
+  it('겹치는 멀티데이 이벤트는 해당 날짜 열만 더 큰 lane 높이를 예약한다', () => {
+    const row = makeRow(2025, 5, 8) // 2025-06-08 ~ 2025-06-14
+    const segs = computeSegments(row, [
+      makeEvent({
+        id: 'a',
+        is_all_day: true,
+        start_at: '2025-06-09T00:00:00Z',
+        end_at: '2025-06-12T00:00:00Z',
+      }),
+      makeEvent({
+        id: 'b',
+        is_all_day: true,
+        start_at: '2025-06-10T00:00:00Z',
+        end_at: '2025-06-11T00:00:00Z',
+      }),
+    ])
+
+    expect(computeLaneHeightsByColumn(segs)).toEqual([0, 18, 36, 36, 18, 0, 0])
   })
 })
 

--- a/src/__tests__/components/CalendarGrid.test.tsx
+++ b/src/__tests__/components/CalendarGrid.test.tsx
@@ -509,6 +509,40 @@ describe('CalendarGrid', () => {
     expect(bars).toHaveLength(2)
   })
 
+  it('월 경계 멀티데이 종일 일정은 실제로 겹치는 날짜 셀에만 lane spacer를 만든다', () => {
+    const events = [
+      makeEvent({
+        id: 'cross-month',
+        title: '근짱 일본',
+        is_all_day: true,
+        start_at: '2026-05-28T00:00:00Z',
+        end_at: '2026-06-02T00:00:00Z',
+      }),
+      makeEvent({
+        id: 'front-day',
+        title: '부처님오신날',
+        is_all_day: true,
+        start_at: '2026-05-24T00:00:00Z',
+        end_at: '2026-05-24T00:00:00Z',
+      }),
+      makeEvent({
+        id: 'mid-day',
+        title: '대체공휴일',
+        is_all_day: true,
+        start_at: '2026-05-25T00:00:00Z',
+        end_at: '2026-05-25T00:00:00Z',
+      }),
+    ]
+
+    render(<CalendarGrid {...defaultProps} year={2026} month={4} events={events} />)
+
+    expect(screen.getByTestId('lane-spacer-2026-05-24')).toHaveStyle({ height: '0px' })
+    expect(screen.getByTestId('lane-spacer-2026-05-25')).toHaveStyle({ height: '0px' })
+    expect(screen.getByTestId('lane-spacer-2026-05-28')).toHaveStyle({ height: '18px' })
+    expect(screen.getByTestId('lane-spacer-2026-05-29')).toHaveStyle({ height: '18px' })
+    expect(screen.getByTestId('lane-spacer-2026-05-30')).toHaveStyle({ height: '18px' })
+  })
+
   it('주 경계에서 잘린 이벤트 첫 segment는 ‹ 화살표가 없다', () => {
     const crossWeekEvent = makeEvent({
       id: 'cross-2',

--- a/src/components/calendar/CalendarGrid.tsx
+++ b/src/components/calendar/CalendarGrid.tsx
@@ -184,6 +184,20 @@ export function computeSegments(row: DayCell[], multiDayEvents: CalendarEvent[])
   return segments
 }
 
+export function computeLaneHeightsByColumn(segments: EventSegment[]): number[] {
+  const heights = Array.from({ length: 7 }, () => 0)
+
+  for (const seg of segments) {
+    const laneHeight = (seg.lane + 1) * LANE_HEIGHT
+    const endCol = seg.colStart + seg.colSpan
+    for (let col = seg.colStart; col < endCol; col += 1) {
+      if (laneHeight > heights[col]) heights[col] = laneHeight
+    }
+  }
+
+  return heights
+}
+
 
 interface Props {
   year: number
@@ -332,8 +346,7 @@ export function CalendarGrid({
       {/* 주 단위 행 — minmax(0,1fr) 트랙 */}
       {rows.map((row, rowIdx) => {
         const segments = computeSegments(row, multiDayEvents)
-        const laneCount = segments.reduce((max, s) => s.lane > max ? s.lane : max, -1) + 1
-        const laneAreaHeight = laneCount * LANE_HEIGHT
+        const laneHeightsByColumn = computeLaneHeightsByColumn(segments)
 
         return (
             <div key={rowIdx} className="relative min-h-0">
@@ -350,6 +363,7 @@ export function CalendarGrid({
                   const isSun = dow === 0
                   const isSat = dow === 6
                   const hasHolidaysAndEvents = dayHolidays.length > 0 && daySingleEvents.length > 0
+                  const laneAreaHeight = laneHeightsByColumn[colIdx] ?? 0
                   const singleEventDisplay = getSingleEventDisplayBudget({
                     rowHeight,
                     dateHeaderHeight: effectiveDateHeaderHeight,

--- a/src/components/calendar/CalendarGrid.tsx
+++ b/src/components/calendar/CalendarGrid.tsx
@@ -425,7 +425,11 @@ export function CalendarGrid({
                       </div>
 
                       {/* 멀티데이 lane 공간 확보용 spacer */}
-                      <div aria-hidden="true" style={{ height: laneAreaHeight }} />
+                      <div
+                        aria-hidden="true"
+                        data-testid={`lane-spacer-${ymd}`}
+                        style={{ height: laneAreaHeight }}
+                      />
 
                       {/* 공휴일 chips */}
                       <div className="w-full space-y-0.5">


### PR DESCRIPTION
## Summary
- 월간 캘린더에서 멀티데이 종일 일정 lane 높이를 주 전체가 아니라 날짜 열별로 계산하도록 변경했습니다.
- 주 후반이나 월 경계에 걸친 종일 일정이 있어도, 실제로 겹치지 않는 날짜의 다른 일정이 불필요하게 한 줄 아래로 밀리지 않도록 수정했습니다.
- 날짜별 lane 높이 계산 회귀 테스트를 추가해 월 경계 종일 일정과 겹치는 멀티데이 일정 케이스를 함께 검증했습니다.

## Testing
- [x] npm run test -- --runInBand src/__tests__/components/CalendarGrid.test.tsx
- [x] npx tsc --noEmit

## Manual Verification
- [ ] 2026년 5월 월간 캘린더에서 5/28~6/2처럼 여러 날짜에 걸친 종일 일정이 있어도 같은 주의 다른 종일 일정이 겹치지 않는 날짜에서는 아래 줄로 밀리지 않는지 확인
- [ ] 월 경계에 걸친 종일 일정이 있는 주에서 실제로 날짜가 겹치는 종일 일정만 아래 lane으로 내려가는지 확인
- [ ] 멀티데이 종일 일정 바의 시작/끝 화살표와 클릭 동작이 기존처럼 유지되는지 확인