### PR TITLE
perf: reduce reminder cron frequency

### DIFF
--- a/src/__tests__/lib/reminder-rpc-sql.test.ts
+++ b/src/__tests__/lib/reminder-rpc-sql.test.ts
@@ -3,12 +3,14 @@ import path from 'node:path'
 import {
   FIXED_ALL_DAY_ADVANCE_REMINDER_HOUR,
   FIXED_ALL_DAY_ADVANCE_REMINDER_MINIMUM_MINUTES,
+  REMINDER_CRON_FORWARD_BUFFER_SECONDS,
+  REMINDER_CRON_LOOKBACK_MINUTES,
   REMINDER_TIME_ZONE,
 } from '@/lib/reminders'
 
 const migrationPath = path.resolve(
   process.cwd(),
-  'supabase/migrations/20260425030000_fix_all_day_advance_reminder_time.sql'
+  'supabase/migrations/20260504000000_reduce_reminder_cron_frequency.sql'
 )
 
 describe('get_and_mark_due_reminders migration', () => {
@@ -28,6 +30,15 @@ describe('get_and_mark_due_reminders migration', () => {
     const sql = fs.readFileSync(migrationPath, 'utf8')
 
     expect(sql).toContain("else\n            e.start_at - (er.remind_minutes_before * interval '1 minute')")
-    expect(sql).toContain("between now() - interval '65 seconds' and now() + interval '5 seconds'")
+    expect(sql).toContain(
+      `between now() - interval '${REMINDER_CRON_LOOKBACK_MINUTES} minutes' and now() + interval '${REMINDER_CRON_FORWARD_BUFFER_SECONDS} seconds'`
+    )
+  })
+
+  it('기존 reminder cron job을 5분 주기로 낮춘다', () => {
+    const sql = fs.readFileSync(migrationPath, 'utf8')
+
+    expect(sql).toContain("where jobname = 'send-push-reminders'")
+    expect(sql).toContain("cron.alter_job(reminder_job_id, schedule := '*/5 * * * *')")
   })
 })

--- a/src/__tests__/lib/reminders.test.ts
+++ b/src/__tests__/lib/reminders.test.ts
@@ -1,7 +1,12 @@
 import {
   FIXED_ALL_DAY_ADVANCE_REMINDER_HOUR,
   FIXED_ALL_DAY_ADVANCE_REMINDER_MINIMUM_MINUTES,
+  REMINDER_CRON_FORWARD_BUFFER_SECONDS,
+  REMINDER_CRON_LOOKBACK_MINUTES,
+  REMINDER_CRON_PERIOD_MINUTES,
   getReminderTriggerAt,
+  getReminderSelectionWindow,
+  isReminderDueForRun,
   usesFixedMorningAllDayReminder,
 } from '@/lib/reminders'
 
@@ -40,5 +45,30 @@ describe('getReminderTriggerAt', () => {
   it('종일 일정의 1주 전도 Tokyo 기준 7일 전 오전 8시에 발송된다', () => {
     expect(getReminderTriggerAt('2026-04-25T00:00:00+09:00', true, 10080))
       .toBe('2026-04-17T23:00:00.000Z')
+  })
+})
+
+describe('reminder selection window', () => {
+  it('5분 cadence와 6분 lookback, 5초 forward buffer를 사용한다', () => {
+    expect(REMINDER_CRON_PERIOD_MINUTES).toBe(5)
+    expect(REMINDER_CRON_LOOKBACK_MINUTES).toBe(6)
+    expect(REMINDER_CRON_FORWARD_BUFFER_SECONDS).toBe(5)
+  })
+
+  it('cron 실행 시각 기준으로 due window를 계산한다', () => {
+    const { start, end } = getReminderSelectionWindow('2026-05-04T10:05:12.000Z')
+
+    expect(start.toISOString()).toBe('2026-05-04T09:59:12.000Z')
+    expect(end.toISOString()).toBe('2026-05-04T10:05:17.000Z')
+  })
+
+  it('5분 주기 실행이 11초 지연돼도 due reminder를 놓치지 않는다', () => {
+    const firstRunAt = '2026-05-04T10:00:01.000Z'
+    const secondRunAt = '2026-05-04T10:05:12.000Z'
+
+    expect(isReminderDueForRun('2026-05-04T10:00:06.000Z', firstRunAt)).toBe(true)
+    expect(isReminderDueForRun('2026-05-04T10:00:07.000Z', firstRunAt)).toBe(false)
+    expect(isReminderDueForRun('2026-05-04T10:00:07.000Z', secondRunAt)).toBe(true)
+    expect(isReminderDueForRun('2026-05-04T10:00:11.000Z', secondRunAt)).toBe(true)
   })
 })

--- a/src/lib/reminders.ts
+++ b/src/lib/reminders.ts
@@ -1,6 +1,9 @@
 export const REMINDER_TIME_ZONE = 'Asia/Tokyo'
 export const FIXED_ALL_DAY_ADVANCE_REMINDER_HOUR = 8
 export const FIXED_ALL_DAY_ADVANCE_REMINDER_MINIMUM_MINUTES = 1440
+export const REMINDER_CRON_PERIOD_MINUTES = 5
+export const REMINDER_CRON_LOOKBACK_MINUTES = 6
+export const REMINDER_CRON_FORWARD_BUFFER_SECONDS = 5
 
 export function usesFixedMorningAllDayReminder(isAllDay: boolean, remindMinutesBefore: number): boolean {
   return (
@@ -49,4 +52,23 @@ export function getReminderTriggerAt(
     daysBefore * 24 * 60 * 60 * 1000 +
     FIXED_ALL_DAY_ADVANCE_REMINDER_HOUR * 60 * 60 * 1000
   ).toISOString()
+}
+
+export function getReminderSelectionWindow(runAt: string | Date): {
+  start: Date
+  end: Date
+} {
+  const runTime = new Date(runAt)
+
+  return {
+    start: new Date(runTime.getTime() - REMINDER_CRON_LOOKBACK_MINUTES * 60 * 1000),
+    end: new Date(runTime.getTime() + REMINDER_CRON_FORWARD_BUFFER_SECONDS * 1000),
+  }
+}
+
+export function isReminderDueForRun(reminderTriggerAt: string | Date, runAt: string | Date): boolean {
+  const triggerTime = new Date(reminderTriggerAt).getTime()
+  const { start, end } = getReminderSelectionWindow(runAt)
+
+  return triggerTime >= start.getTime() && triggerTime <= end.getTime()
 }

--- a/supabase/migrations/20260404000001_push_subscriptions.sql
+++ b/supabase/migrations/20260404000001_push_subscriptions.sql
@@ -66,7 +66,7 @@ $$;
 --
 -- select cron.schedule(
 --   'send-push-reminders',
---   '* * * * *',
+--   '*/5 * * * *',
 --   $$
 --   select net.http_post(
 --     url     := 'https://<VERCEL_URL>/api/cron/send-reminders',

--- a/supabase/migrations/20260504000000_reduce_reminder_cron_frequency.sql
+++ b/supabase/migrations/20260504000000_reduce_reminder_cron_frequency.sql
@@ -1,0 +1,64 @@
+-- Reduce reminder polling overhead by running the reminder cron every 5 minutes
+-- with a 6-minute lookback window for scheduler jitter.
+
+drop function if exists public.get_and_mark_due_reminders();
+
+create function public.get_and_mark_due_reminders()
+returns table (
+  reminder_id  uuid,
+  event_title  text,
+  event_start  timestamptz,
+  is_all_day   boolean,
+  family_id    uuid
+)
+security definer
+set search_path = public, pg_temp
+language plpgsql as $$
+begin
+  return query
+    update event_reminders er
+    set sent_at = now()
+    from events e
+    where er.event_id = e.id
+      and er.sent_at is null
+      and (
+        case
+          when e.is_all_day
+            and er.remind_minutes_before >= 1440
+            and mod(er.remind_minutes_before, 1440) = 0 then
+            (
+              (
+                timezone('Asia/Tokyo', e.start_at)::date
+                - (er.remind_minutes_before / 1440)
+              )::timestamp
+              + time '08:00'
+            ) at time zone 'Asia/Tokyo'
+          else
+            e.start_at - (er.remind_minutes_before * interval '1 minute')
+        end
+      ) between now() - interval '6 minutes' and now() + interval '5 seconds'
+    returning er.id, e.title, e.start_at, e.is_all_day, e.family_id;
+end;
+$$;
+
+revoke execute on function public.get_and_mark_due_reminders()
+from public, anon, authenticated;
+
+grant execute on function public.get_and_mark_due_reminders()
+to service_role;
+
+do $$
+declare
+  reminder_job_id bigint;
+begin
+  select jobid
+  into reminder_job_id
+  from cron.job
+  where jobname = 'send-push-reminders'
+  limit 1;
+
+  if reminder_job_id is not null then
+    perform cron.alter_job(reminder_job_id, schedule := '*/5 * * * *');
+  end if;
+end;
+$$;


### PR DESCRIPTION
## Summary
- widen the reminder due window to six minutes to preserve a five-minute polling cadence with jitter tolerance
- reschedule the existing send-push-reminders cron job from every minute to every five minutes
- update the reminder SQL migration test and cron setup example to match the new schedule

## Testing
- npm test -- --runInBand src/__tests__/lib/reminder-rpc-sql.test.ts
- npx tsc --noEmit
- npm run lint
