### PR TITLE
feat: add following recurrence split groundwork

### DIFF
--- a/src/__tests__/api/events/recurring.test.ts
+++ b/src/__tests__/api/events/recurring.test.ts
@@ -317,10 +317,72 @@ describe('PATCH /api/events/[id] (series scope)', () => {
     )
   })
 
-  it('following scope에서 날짜 이동을 요청하면 400을 반환한다', async () => {
+  it('following scope에서 날짜 이동을 요청하면 split_recurring_series_following_authorized를 호출한다', async () => {
+    mockRpc.mockResolvedValue({
+      data: {
+        is_changed: true,
+        family_id: FAMILY_ID,
+        new_calendar_id: null,
+        new_title: '회의',
+        new_start_at: '2026-04-18T09:00:00.000Z',
+        series_id: 'series-2',
+        old_series_id: SERIES_ID,
+      },
+      error: null,
+    })
     const body = {
       title: '회의',
       scope: 'following',
+      anchorOccurrenceDate: '2026-04-17',
+      localStartDate: '2026-04-18',
+      startAt: '2026-04-18T09:00:00.000Z',
+      endAt: '2026-04-18T10:00:00.000Z',
+      recurrence: { freq: 'weekly', interval: 1, daysOfWeek: [6] },
+    }
+    const res = await PATCH(
+      makeRequest('PATCH', `http://localhost/api/events/${EVENT_ID}`, body),
+      makeParams(EVENT_ID)
+    )
+    expect(res.status).toBe(204)
+    expect(mockRpc).toHaveBeenCalledWith(
+      'split_recurring_series_following_authorized',
+      expect.objectContaining({
+        p_anchor_occurrence_date: '2026-04-17',
+        p_local_start_date: '2026-04-18',
+        p_start_at: '2026-04-18T09:00:00.000Z',
+        p_end_at: '2026-04-18T10:00:00.000Z',
+        p_freq: 'weekly',
+        p_interval: 1,
+        p_days_of_week: [6],
+      })
+    )
+    expect(mockSendEventNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'updated', eventStartAt: '2026-04-18T09:00:00.000Z' })
+    )
+  })
+
+  it('following 날짜 이동 split이 생성할 occurrence가 없으면 400을 반환한다', async () => {
+    mockRpc.mockResolvedValue({ data: null, error: { message: 'no_future_occurrences' } })
+    const body = {
+      title: '회의',
+      scope: 'following',
+      anchorOccurrenceDate: '2026-04-17',
+      localStartDate: '2026-04-18',
+      startAt: '2026-04-18T09:00:00.000Z',
+      recurrence: { freq: 'weekly', interval: 1, daysOfWeek: [6], endDate: '2026-04-17' },
+    }
+    const res = await PATCH(
+      makeRequest('PATCH', `http://localhost/api/events/${EVENT_ID}`, body),
+      makeParams(EVENT_ID)
+    )
+    expect(res.status).toBe(400)
+    expect(mockSendEventNotification).not.toHaveBeenCalled()
+  })
+
+  it('all scope에서 날짜 이동을 요청하면 400을 반환한다', async () => {
+    const body = {
+      title: '회의',
+      scope: 'all',
       anchorOccurrenceDate: '2026-04-17',
       localStartDate: '2026-04-18',
       startAt: '2026-04-18T09:00:00.000Z',

--- a/src/__tests__/lib/recurrence-following-split-sql.test.ts
+++ b/src/__tests__/lib/recurrence-following-split-sql.test.ts
@@ -1,0 +1,50 @@
+import fs from 'fs'
+import path from 'path'
+
+const migrationPath = path.join(
+  process.cwd(),
+  'supabase/migrations/20260505001000_split_recurring_series_following.sql'
+)
+
+describe('split_recurring_series_following_authorized migration', () => {
+  const sql = () => fs.readFileSync(migrationPath, 'utf8')
+
+  it('기존 series를 anchor 전날까지 trim하고 future events를 취소한다', () => {
+    const migration = sql()
+
+    expect(migration).toContain('CREATE OR REPLACE FUNCTION split_recurring_series_following_authorized')
+    expect(migration.indexOf('IF v_count = 0 THEN')).toBeGreaterThan(-1)
+    expect(migration.indexOf('UPDATE events SET is_cancelled = true')).toBeGreaterThan(
+      migration.indexOf('IF v_count = 0 THEN')
+    )
+    expect(migration).toContain('UPDATE events SET is_cancelled = true')
+    expect(migration).toContain('series_occurrence_date >= p_anchor_occurrence_date')
+    expect(migration).toContain('SET end_date = p_anchor_occurrence_date - 1')
+  })
+
+  it('새 rule과 새 series를 만들고 변경된 rule로 future events를 materialize한다', () => {
+    const migration = sql()
+
+    expect(migration).toContain('INSERT INTO recurrence_rules')
+    expect(migration).toContain('INSERT INTO recurrence_series')
+    expect(migration).toContain('RETURNING id INTO v_new_series_id')
+    expect(migration).toContain('PERFORM insert_series_event_instance')
+    expect(migration).toContain("'old_series_id',   v_event.series_id")
+  })
+
+  it('weekly 날짜 변경은 새 시작일의 요일을 기본 days_of_week로 사용한다', () => {
+    const migration = sql()
+
+    expect(migration).toContain('p_local_start_date        date')
+    expect(migration).toContain('v_start_date := p_local_start_date')
+    expect(migration).toContain("WHEN v_freq = 'weekly' THEN COALESCE")
+    expect(migration).toContain('ARRAY[EXTRACT(DOW FROM v_start_date)::int]')
+  })
+
+  it('새 종료일이 시작일보다 빠르면 기존 future를 취소하지 않고 실패한다', () => {
+    const migration = sql()
+
+    expect(migration).toContain('IF v_end_date IS NOT NULL AND v_end_date < v_start_date THEN')
+    expect(migration).toContain("RAISE EXCEPTION 'no_future_occurrences'")
+  })
+})

--- a/src/app/api/events/[id]/route.ts
+++ b/src/app/api/events/[id]/route.ts
@@ -6,6 +6,14 @@ import type { RecurrenceScope } from '@/types/recurrence'
 import { VALID_SCOPES } from '@/types/recurrence'
 import { ALLOWED_LABEL_COLORS } from '@/lib/label-colors'
 
+interface RecurrenceInput {
+  freq: 'daily' | 'weekly' | 'monthly' | 'yearly'
+  interval: number
+  daysOfWeek?: number[]
+  dayOfMonth?: number | null
+  endDate?: string | null
+}
+
 interface UpdateEventRequest {
   calendarId?: string | null
   title?: string
@@ -19,6 +27,7 @@ interface UpdateEventRequest {
   isAllDay?: boolean
   reminderMinutes?: number[]
   labelColor?: string | null
+  recurrence?: RecurrenceInput | null
   // series-only
   scope?: RecurrenceScope
   anchorOccurrenceDate?: string | null
@@ -70,15 +79,17 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
   }
 
   const requestedOccurrenceDate = body.localStartDate ?? (body.startAt ? getIsoDatePart(body.startAt) : null)
-  if (
+  const isScopedDateChange = Boolean(
     scope &&
     scope !== 'single' &&
     requestedOccurrenceDate &&
     body.anchorOccurrenceDate &&
     requestedOccurrenceDate !== body.anchorOccurrenceDate
-  ) {
+  )
+
+  if (isScopedDateChange && scope !== 'following') {
     return NextResponse.json(
-      { error: 'Changing occurrence date requires single scope' },
+      { error: 'Changing occurrence date is only supported for following scope' },
       { status: 400 }
     )
   }
@@ -87,6 +98,72 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
   if (scope) {
     const startTime = body.startTime ?? (body.startAt ? new Date(body.startAt).toISOString().slice(11, 19) : null)
     const endTime = body.endTime ?? (body.endAt ? new Date(body.endAt).toISOString().slice(11, 19) : null)
+
+    if (isScopedDateChange) {
+      const anchorOccurrenceDate = body.anchorOccurrenceDate
+      if (!body.startAt) {
+        return NextResponse.json({ error: 'startAt required for following date change' }, { status: 400 })
+      }
+      if (!anchorOccurrenceDate) {
+        return NextResponse.json({ error: 'anchorOccurrenceDate required for following scope' }, { status: 400 })
+      }
+      if (!body.localStartDate) {
+        return NextResponse.json({ error: 'localStartDate required for following date change' }, { status: 400 })
+      }
+
+      const { data: result, error } = await supabaseAdmin.rpc('split_recurring_series_following_authorized', {
+        p_actor_user_id:          actorUserId,
+        p_event_id:               eventId,
+        p_anchor_occurrence_date: anchorOccurrenceDate,
+        p_local_start_date:       body.localStartDate,
+        p_title:                  body.title ?? null,
+        p_description:            body.description ?? null,
+        p_has_description:        'description' in body,
+        p_start_at:               body.startAt,
+        p_end_at:                 body.endAt ?? null,
+        p_has_end_at:             'endAt' in body,
+        p_is_all_day:             body.isAllDay ?? null,
+        p_calendar_id:            body.calendarId ?? null,
+        p_has_calendar_id:        'calendarId' in body,
+        p_reminder_minutes:       body.reminderMinutes ?? null,
+        p_label_color:            body.labelColor ?? null,
+        p_has_label_color:        'labelColor' in body,
+        p_freq:                   body.recurrence?.freq ?? null,
+        p_interval:               body.recurrence?.interval ?? null,
+        p_days_of_week:           body.recurrence?.daysOfWeek ?? null,
+        p_day_of_month:           body.recurrence?.dayOfMonth ?? null,
+        p_end_date:               body.recurrence?.endDate ?? null,
+      })
+
+      if (error) {
+        if (error.message === 'not_found')        return NextResponse.json({ error: 'Event not found' }, { status: 404 })
+        if (error.message === 'not_series_event') return NextResponse.json({ error: 'Not a series event' }, { status: 400 })
+        if (error.message === 'anchor_required')  return NextResponse.json({ error: 'anchorOccurrenceDate required for following scope' }, { status: 400 })
+        if (error.message === 'local_start_date_required') return NextResponse.json({ error: 'localStartDate required for following date change' }, { status: 400 })
+        if (error.message === 'start_at_required') return NextResponse.json({ error: 'startAt required for following date change' }, { status: 400 })
+        if (error.message === 'invalid_start_date') return NextResponse.json({ error: 'startAt must be on or after anchorOccurrenceDate' }, { status: 400 })
+        if (error.message === 'invalid_interval') return NextResponse.json({ error: 'Invalid recurrence interval' }, { status: 400 })
+        if (error.message === 'invalid_frequency') return NextResponse.json({ error: 'Invalid recurrence frequency' }, { status: 400 })
+        if (error.message === 'no_future_occurrences') return NextResponse.json({ error: 'No future occurrences would be created' }, { status: 400 })
+        if (error.message === 'forbidden')        return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+        return NextResponse.json({ error: 'Failed to split recurring event' }, { status: 500 })
+      }
+
+      const { is_changed, family_id, new_calendar_id, new_title, new_start_at } = result as UpdateResult
+      if (is_changed) {
+        after(async () => {
+          await sendEventNotification({
+            familyId: family_id,
+            calendarId: new_calendar_id,
+            actorUserId,
+            action: 'updated',
+            eventTitle: new_title,
+            eventStartAt: new_start_at,
+          })
+        })
+      }
+      return new NextResponse(null, { status: 204 })
+    }
 
     const { data: result, error } = await supabaseAdmin.rpc('update_series_authorized', {
       p_actor_user_id:          actorUserId,

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -797,6 +797,32 @@ export type Database = {
         }
         Returns: Json
       }
+      split_recurring_series_following_authorized: {
+        Args: {
+          p_actor_user_id: string
+          p_event_id: string
+          p_anchor_occurrence_date: string
+          p_local_start_date: string
+          p_title: string | null
+          p_description: string | null
+          p_has_description: boolean
+          p_start_at: string
+          p_end_at: string | null
+          p_has_end_at: boolean
+          p_is_all_day: boolean | null
+          p_calendar_id: string | null
+          p_has_calendar_id: boolean
+          p_reminder_minutes: number[] | null
+          p_label_color?: string | null
+          p_has_label_color?: boolean
+          p_freq?: string | null
+          p_interval?: number | null
+          p_days_of_week?: number[] | null
+          p_day_of_month?: number | null
+          p_end_date?: string | null
+        }
+        Returns: Json
+      }
       update_series_authorized: {
         Args: {
           p_actor_user_id: string

--- a/supabase/migrations/20260505001000_split_recurring_series_following.sql
+++ b/supabase/migrations/20260505001000_split_recurring_series_following.sql
@@ -1,0 +1,260 @@
+-- Support recurrence pattern changes for following-scoped edits by splitting
+-- the future range into a new recurrence series.
+
+CREATE OR REPLACE FUNCTION split_recurring_series_following_authorized(
+  p_actor_user_id          uuid,
+  p_event_id               uuid,
+  p_anchor_occurrence_date date,
+  p_local_start_date        date,
+  p_title                  text,
+  p_description            text,
+  p_has_description        boolean,
+  p_start_at               timestamptz,
+  p_end_at                 timestamptz,
+  p_has_end_at             boolean,
+  p_is_all_day             boolean,
+  p_calendar_id            uuid,
+  p_has_calendar_id        boolean,
+  p_reminder_minutes       int[],
+  p_label_color            text DEFAULT NULL,
+  p_has_label_color        boolean DEFAULT false,
+  p_freq                   text DEFAULT NULL,
+  p_interval               int DEFAULT NULL,
+  p_days_of_week           int[] DEFAULT NULL,
+  p_day_of_month           int DEFAULT NULL,
+  p_end_date               date DEFAULT NULL
+)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_event            events%rowtype;
+  v_series           recurrence_series%rowtype;
+  v_rule             recurrence_rules%rowtype;
+  v_has_access       boolean;
+  v_new_rule_id      uuid;
+  v_new_series_id    uuid;
+  v_family_id        uuid;
+  v_calendar_id      uuid;
+  v_title            text;
+  v_description      text;
+  v_is_all_day       boolean;
+  v_start_date       date;
+  v_horizon          date;
+  v_start_time       time;
+  v_end_time         time;
+  v_reminder_minutes int[];
+  v_label_color      text;
+  v_freq             text;
+  v_interval         int;
+  v_days_of_week     int[];
+  v_day_of_month     int;
+  v_end_date         date;
+  v_current_date     date;
+  v_eff_days         int[];
+  v_dow              int;
+  v_week_start       date;
+  v_dom              int;
+  v_occ              date;
+  v_count            int := 0;
+BEGIN
+  SELECT * INTO v_event FROM events WHERE id = p_event_id;
+  IF NOT FOUND THEN RAISE EXCEPTION 'not_found'; END IF;
+  IF v_event.series_id IS NULL THEN RAISE EXCEPTION 'not_series_event'; END IF;
+
+  IF p_anchor_occurrence_date IS NULL THEN RAISE EXCEPTION 'anchor_required'; END IF;
+  IF p_local_start_date IS NULL THEN RAISE EXCEPTION 'local_start_date_required'; END IF;
+  IF p_start_at IS NULL THEN RAISE EXCEPTION 'start_at_required'; END IF;
+
+  SELECT * INTO v_series FROM recurrence_series WHERE id = v_event.series_id;
+  IF NOT FOUND OR v_series.deleted_at IS NOT NULL THEN RAISE EXCEPTION 'not_found'; END IF;
+
+  SELECT * INTO v_rule FROM recurrence_rules WHERE id = v_series.rule_id;
+  IF NOT FOUND THEN RAISE EXCEPTION 'not_found'; END IF;
+
+  IF v_event.calendar_id IS NOT NULL THEN
+    SELECT (
+      EXISTS(SELECT 1 FROM calendars WHERE id = v_event.calendar_id AND family_id = v_event.family_id)
+      AND EXISTS(SELECT 1 FROM calendar_members WHERE calendar_id = v_event.calendar_id AND user_id = p_actor_user_id)
+    ) INTO v_has_access;
+  ELSE
+    SELECT EXISTS(
+      SELECT 1 FROM family_members WHERE family_id = v_event.family_id AND user_id = p_actor_user_id
+    ) INTO v_has_access;
+  END IF;
+  IF NOT v_has_access THEN RAISE EXCEPTION 'forbidden'; END IF;
+
+  v_calendar_id := CASE WHEN p_has_calendar_id THEN p_calendar_id ELSE v_event.calendar_id END;
+
+  IF p_has_calendar_id AND p_calendar_id IS NOT NULL AND p_calendar_id IS DISTINCT FROM v_event.calendar_id THEN
+    SELECT (
+      EXISTS(SELECT 1 FROM calendars WHERE id = p_calendar_id AND family_id = v_event.family_id)
+      AND EXISTS(SELECT 1 FROM calendar_members WHERE calendar_id = p_calendar_id AND user_id = p_actor_user_id)
+    ) INTO v_has_access;
+    IF NOT v_has_access THEN RAISE EXCEPTION 'forbidden'; END IF;
+  END IF;
+
+  v_start_date := p_local_start_date;
+  IF v_start_date < p_anchor_occurrence_date THEN
+    RAISE EXCEPTION 'invalid_start_date';
+  END IF;
+
+  v_family_id := v_event.family_id;
+  v_title := COALESCE(p_title, v_event.title);
+  v_description := CASE WHEN p_has_description THEN p_description ELSE v_event.description END;
+  v_is_all_day := COALESCE(p_is_all_day, v_event.is_all_day);
+  v_reminder_minutes := COALESCE(p_reminder_minutes, v_series.reminder_minutes);
+  v_label_color := CASE WHEN p_has_label_color THEN p_label_color ELSE v_event.label_color END;
+
+  IF NOT v_is_all_day THEN
+    v_start_time := p_start_at::time;
+    v_end_time := COALESCE(
+      CASE WHEN p_has_end_at THEN p_end_at ELSE v_event.end_at END,
+      p_start_at
+    )::time;
+  END IF;
+
+  v_freq := COALESCE(p_freq, v_rule.freq);
+  v_interval := COALESCE(p_interval, v_rule.interval);
+  IF v_freq NOT IN ('daily', 'weekly', 'monthly', 'yearly') THEN RAISE EXCEPTION 'invalid_frequency'; END IF;
+  IF v_interval < 1 THEN RAISE EXCEPTION 'invalid_interval'; END IF;
+
+  v_days_of_week := CASE
+    WHEN v_freq = 'weekly' THEN COALESCE(
+      CASE WHEN p_days_of_week IS NOT NULL AND cardinality(p_days_of_week) > 0 THEN p_days_of_week END,
+      ARRAY[EXTRACT(DOW FROM v_start_date)::int]
+    )
+    ELSE COALESCE(p_days_of_week, v_rule.days_of_week)
+  END;
+
+  v_day_of_month := CASE
+    WHEN v_freq = 'monthly' THEN COALESCE(p_day_of_month, EXTRACT(DAY FROM v_start_date)::int)
+    ELSE COALESCE(p_day_of_month, v_rule.day_of_month)
+  END;
+
+  v_end_date := COALESCE(p_end_date, v_rule.end_date);
+  IF v_end_date IS NOT NULL AND v_end_date < v_start_date THEN
+    RAISE EXCEPTION 'no_future_occurrences';
+  END IF;
+
+  v_horizon := LEAST(
+    COALESCE(v_end_date, (v_start_date + INTERVAL '1 year')::date),
+    (v_start_date + INTERVAL '2 years')::date
+  );
+
+  INSERT INTO recurrence_rules (freq, interval, days_of_week, day_of_month, end_date)
+  VALUES (v_freq, v_interval, v_days_of_week, v_day_of_month, v_end_date)
+  RETURNING id INTO v_new_rule_id;
+
+  INSERT INTO recurrence_series (
+    family_id, calendar_id, title, description, is_all_day,
+    start_time, end_time, reminder_minutes, rule_id, created_by
+  ) VALUES (
+    v_family_id, v_calendar_id, v_title, v_description, v_is_all_day,
+    v_start_time, v_end_time, v_reminder_minutes, v_new_rule_id, p_actor_user_id
+  )
+  RETURNING id INTO v_new_series_id;
+
+  IF v_freq = 'daily' THEN
+    v_current_date := v_start_date;
+    WHILE v_current_date <= v_horizon LOOP
+      PERFORM insert_series_event_instance(
+        v_new_series_id, v_family_id, p_actor_user_id, v_calendar_id,
+        v_title, v_description, v_is_all_day,
+        v_start_time, v_end_time, v_current_date, v_reminder_minutes, v_label_color
+      );
+      v_count := v_count + 1;
+      v_current_date := v_current_date + (v_interval || ' days')::INTERVAL;
+    END LOOP;
+
+  ELSIF v_freq = 'weekly' THEN
+    v_eff_days := v_days_of_week;
+    v_week_start := v_start_date - EXTRACT(DOW FROM v_start_date)::int;
+    WHILE v_week_start <= v_horizon LOOP
+      FOREACH v_dow IN ARRAY v_eff_days LOOP
+        v_current_date := v_week_start + v_dow;
+        IF v_current_date >= v_start_date AND v_current_date <= v_horizon THEN
+          PERFORM insert_series_event_instance(
+            v_new_series_id, v_family_id, p_actor_user_id, v_calendar_id,
+            v_title, v_description, v_is_all_day,
+            v_start_time, v_end_time, v_current_date, v_reminder_minutes, v_label_color
+          );
+          v_count := v_count + 1;
+        END IF;
+      END LOOP;
+      v_week_start := v_week_start + (v_interval * 7 || ' days')::INTERVAL;
+    END LOOP;
+
+  ELSIF v_freq = 'monthly' THEN
+    v_dom := COALESCE(v_day_of_month, EXTRACT(DAY FROM v_start_date)::int);
+    v_current_date := v_start_date;
+    WHILE DATE_TRUNC('month', v_current_date)::date <= DATE_TRUNC('month', v_horizon)::date LOOP
+      v_occ := (DATE_TRUNC('month', v_current_date) + (v_dom - 1) * INTERVAL '1 day')::date;
+      IF EXTRACT(MONTH FROM v_occ) = EXTRACT(MONTH FROM DATE_TRUNC('month', v_current_date))
+         AND v_occ >= v_start_date AND v_occ <= v_horizon
+      THEN
+        PERFORM insert_series_event_instance(
+          v_new_series_id, v_family_id, p_actor_user_id, v_calendar_id,
+          v_title, v_description, v_is_all_day,
+          v_start_time, v_end_time, v_occ, v_reminder_minutes, v_label_color
+        );
+        v_count := v_count + 1;
+      END IF;
+      v_current_date := (DATE_TRUNC('month', v_current_date) + (v_interval || ' months')::INTERVAL)::date;
+    END LOOP;
+
+  ELSIF v_freq = 'yearly' THEN
+    v_current_date := v_start_date;
+    WHILE v_current_date <= v_horizon LOOP
+      PERFORM insert_series_event_instance(
+        v_new_series_id, v_family_id, p_actor_user_id, v_calendar_id,
+        v_title, v_description, v_is_all_day,
+        v_start_time, v_end_time, v_current_date, v_reminder_minutes, v_label_color
+      );
+      v_count := v_count + 1;
+      v_current_date := (v_current_date + (v_interval || ' years')::INTERVAL)::date;
+    END LOOP;
+  ELSE
+    RAISE EXCEPTION 'invalid_frequency';
+  END IF;
+
+  IF v_count = 0 THEN
+    RAISE EXCEPTION 'no_future_occurrences';
+  END IF;
+
+  UPDATE events SET is_cancelled = true
+  WHERE series_id = v_event.series_id
+    AND NOT is_cancelled
+    AND series_occurrence_date >= p_anchor_occurrence_date;
+
+  DELETE FROM event_reminders er
+  USING events ev
+  WHERE er.event_id = ev.id
+    AND ev.series_id = v_event.series_id
+    AND ev.series_occurrence_date >= p_anchor_occurrence_date;
+
+  UPDATE recurrence_rules
+  SET end_date = p_anchor_occurrence_date - 1
+  WHERE id = v_series.rule_id
+    AND (end_date IS NULL OR end_date > p_anchor_occurrence_date - 1);
+
+  RETURN json_build_object(
+    'is_changed',      true,
+    'family_id',       v_family_id,
+    'series_id',       v_new_series_id,
+    'old_series_id',   v_event.series_id,
+    'scope',           'following',
+    'event_count',     v_count,
+    'new_calendar_id', v_calendar_id,
+    'new_title',       v_title,
+    'new_start_at',    p_start_at
+  );
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION split_recurring_series_following_authorized(
+  uuid, uuid, date, date, text, text, boolean, timestamptz, timestamptz, boolean,
+  boolean, uuid, boolean, int[], text, boolean, text, int, int[], int, date
+) FROM public, anon, authenticated;


### PR DESCRIPTION
## Summary

- Add a new `split_recurring_series_following_authorized` RPC for following-scoped recurrence date changes.
- Route following date-change PATCH requests to the split RPC while keeping `all` date changes rejected.
- Keep the UI locked for scoped recurrence date changes; this PR only adds DB/API groundwork.
- Add DB contract types and tests for the new split path.

## Testing

- `npm run test -- --runTestsByPath src/__tests__/api/events/recurring.test.ts src/__tests__/lib/recurrence-following-split-sql.test.ts`
- `npx tsc --noEmit`
- `npm run lint` (passes with existing warnings)
- `npm run test`

Refs #116
