### PR TITLE
chore: clean up cron run logs

### DIFF
--- a/src/__tests__/lib/cron-cleanup-sql.test.ts
+++ b/src/__tests__/lib/cron-cleanup-sql.test.ts
@@ -1,0 +1,28 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+const migrationPath = path.resolve(
+  process.cwd(),
+  'supabase/migrations/20260504001000_cleanup_cron_run_details.sql'
+)
+
+describe('cron job run details cleanup migration', () => {
+  it('deletes old pg_cron run details with a bounded retention window', () => {
+    const sql = fs.readFileSync(migrationPath, 'utf8')
+
+    expect(sql).toContain('create or replace function maintenance.cleanup_cron_job_run_details')
+    expect(sql).toContain('set search_path = pg_catalog, cron, pg_temp')
+    expect(sql).toContain('p_retention_days integer default 14')
+    expect(sql).toContain('delete from cron.job_run_details')
+    expect(sql).toContain('Preserve rows without end_time')
+    expect(sql).toContain('where end_time < now() - make_interval(days => p_retention_days)')
+  })
+
+  it('schedules a single daily cleanup job', () => {
+    const sql = fs.readFileSync(migrationPath, 'utf8')
+
+    expect(sql).toContain("where jobname = 'cleanup-cron-job-run-details'")
+    expect(sql).toContain('cron.unschedule(cleanup_job_id)')
+    expect(sql).toContain("cron.schedule(\n    'cleanup-cron-job-run-details',\n    '23 3 * * *'")
+  })
+})

--- a/supabase/migrations/20260504001000_cleanup_cron_run_details.sql
+++ b/supabase/migrations/20260504001000_cleanup_cron_run_details.sql
@@ -1,0 +1,57 @@
+-- Keep pg_cron execution logs bounded so routine jobs do not grow
+-- cron.job_run_details indefinitely.
+
+create schema if not exists maintenance;
+
+create or replace function maintenance.cleanup_cron_job_run_details(
+  p_retention_days integer default 14
+)
+returns integer
+security definer
+set search_path = pg_catalog, cron, pg_temp
+language plpgsql
+as $$
+declare
+  v_deleted_count integer;
+begin
+  if p_retention_days < 0 then
+    raise exception 'invalid_retention_days';
+  end if;
+
+  with deleted_rows as (
+    delete from cron.job_run_details
+    -- Preserve rows without end_time so in-flight or abnormal runs are not deleted blindly.
+    where end_time < now() - make_interval(days => p_retention_days)
+    returning 1
+  )
+  select count(*)::integer into v_deleted_count
+  from deleted_rows;
+
+  return v_deleted_count;
+end;
+$$;
+
+revoke execute on function maintenance.cleanup_cron_job_run_details(integer)
+from public, anon, authenticated;
+
+do $do$
+declare
+  cleanup_job_id bigint;
+begin
+  select jobid
+  into cleanup_job_id
+  from cron.job
+  where jobname = 'cleanup-cron-job-run-details'
+  limit 1;
+
+  if cleanup_job_id is not null then
+    perform cron.unschedule(cleanup_job_id);
+  end if;
+
+  perform cron.schedule(
+    'cleanup-cron-job-run-details',
+    '23 3 * * *',
+    $$select maintenance.cleanup_cron_job_run_details(14);$$
+  );
+end;
+$do$;


### PR DESCRIPTION
## Summary
- add a maintenance RPC that deletes pg_cron run details older than 14 days
- schedule a daily cleanup job for cron.job_run_details
- add SQL coverage for the retention window and scheduled cleanup job

## Testing
- npm test -- --runInBand src/__tests__/lib/cron-cleanup-sql.test.ts
- npx tsc --noEmit
- npm run lint
