### PR TITLE
feat: enable following recurrence date edits

### DIFF
--- a/src/__tests__/components/CalendarTab.test.tsx
+++ b/src/__tests__/components/CalendarTab.test.tsx
@@ -2,7 +2,7 @@ import { render, act, fireEvent, screen, waitFor } from '@testing-library/react'
 import type { User } from '@supabase/supabase-js'
 import { CalendarTab } from '@/components/tabs/CalendarTab'
 import { getCalendarMembers, getEventsByMonth, getFamilyMembers, setCalendarMembers, updateCalendar } from '@/lib/calendar'
-import { deleteWithAuth } from '@/lib/api-client'
+import { deleteWithAuth, patchJsonWithAuth } from '@/lib/api-client'
 
 // ── 의존성 모킹 ──────────────────────────────────────────────
 const mockReloadCalendars = jest.fn()
@@ -105,8 +105,11 @@ jest.mock('@/components/calendar/DayEventsSheet', () => ({
   ),
 }))
 jest.mock('@/components/calendar/EventDetailSheet', () => ({
-  EventDetailSheet: ({ onDelete, onClose }: { onDelete: () => Promise<void>; onClose: () => void }) => (
+  EventDetailSheet: ({ onEdit, onDelete, onClose }: { onEdit: () => void; onDelete: () => Promise<void>; onClose: () => void }) => (
     <div data-testid="event-detail-sheet">
+      <button data-testid="detail-edit" onClick={onEdit}>
+        edit
+      </button>
       <button
         data-testid="detail-delete"
         onClick={async () => {
@@ -120,7 +123,40 @@ jest.mock('@/components/calendar/EventDetailSheet', () => ({
   ),
 }))
 jest.mock('@/components/calendar/EventFormModal', () => ({
-  EventFormModal: () => <div />,
+  EventFormModal: ({ onSave }: {
+    onSave: (params: {
+      calendarId: string | null
+      title: string
+      description: string | null
+      startAt: string
+      endAt: string | null
+      localStartDate: string
+      localEndDate: string
+      isAllDay: boolean
+      reminderMinutes: number[]
+      recurrence: null
+      labelColor: string | null
+    }) => Promise<void>
+  }) => (
+    <button
+      data-testid="event-form-save-following-date"
+      onClick={() => onSave({
+        calendarId: 'cal-1',
+        title: '반복 일정 수정',
+        description: null,
+        startAt: '2026-04-18T09:00:00.000Z',
+        endAt: '2026-04-18T10:00:00.000Z',
+        localStartDate: '2026-04-18',
+        localEndDate: '2026-04-18',
+        isAllDay: false,
+        reminderMinutes: [],
+        recurrence: null,
+        labelColor: null,
+      })}
+    >
+      save following date
+    </button>
+  ),
 }))
 jest.mock('@/components/calendar/CalendarFormModal', () => ({
   CalendarFormModal: () => <div />,
@@ -143,6 +179,7 @@ jest.mock('@/components/calendar/CalendarListSheet', () => ({
 jest.mock('@/components/calendar/RecurrenceScopeSheet', () => ({
   RecurrenceScopeSheet: ({ onSelect }: { onSelect: (scope: 'single' | 'following' | 'all') => void }) => (
     <div data-testid="recurrence-scope-sheet">
+      <button data-testid="scope-following" onClick={() => onSelect('following')}>following</button>
       <button data-testid="scope-all" onClick={() => onSelect('all')}>all</button>
     </div>
   ),
@@ -177,6 +214,7 @@ const mockGetCalendarMembers = getCalendarMembers as jest.MockedFunction<typeof 
 const mockSetCalendarMembers = setCalendarMembers as jest.MockedFunction<typeof setCalendarMembers>
 const mockUpdateCalendar = updateCalendar as jest.MockedFunction<typeof updateCalendar>
 const mockDeleteWithAuth = deleteWithAuth as jest.MockedFunction<typeof deleteWithAuth>
+const mockPatchJsonWithAuth = patchJsonWithAuth as jest.MockedFunction<typeof patchJsonWithAuth>
 let consoleErrorSpy: jest.SpyInstance
 const mockCalendars = [{
   id: 'cal-1',
@@ -214,6 +252,7 @@ describe('CalendarTab — touch-action 스크롤 차단', () => {
     mockGetFamilyMembers.mockResolvedValue([])
     mockGetCalendarMembers.mockResolvedValue([])
     mockDeleteWithAuth.mockResolvedValue(undefined)
+    mockPatchJsonWithAuth.mockResolvedValue(undefined)
   })
 
   it('가족 단위 채널명을 사용하고 연/월을 포함하지 않는다', async () => {
@@ -451,6 +490,31 @@ describe('CalendarTab — touch-action 스크롤 차단', () => {
     await waitFor(() => {
       expect(mockDeleteWithAuth).toHaveBeenCalledWith(
         '/api/events/evt-series-1?scope=all&anchorOccurrenceDate=2026-04-17'
+      )
+    })
+  })
+
+  it('반복 일정 following 날짜 변경은 startAt과 localStartDate를 함께 PATCH한다', async () => {
+    render(<CalendarTab {...defaultProps} />)
+    await act(async () => {})
+
+    fireEvent.click(screen.getByTestId('select-date'))
+    fireEvent.click(screen.getByTestId('select-recurring-event'))
+    fireEvent.click(screen.getByTestId('detail-edit'))
+    fireEvent.click(await screen.findByTestId('scope-following'))
+    fireEvent.click(await screen.findByTestId('event-form-save-following-date'))
+
+    await waitFor(() => {
+      expect(mockPatchJsonWithAuth).toHaveBeenCalledWith(
+        '/api/events/evt-series-1',
+        expect.objectContaining({
+          scope: 'following',
+          anchorOccurrenceDate: '2026-04-17',
+          startAt: '2026-04-18T09:00:00.000Z',
+          endAt: '2026-04-18T10:00:00.000Z',
+          localStartDate: '2026-04-18',
+          localEndDate: '2026-04-18',
+        })
       )
     })
   })

--- a/src/__tests__/components/EventFormModal.test.tsx
+++ b/src/__tests__/components/EventFormModal.test.tsx
@@ -373,7 +373,7 @@ describe('EventFormModal', () => {
     expect(screen.queryByTestId('time-wheel-picker')).not.toBeInTheDocument()
   })
 
-  it('반복 일정 이후/전체 편집에서는 날짜 input이 비활성화된다', () => {
+  it('반복 일정 following 편집에서는 시작 날짜만 anchor 이후로 수정할 수 있다', async () => {
     const initial = {
       id: 'evt-1',
       family_id: 'fam-1',
@@ -395,9 +395,84 @@ describe('EventFormModal', () => {
     render(<EventFormModal {...defaultProps} initial={initial} recurrenceScope="following" />)
 
     const dateInputs = document.querySelectorAll('input[type="date"]')
+    expect((dateInputs[0] as HTMLInputElement).disabled).toBe(false)
+    expect((dateInputs[0] as HTMLInputElement).min).toBe('2026-03-31')
+    expect((dateInputs[1] as HTMLInputElement).disabled).toBe(true)
+
+    fireEvent.change(dateInputs[0] as HTMLInputElement, { target: { value: '2026-04-01' } })
+    expect((dateInputs[1] as HTMLInputElement).value).toBe('2026-04-01')
+    fireEvent.change(screen.getByPlaceholderText('제목'), { target: { value: '반복 일정 수정' } })
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('저장'))
+    })
+
+    expect(defaultProps.onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        localStartDate: '2026-04-01',
+        localEndDate: '2026-04-01',
+      })
+    )
+  })
+
+  it('반복 일정 following 편집에서 anchor 이전 시작 날짜 저장을 막는다', async () => {
+    const initial = {
+      id: 'evt-1',
+      family_id: 'fam-1',
+      calendar_id: 'cal-1',
+      created_by: 'user-1',
+      title: '반복 일정',
+      description: null,
+      start_at: '2026-03-31T09:00:00.000Z',
+      end_at: '2026-03-31T10:00:00.000Z',
+      is_all_day: false,
+      is_cancelled: false,
+      label_color: null,
+      series_id: 'series-1',
+      series_occurrence_date: '2026-03-31',
+      created_at: '',
+      updated_at: '',
+    }
+
+    render(<EventFormModal {...defaultProps} initial={initial} recurrenceScope="following" />)
+
+    const dateInputs = document.querySelectorAll('input[type="date"]')
+    fireEvent.change(dateInputs[0] as HTMLInputElement, { target: { value: '2026-03-30' } })
+    fireEvent.change(screen.getByPlaceholderText('제목'), { target: { value: '반복 일정 수정' } })
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('저장'))
+    })
+
+    expect(defaultProps.onSave).not.toHaveBeenCalled()
+    expect(screen.getByText('이후 일정은 선택한 일정 날짜 이후로만 이동할 수 있어요.')).toBeInTheDocument()
+  })
+
+  it('반복 일정 전체 편집에서는 날짜 input이 비활성화된다', () => {
+    const initial = {
+      id: 'evt-1',
+      family_id: 'fam-1',
+      calendar_id: 'cal-1',
+      created_by: 'user-1',
+      title: '반복 일정',
+      description: null,
+      start_at: '2026-03-31T09:00:00.000Z',
+      end_at: '2026-03-31T10:00:00.000Z',
+      is_all_day: false,
+      is_cancelled: false,
+      label_color: null,
+      series_id: 'series-1',
+      series_occurrence_date: '2026-03-31',
+      created_at: '',
+      updated_at: '',
+    }
+
+    render(<EventFormModal {...defaultProps} initial={initial} recurrenceScope="all" />)
+
+    const dateInputs = document.querySelectorAll('input[type="date"]')
     expect((dateInputs[0] as HTMLInputElement).disabled).toBe(true)
     expect((dateInputs[1] as HTMLInputElement).disabled).toBe(true)
-    expect(screen.getByText('이 범위에서는 날짜 이동 없이 시간과 내용만 변경할 수 있어요.')).toBeInTheDocument()
+    expect(screen.getByText('전체 반복 일정은 날짜 이동 없이 시간과 내용만 변경할 수 있어요.')).toBeInTheDocument()
   })
 
   it('사용자화 반복 간격을 수정해 저장할 수 있다', async () => {

--- a/src/__tests__/components/RecurrenceCustomModal.test.tsx
+++ b/src/__tests__/components/RecurrenceCustomModal.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen, fireEvent, createEvent } from '@testing-library/react'
+import { RecurrenceCustomModal } from '@/components/calendar/RecurrenceCustomModal'
+
+const defaultProps = {
+  initial: { freq: 'weekly' as const, interval: 1, daysOfWeek: [6], endDate: '2026-08-22' },
+  startDate: '2026-05-22',
+  onSave: jest.fn(),
+  onBack: jest.fn(),
+}
+
+describe('RecurrenceCustomModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('보이는 종료일 행 클릭 시 데스크톱 날짜 picker를 연다', () => {
+    render(<RecurrenceCustomModal {...defaultProps} />)
+
+    const endDateInput = screen.getByLabelText('반복 종료일') as HTMLInputElement
+    const showPicker = jest.fn()
+    Object.defineProperty(endDateInput, 'showPicker', { value: showPicker, configurable: true })
+
+    fireEvent.click(screen.getByTestId('recurrence-end-date-button'))
+
+    expect(showPicker).toHaveBeenCalledTimes(1)
+  })
+
+  it('showPicker()가 없는 브라우저에서는 native 날짜 input 기본 동작을 막지 않는다', () => {
+    render(<RecurrenceCustomModal {...defaultProps} />)
+
+    const endDateInput = screen.getByLabelText('반복 종료일') as HTMLInputElement
+    Object.defineProperty(endDateInput, 'showPicker', { value: undefined, configurable: true })
+
+    const click = createEvent.click(screen.getByTestId('recurrence-end-date-button'))
+    const preventDefault = jest.spyOn(click, 'preventDefault')
+    fireEvent(screen.getByTestId('recurrence-end-date-button'), click)
+
+    expect(preventDefault).not.toHaveBeenCalled()
+  })
+
+  it('반복 종료일은 시작일 이후의 가까운 날짜를 선택할 수 있다', () => {
+    render(
+      <RecurrenceCustomModal
+        {...defaultProps}
+        startDate="2026-05-23"
+        initial={{ freq: 'weekly', interval: 1, daysOfWeek: [6], endDate: '2026-05-30' }}
+      />
+    )
+
+    const endDateInput = screen.getByLabelText('반복 종료일') as HTMLInputElement
+    expect(endDateInput.min).toBe('2026-05-23')
+    expect(endDateInput.value).toBe('2026-05-30')
+  })
+})

--- a/src/components/calendar/EventFormModal.tsx
+++ b/src/components/calendar/EventFormModal.tsx
@@ -114,14 +114,20 @@ export function EventFormModal({
   const [labelPickerOpen, setLabelPickerOpen] = useState(false)
   const [saving, setSaving] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
+  const [dateError, setDateError] = useState<string | null>(null)
 
   // Recurrence state (only for new events — editing uses scope sheet in parent)
   const isNewEvent = !initial
   const [recurrence, setRecurrence] = useState<RecurrenceRule | null>(null)
   const [customRule, setCustomRule] = useState<RecurrenceRule | null>(null)
   const [recurrenceModal, setRecurrenceModal] = useState<'picker' | 'custom' | null>(null)
-  const isScopedRecurringEdit = Boolean(initial?.series_id && recurrenceScope && recurrenceScope !== 'single')
-  const canEditOccurrenceDate = !isScopedRecurringEdit
+  const followingAnchorDate = initial?.series_id && recurrenceScope === 'following'
+    ? initial.series_occurrence_date
+    : null
+  const isFollowingSeriesEdit = Boolean(followingAnchorDate)
+  const isAllSeriesEdit = Boolean(initial?.series_id && recurrenceScope === 'all')
+  const canEditStartDate = !isAllSeriesEdit
+  const canEditEndDate = !isAllSeriesEdit && !isFollowingSeriesEdit
 
   const titleInputRef = useRef<HTMLInputElement>(null)
   const startDateInputRef = useRef<HTMLInputElement>(null)
@@ -196,11 +202,22 @@ export function EventFormModal({
   }
 
   const handleStartDateChange = (value: string) => {
+    if (followingAnchorDate && value < followingAnchorDate) {
+      setDateError('이후 일정은 선택한 일정 날짜 이후로만 이동할 수 있어요.')
+      return
+    }
+
+    setDateError(null)
     setStartDate(value)
+    if (isFollowingSeriesEdit) {
+      setEndDate(value)
+      return
+    }
     keepEndAtOrAfterStart(value, startTime)
   }
 
   const handleEndDateChange = (value: string) => {
+    if (!canEditEndDate) return
     if (keepEndAtOrAfterStart(startDate, startTime, value)) {
       setEndDate(value)
     }
@@ -230,6 +247,11 @@ export function EventFormModal({
 
   const handleSave = async () => {
     if (!title.trim() || !startDate) return
+    if (dateError) return
+    if (followingAnchorDate && startDate < followingAnchorDate) {
+      setDateError('이후 일정은 선택한 일정 날짜 이후로만 이동할 수 있어요.')
+      return
+    }
 
     const startAt = isAllDay ? buildAllDayISO(startDate) : buildISO(startDate, startTime)
     const endAt = isAllDay ? buildAllDayISO(endDate) : buildISO(endDate, endTime)
@@ -295,7 +317,7 @@ export function EventFormModal({
         </button>
         <button
           onClick={handleSave}
-          disabled={!title.trim() || !startDate || saving}
+          disabled={!title.trim() || !startDate || saving || Boolean(dateError)}
           className="rounded-full border border-stone-200 bg-stone-50 px-7 py-2 text-sm font-bold text-stone-800 transition-colors hover:bg-stone-100 disabled:opacity-40 dark:border-stone-800 dark:bg-stone-950 dark:text-stone-100 dark:hover:bg-stone-900 sm:px-8 sm:py-2.5"
         >
           저장
@@ -315,8 +337,8 @@ export function EventFormModal({
           />
         </div>
 
-        {saveError && (
-          <p className="mx-6 mb-3 rounded-2xl bg-red-50 px-4 py-3 text-sm text-red-500 dark:bg-red-950/30 dark:text-red-300">{saveError}</p>
+        {(dateError ?? saveError) && (
+          <p className="mx-6 mb-3 rounded-2xl bg-red-50 px-4 py-3 text-sm text-red-500 dark:bg-red-950/30 dark:text-red-300">{dateError ?? saveError}</p>
         )}
 
         <div className="border-y border-stone-200/70 dark:border-stone-900">
@@ -377,9 +399,9 @@ export function EventFormModal({
           <div className="grid grid-cols-[3.25rem_1fr] border-b border-stone-200/70 dark:border-stone-900 sm:grid-cols-[4.5rem_1fr]">
             <div />
             <div className="py-3 pr-4 sm:py-5 sm:pr-5">
-              {isScopedRecurringEdit && (
+              {isAllSeriesEdit && (
                 <p className="mb-3 rounded-2xl bg-stone-100 px-4 py-3 text-sm text-stone-500 dark:bg-stone-900 dark:text-stone-400">
-                  이 범위에서는 날짜 이동 없이 시간과 내용만 변경할 수 있어요.
+                  전체 반복 일정은 날짜 이동 없이 시간과 내용만 변경할 수 있어요.
                 </p>
               )}
 
@@ -396,10 +418,11 @@ export function EventFormModal({
                       ref={startDateInputRef}
                       type="date"
                       value={startDate}
-                      disabled={!canEditOccurrenceDate}
+                      min={followingAnchorDate ?? undefined}
+                      disabled={!canEditStartDate}
                       aria-label={`시작 날짜 ${formatDateWithDOW(startDate)}`}
                       onChange={(e) => handleStartDateChange(e.target.value)}
-                      className={`absolute inset-0 h-full w-full opacity-0 ${canEditOccurrenceDate ? 'cursor-pointer' : 'cursor-default'}`}
+                      className={`absolute inset-0 h-full w-full opacity-0 ${canEditStartDate ? 'cursor-pointer' : 'cursor-default'}`}
                     />
                   </label>
                   {!isAllDay && (
@@ -434,10 +457,11 @@ export function EventFormModal({
                       ref={endDateInputRef}
                       type="date"
                       value={endDate}
-                      disabled={!canEditOccurrenceDate}
+                      min={startDate}
+                      disabled={!canEditEndDate}
                       aria-label={`종료 날짜 ${formatDateWithDOW(endDate)}`}
                       onChange={(e) => handleEndDateChange(e.target.value)}
-                      className={`absolute inset-0 h-full w-full opacity-0 ${canEditOccurrenceDate ? 'cursor-pointer' : 'cursor-default'}`}
+                      className={`absolute inset-0 h-full w-full opacity-0 ${canEditEndDate ? 'cursor-pointer' : 'cursor-default'}`}
                     />
                   </label>
                   {!isAllDay && (

--- a/src/components/calendar/RecurrenceCustomModal.tsx
+++ b/src/components/calendar/RecurrenceCustomModal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useRef, useState, type MouseEvent } from 'react'
 import { ChevronLeft } from 'lucide-react'
 import type { RecurrenceFreq, RecurrenceRule } from '@/types/recurrence'
 import { buildRecurrenceLabel, DOW_KR, getRecurrenceIntervalUnit } from '@/types/recurrence'
@@ -54,6 +54,7 @@ export function RecurrenceCustomModal({ initial, startDate, onSave, onBack }: Pr
     initial?.endDate ?? addMonths(startDate, 3)
   )
   const [showFreqPicker, setShowFreqPicker] = useState(false)
+  const endDateInputRef = useRef<HTMLInputElement>(null)
 
   const currentRule: RecurrenceRule = {
     freq,
@@ -88,6 +89,18 @@ export function RecurrenceCustomModal({ initial, startDate, onSave, onBack }: Pr
       return
     }
     setInterval(parsed)
+  }
+
+  const openDatePicker = (input: HTMLInputElement) => {
+    input.focus({ preventScroll: true })
+    input.showPicker()
+  }
+
+  const handleEndDateButtonClick = (event: MouseEvent<HTMLLabelElement>) => {
+    const input = endDateInputRef.current
+    if (!input || typeof input.showPicker !== 'function') return
+    event.preventDefault()
+    openDatePicker(input)
   }
 
   return (
@@ -201,18 +214,24 @@ export function RecurrenceCustomModal({ initial, startDate, onSave, onBack }: Pr
             </div>
             {hasEndDate && (
               <div className="border-t border-stone-100 dark:border-stone-700">
-                <div className="relative px-4 py-3.5 flex items-center justify-between">
+                <label
+                  data-testid="recurrence-end-date-button"
+                  onClick={handleEndDateButtonClick}
+                  className="relative flex cursor-pointer items-center justify-between px-4 py-3.5"
+                >
                   <span className="text-sm text-stone-700 dark:text-stone-300">종료일</span>
                   <span className="text-sm text-stone-500 dark:text-stone-400">{endDate}</span>
                   <input
+                    ref={endDateInputRef}
                     type="date"
                     value={endDate}
-                    min={addMonths(startDate, 1)}
+                    min={startDate}
                     max={addYears(startDate, 2)}
+                    aria-label="반복 종료일"
                     onChange={(e) => setEndDate(e.target.value)}
                     className="absolute inset-0 opacity-0 w-full h-full cursor-pointer"
                   />
-                </div>
+                </label>
               </div>
             )}
           </div>

--- a/src/components/tabs/CalendarTab.tsx
+++ b/src/components/tabs/CalendarTab.tsx
@@ -82,6 +82,12 @@ function getAdjacentMonth(year: number, month: number, delta: -1 | 1) {
     : { year, month: month + 1 }
 }
 
+function getLocalTimePart(isoString: string): string {
+  const date = new Date(isoString)
+  const pad = (value: number) => String(value).padStart(2, '0')
+  return `${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`
+}
+
 export function CalendarTab({
   preferences,
   updatePreferences,
@@ -582,21 +588,27 @@ export function CalendarTab({
         const prevLabelColor = editingEvent.event.label_color ?? null
         const scope = (editingEvent.event as CalendarEvent & { _seriesScope?: RecurrenceScope })._seriesScope ?? params.scope ?? 'single'
         const isScopedSeriesEdit = Boolean(editingEvent.event.series_id && scope !== 'single')
+        const isFollowingDateChange = Boolean(
+          isScopedSeriesEdit &&
+          scope === 'following' &&
+          editingEvent.event.series_occurrence_date &&
+          params.localStartDate !== editingEvent.event.series_occurrence_date
+        )
         await Promise.all([
           patchJsonWithAuth(`/api/events/${editingEvent.event.id}`, {
             calendarId: params.calendarId,
             title: params.title,
             description: params.description,
-            startAt: isScopedSeriesEdit ? undefined : params.startAt,
-            endAt: isScopedSeriesEdit ? undefined : params.endAt,
+            startAt: isScopedSeriesEdit && !isFollowingDateChange ? undefined : params.startAt,
+            endAt: isScopedSeriesEdit && !isFollowingDateChange ? undefined : params.endAt,
             localStartDate: params.localStartDate,
             localEndDate: params.localEndDate,
             isAllDay: params.isAllDay,
             reminderMinutes: params.reminderMinutes,
             labelColor: params.labelColor,
             ...(isScopedSeriesEdit && !params.isAllDay ? {
-              startTime: new Date(params.startAt).toISOString().slice(11, 19),
-              endTime: params.endAt ? new Date(params.endAt).toISOString().slice(11, 19) : null,
+              startTime: getLocalTimePart(params.startAt),
+              endTime: params.endAt ? getLocalTimePart(params.endAt) : null,
             } : {}),
             ...(editingEvent.event.series_id ? {
               scope,


### PR DESCRIPTION
## Summary
- 반복 일정 `following` 편집에서는 날짜 입력을 다시 허용하고, `all` 편집에서는 날짜 이동을 계속 잠급니다.
- `following` 날짜 변경 저장 시 API가 split RPC 경로를 탈 수 있도록 `startAt`/`endAt`과 `localStartDate`를 함께 보냅니다.
- 반복 일정 범위 편집의 시간 변경 payload는 ISO UTC slice가 아니라 브라우저 로컬 시간 기준으로 보냅니다.
- 반복 사용자화 화면의 종료일 행을 안정적으로 클릭할 수 있도록 date picker 트리거를 보강했습니다.
- 반복 종료일의 최소 선택 가능 날짜를 시작일로 낮춰 단기 반복 종료를 허용합니다.
- following 날짜 편집 UI와 CalendarTab API payload 회귀 테스트를 추가했습니다.

Refs #116

## Testing
- `npm run test -- --runTestsByPath src/__tests__/components/RecurrenceCustomModal.test.tsx src/__tests__/components/EventFormModal.test.tsx src/__tests__/components/CalendarTab.test.tsx`
- `npx tsc --noEmit`
- `npm run lint` (이번 변경과 무관한 기존 warning 5개만 남아 있습니다)

Manual:
- [x] 반복 일정 하나를 선택해 `이 일정 및 이후 일정`으로 수정할 때, 시작 날짜가 선택한 일정 날짜보다 이전으로 내려가지 않는지 확인합니다.
- [x] 같은 화면에서 시작 날짜를 이후 날짜로 바꾸면 종료 날짜 표시도 같은 날짜로 따라가는지 확인합니다.
- [x] `이 일정 및 이후 일정` 저장 후 선택한 일정 이전 occurrence는 그대로이고, 선택한 일정 및 이후 occurrence만 새 날짜 패턴으로 보이는지 확인합니다.
- [x] `전체 반복 일정` 수정에서는 날짜 입력이 계속 잠겨 있는지 확인합니다.
- [x] 새 반복 일정 생성의 사용자화 화면에서 `종료일 설정`을 켠 뒤 `종료일` 행을 눌러 날짜 선택기가 열리는지 확인합니다.
- [x] 5월 23일 시작 반복 일정에서 종료일을 5월 30일처럼 가까운 날짜로 선택할 수 있는지 확인합니다.
