### PR TITLE
feat: enable following recurrence rule edits

### DIFF
--- a/src/__tests__/api/events/recurring.test.ts
+++ b/src/__tests__/api/events/recurring.test.ts
@@ -354,10 +354,88 @@ describe('PATCH /api/events/[id] (series scope)', () => {
         p_freq: 'weekly',
         p_interval: 1,
         p_days_of_week: [6],
+        p_should_update_end_date: true,
       })
     )
     expect(mockSendEventNotification).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'updated', eventStartAt: '2026-04-18T09:00:00.000Z' })
+    )
+  })
+
+  it('following scope에서 반복 규칙 변경을 요청하면 split_recurring_series_following_authorized를 호출한다', async () => {
+    mockRpc.mockResolvedValue({
+      data: {
+        is_changed: true,
+        family_id: FAMILY_ID,
+        new_calendar_id: null,
+        new_title: '회의',
+        new_start_at: '2026-04-17T09:00:00.000Z',
+        series_id: 'series-2',
+        old_series_id: SERIES_ID,
+      },
+      error: null,
+    })
+    const body = {
+      title: '회의',
+      scope: 'following',
+      anchorOccurrenceDate: '2026-04-17',
+      localStartDate: '2026-04-17',
+      startAt: '2026-04-17T09:00:00.000Z',
+      endAt: '2026-04-17T10:00:00.000Z',
+      recurrence: { freq: 'weekly', interval: 2, daysOfWeek: [5], endDate: '2026-06-12' },
+    }
+    const res = await PATCH(
+      makeRequest('PATCH', `http://localhost/api/events/${EVENT_ID}`, body),
+      makeParams(EVENT_ID)
+    )
+    expect(res.status).toBe(204)
+    expect(mockRpc).toHaveBeenCalledWith(
+      'split_recurring_series_following_authorized',
+      expect.objectContaining({
+        p_anchor_occurrence_date: '2026-04-17',
+        p_local_start_date: '2026-04-17',
+        p_start_at: '2026-04-17T09:00:00.000Z',
+        p_freq: 'weekly',
+        p_interval: 2,
+        p_days_of_week: [5],
+        p_end_date: '2026-06-12',
+        p_should_update_end_date: true,
+      })
+    )
+  })
+
+  it('following scope에서 반복 종료일 제거를 요청하면 end date update flag와 null을 전달한다', async () => {
+    mockRpc.mockResolvedValue({
+      data: {
+        is_changed: true,
+        family_id: FAMILY_ID,
+        new_calendar_id: null,
+        new_title: '회의',
+        new_start_at: '2026-04-17T09:00:00.000Z',
+        series_id: 'series-2',
+        old_series_id: SERIES_ID,
+      },
+      error: null,
+    })
+    const body = {
+      title: '회의',
+      scope: 'following',
+      anchorOccurrenceDate: '2026-04-17',
+      localStartDate: '2026-04-17',
+      startAt: '2026-04-17T09:00:00.000Z',
+      recurrence: { freq: 'weekly', interval: 1, daysOfWeek: [5] },
+    }
+    const res = await PATCH(
+      makeRequest('PATCH', `http://localhost/api/events/${EVENT_ID}`, body),
+      makeParams(EVENT_ID)
+    )
+    expect(res.status).toBe(204)
+    expect(mockRpc).toHaveBeenCalledWith(
+      'split_recurring_series_following_authorized',
+      expect.objectContaining({
+        p_end_date: null,
+        p_should_update_end_date: true,
+      })
     )
   })
 

--- a/src/__tests__/components/CalendarTab.test.tsx
+++ b/src/__tests__/components/CalendarTab.test.tsx
@@ -1,7 +1,7 @@
 import { render, act, fireEvent, screen, waitFor } from '@testing-library/react'
 import type { User } from '@supabase/supabase-js'
 import { CalendarTab } from '@/components/tabs/CalendarTab'
-import { getCalendarMembers, getEventsByMonth, getFamilyMembers, setCalendarMembers, updateCalendar } from '@/lib/calendar'
+import { getCalendarMembers, getEventsByMonth, getFamilyMembers, getRecurrenceRule, setCalendarMembers, updateCalendar } from '@/lib/calendar'
 import { deleteWithAuth, patchJsonWithAuth } from '@/lib/api-client'
 
 // ── 의존성 모킹 ──────────────────────────────────────────────
@@ -21,6 +21,7 @@ jest.mock('@/lib/calendar', () => ({
   getCalendarMembersForCalendars: jest.fn().mockResolvedValue([]),
   setCalendarMembers: jest.fn(),
   getFamilyMembers: jest.fn().mockResolvedValue([]),
+  getRecurrenceRule: jest.fn().mockResolvedValue(null),
   createEvent: jest.fn(),
   updateEvent: jest.fn(),
   deleteEvent: jest.fn(),
@@ -123,7 +124,8 @@ jest.mock('@/components/calendar/EventDetailSheet', () => ({
   ),
 }))
 jest.mock('@/components/calendar/EventFormModal', () => ({
-  EventFormModal: ({ onSave }: {
+  EventFormModal: ({ initialRecurrence, onSave }: {
+    initialRecurrence?: import('@/types/recurrence').RecurrenceRule | null
     onSave: (params: {
       calendarId: string | null
       title: string
@@ -134,10 +136,11 @@ jest.mock('@/components/calendar/EventFormModal', () => ({
       localEndDate: string
       isAllDay: boolean
       reminderMinutes: number[]
-      recurrence: null
+      recurrence: import('@/types/recurrence').RecurrenceRule | null
       labelColor: string | null
     }) => Promise<void>
   }) => (
+    <>
     <button
       data-testid="event-form-save-following-date"
       onClick={() => onSave({
@@ -156,6 +159,26 @@ jest.mock('@/components/calendar/EventFormModal', () => ({
     >
       save following date
     </button>
+    <button
+      data-testid="event-form-save-following-recurrence"
+      data-initial-recurrence={initialRecurrence ? `${initialRecurrence.freq}:${initialRecurrence.interval}` : ''}
+      onClick={() => onSave({
+        calendarId: 'cal-1',
+        title: '반복 일정 수정',
+        description: null,
+        startAt: '2026-04-17T09:00:00.000Z',
+        endAt: '2026-04-17T10:00:00.000Z',
+        localStartDate: '2026-04-17',
+        localEndDate: '2026-04-17',
+        isAllDay: false,
+        reminderMinutes: [],
+        recurrence: { freq: 'weekly', interval: 2, daysOfWeek: [6] },
+        labelColor: null,
+      })}
+    >
+      save following recurrence
+    </button>
+    </>
   ),
 }))
 jest.mock('@/components/calendar/CalendarFormModal', () => ({
@@ -211,6 +234,7 @@ jest.mock('@/components/calendar/YearMonthPickerSheet', () => ({
 const mockGetEventsByMonth = getEventsByMonth as jest.MockedFunction<typeof getEventsByMonth>
 const mockGetFamilyMembers = getFamilyMembers as jest.MockedFunction<typeof getFamilyMembers>
 const mockGetCalendarMembers = getCalendarMembers as jest.MockedFunction<typeof getCalendarMembers>
+const mockGetRecurrenceRule = getRecurrenceRule as jest.MockedFunction<typeof getRecurrenceRule>
 const mockSetCalendarMembers = setCalendarMembers as jest.MockedFunction<typeof setCalendarMembers>
 const mockUpdateCalendar = updateCalendar as jest.MockedFunction<typeof updateCalendar>
 const mockDeleteWithAuth = deleteWithAuth as jest.MockedFunction<typeof deleteWithAuth>
@@ -251,6 +275,7 @@ describe('CalendarTab — touch-action 스크롤 차단', () => {
     mockGetEventsByMonth.mockResolvedValue([])
     mockGetFamilyMembers.mockResolvedValue([])
     mockGetCalendarMembers.mockResolvedValue([])
+    mockGetRecurrenceRule.mockResolvedValue({ freq: 'weekly', interval: 1, daysOfWeek: [5] })
     mockDeleteWithAuth.mockResolvedValue(undefined)
     mockPatchJsonWithAuth.mockResolvedValue(undefined)
   })
@@ -514,6 +539,36 @@ describe('CalendarTab — touch-action 스크롤 차단', () => {
           endAt: '2026-04-18T10:00:00.000Z',
           localStartDate: '2026-04-18',
           localEndDate: '2026-04-18',
+        })
+      )
+    })
+  })
+
+  it('반복 일정 following 규칙 변경은 기존 규칙을 로드하고 recurrence와 startAt을 함께 PATCH한다', async () => {
+    render(<CalendarTab {...defaultProps} />)
+    await act(async () => {})
+
+    fireEvent.click(screen.getByTestId('select-date'))
+    fireEvent.click(screen.getByTestId('select-recurring-event'))
+    fireEvent.click(screen.getByTestId('detail-edit'))
+    fireEvent.click(await screen.findByTestId('scope-following'))
+
+    const saveButton = await screen.findByTestId('event-form-save-following-recurrence')
+    expect(mockGetRecurrenceRule).toHaveBeenCalledWith('series-1')
+    expect(saveButton).toHaveAttribute('data-initial-recurrence', 'weekly:1')
+
+    fireEvent.click(saveButton)
+
+    await waitFor(() => {
+      expect(mockPatchJsonWithAuth).toHaveBeenCalledWith(
+        '/api/events/evt-series-1',
+        expect.objectContaining({
+          scope: 'following',
+          anchorOccurrenceDate: '2026-04-17',
+          startAt: '2026-04-17T09:00:00.000Z',
+          endAt: '2026-04-17T10:00:00.000Z',
+          localStartDate: '2026-04-17',
+          recurrence: { freq: 'weekly', interval: 2, daysOfWeek: [6] },
         })
       )
     })

--- a/src/__tests__/components/EventFormModal.test.tsx
+++ b/src/__tests__/components/EventFormModal.test.tsx
@@ -508,6 +508,60 @@ describe('EventFormModal', () => {
       })
     )
   })
+
+  it('following 반복 일정은 기존 반복 규칙을 표시하고 변경된 규칙을 저장한다', async () => {
+    const initial: import('@/lib/calendar').CalendarEvent = {
+      id: 'evt-1',
+      family_id: 'fam-1',
+      calendar_id: 'cal-1',
+      created_by: 'user-1',
+      title: '반복 일정',
+      description: null,
+      start_at: '2026-03-31T09:00:00.000Z',
+      end_at: '2026-03-31T10:00:00.000Z',
+      is_all_day: false,
+      is_cancelled: false,
+      label_color: null,
+      series_id: 'series-1',
+      series_occurrence_date: '2026-03-31',
+      created_at: '',
+      updated_at: '',
+    }
+
+    render(
+      <EventFormModal
+        {...defaultProps}
+        initial={initial}
+        recurrenceScope="following"
+        initialRecurrence={{ freq: 'weekly', interval: 1, daysOfWeek: [2] }}
+      />
+    )
+
+    expect(screen.getByText('매주 화요일')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('매주 화요일'))
+    expect(screen.queryByText('안 함')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByText('사용자화'))
+
+    const intervalInput = screen.getByLabelText('반복 간격') as HTMLInputElement
+    fireEvent.change(intervalInput, { target: { value: '2' } })
+    fireEvent.click(screen.getByText('완료'))
+
+    fireEvent.change(screen.getByPlaceholderText('제목'), { target: { value: '반복 일정 수정' } })
+    await act(async () => {
+      fireEvent.click(screen.getByText('저장'))
+    })
+
+    expect(defaultProps.onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recurrence: expect.objectContaining({
+          freq: 'weekly',
+          interval: 2,
+          daysOfWeek: [2],
+        }),
+      })
+    )
+  })
 })
 
 // ── 라벨 색상 ────────────────────────────────────────────────

--- a/src/__tests__/lib/recurrence-following-split-sql.test.ts
+++ b/src/__tests__/lib/recurrence-following-split-sql.test.ts
@@ -3,7 +3,7 @@ import path from 'path'
 
 const migrationPath = path.join(
   process.cwd(),
-  'supabase/migrations/20260505001000_split_recurring_series_following.sql'
+  'supabase/migrations/20260507001000_update_following_split_end_date_override.sql'
 )
 
 describe('split_recurring_series_following_authorized migration', () => {
@@ -46,5 +46,13 @@ describe('split_recurring_series_following_authorized migration', () => {
 
     expect(migration).toContain('IF v_end_date IS NOT NULL AND v_end_date < v_start_date THEN')
     expect(migration).toContain("RAISE EXCEPTION 'no_future_occurrences'")
+  })
+
+  it('반복 종료일 제거와 기존 종료일 유지를 명시 플래그로 구분한다', () => {
+    const migration = sql()
+
+    expect(migration).toContain('p_should_update_end_date boolean DEFAULT false')
+    expect(migration).toContain('WHEN p_should_update_end_date THEN p_end_date')
+    expect(migration).toContain('ELSE v_rule.end_date')
   })
 })

--- a/src/app/api/events/[id]/route.ts
+++ b/src/app/api/events/[id]/route.ts
@@ -86,6 +86,10 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
     body.anchorOccurrenceDate &&
     requestedOccurrenceDate !== body.anchorOccurrenceDate
   )
+  const isFollowingRecurrenceChange = Boolean(
+    scope === 'following' &&
+    body.recurrence
+  )
 
   if (isScopedDateChange && scope !== 'following') {
     return NextResponse.json(
@@ -99,16 +103,16 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
     const startTime = body.startTime ?? (body.startAt ? new Date(body.startAt).toISOString().slice(11, 19) : null)
     const endTime = body.endTime ?? (body.endAt ? new Date(body.endAt).toISOString().slice(11, 19) : null)
 
-    if (isScopedDateChange) {
+    if (isScopedDateChange || isFollowingRecurrenceChange) {
       const anchorOccurrenceDate = body.anchorOccurrenceDate
       if (!body.startAt) {
-        return NextResponse.json({ error: 'startAt required for following date change' }, { status: 400 })
+        return NextResponse.json({ error: 'startAt required for following split' }, { status: 400 })
       }
       if (!anchorOccurrenceDate) {
         return NextResponse.json({ error: 'anchorOccurrenceDate required for following scope' }, { status: 400 })
       }
       if (!body.localStartDate) {
-        return NextResponse.json({ error: 'localStartDate required for following date change' }, { status: 400 })
+        return NextResponse.json({ error: 'localStartDate required for following split' }, { status: 400 })
       }
 
       const { data: result, error } = await supabaseAdmin.rpc('split_recurring_series_following_authorized', {
@@ -133,6 +137,7 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
         p_days_of_week:           body.recurrence?.daysOfWeek ?? null,
         p_day_of_month:           body.recurrence?.dayOfMonth ?? null,
         p_end_date:               body.recurrence?.endDate ?? null,
+        p_should_update_end_date: Boolean(body.recurrence),
       })
 
       if (error) {

--- a/src/components/calendar/EventFormModal.tsx
+++ b/src/components/calendar/EventFormModal.tsx
@@ -41,10 +41,25 @@ function buildAllDayISO(date: string): string {
   return new Date(date + 'T00:00:00').toISOString()
 }
 
+function isSameRecurrenceRule(a: RecurrenceRule | null, b: RecurrenceRule | null): boolean {
+  if (a === null && b === null) return true
+  if (a === null || b === null) return false
+  const daysA = [...(a.daysOfWeek ?? [])].sort().join(',')
+  const daysB = [...(b.daysOfWeek ?? [])].sort().join(',')
+  return (
+    a.freq === b.freq &&
+    a.interval === b.interval &&
+    daysA === daysB &&
+    (a.dayOfMonth ?? null) === (b.dayOfMonth ?? null) &&
+    (a.endDate ?? null) === (b.endDate ?? null)
+  )
+}
+
 interface Props {
   initial?: CalendarEvent
   initialDate?: Date
   initialReminderMinutes?: number[]
+  initialRecurrence?: RecurrenceRule | null
   recurrenceScope?: RecurrenceScope
   defaultLabelColor?: string | null
   calendars: Calendar[]
@@ -68,6 +83,7 @@ export function EventFormModal({
   initial,
   initialDate,
   initialReminderMinutes = [],
+  initialRecurrence = null,
   recurrenceScope,
   defaultLabelColor,
   calendars,
@@ -116,15 +132,18 @@ export function EventFormModal({
   const [saveError, setSaveError] = useState<string | null>(null)
   const [dateError, setDateError] = useState<string | null>(null)
 
-  // Recurrence state (only for new events — editing uses scope sheet in parent)
   const isNewEvent = !initial
-  const [recurrence, setRecurrence] = useState<RecurrenceRule | null>(null)
-  const [customRule, setCustomRule] = useState<RecurrenceRule | null>(null)
-  const [recurrenceModal, setRecurrenceModal] = useState<'picker' | 'custom' | null>(null)
   const followingAnchorDate = initial?.series_id && recurrenceScope === 'following'
     ? initial.series_occurrence_date
     : null
   const isFollowingSeriesEdit = Boolean(followingAnchorDate)
+  const [recurrence, setRecurrence] = useState<RecurrenceRule | null>(
+    isFollowingSeriesEdit ? initialRecurrence : null
+  )
+  const [customRule, setCustomRule] = useState<RecurrenceRule | null>(
+    isFollowingSeriesEdit ? initialRecurrence : null
+  )
+  const [recurrenceModal, setRecurrenceModal] = useState<'picker' | 'custom' | null>(null)
   const isAllSeriesEdit = Boolean(initial?.series_id && recurrenceScope === 'all')
   const canEditStartDate = !isAllSeriesEdit
   const canEditEndDate = !isAllSeriesEdit && !isFollowingSeriesEdit
@@ -271,7 +290,9 @@ export function EventFormModal({
         localEndDate: endDate,
         isAllDay,
         reminderMinutes: Array.from(reminderMinutes),
-        recurrence: isNewEvent ? recurrence : null,
+        recurrence: isNewEvent || (isFollowingSeriesEdit && !isSameRecurrenceRule(recurrence, initialRecurrence))
+          ? recurrence
+          : null,
         labelColor,
       })
       onClose()
@@ -600,7 +621,7 @@ export function EventFormModal({
           </div>
 
           {/* 반복 */}
-          {isNewEvent && (
+          {(isNewEvent || isFollowingSeriesEdit) && (
             <button
               type="button"
               onClick={() => setRecurrenceModal('picker')}
@@ -626,6 +647,7 @@ export function EventFormModal({
           onSelect={(rule) => { setRecurrence(rule); setRecurrenceModal(null) }}
           onCustomize={() => setRecurrenceModal('custom')}
           onClose={() => setRecurrenceModal(null)}
+          allowNone={isNewEvent}
         />
       )}
 

--- a/src/components/calendar/RecurrencePickerSheet.tsx
+++ b/src/components/calendar/RecurrencePickerSheet.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { ChevronRight } from 'lucide-react'
-import type { RecurrenceFreq, RecurrenceRule } from '@/types/recurrence'
+import type { RecurrenceRule } from '@/types/recurrence'
 import { buildRecurrenceLabel } from '@/types/recurrence'
 
 interface Props {
@@ -10,6 +10,7 @@ interface Props {
   onCustomize: () => void
   customRule: RecurrenceRule | null
   onClose: () => void
+  allowNone?: boolean
 }
 
 const PRESETS: Array<{ label: string; rule: RecurrenceRule | null }> = [
@@ -37,8 +38,9 @@ function isCustom(rule: RecurrenceRule | null): boolean {
   return !PRESETS.some((p) => isSameRule(p.rule, rule))
 }
 
-export function RecurrencePickerSheet({ value, onSelect, onCustomize, customRule, onClose }: Props) {
+export function RecurrencePickerSheet({ value, onSelect, onCustomize, customRule, onClose, allowNone = true }: Props) {
   const showCustomCheck = isCustom(value)
+  const presets = allowNone ? PRESETS : PRESETS.filter((preset) => preset.rule !== null)
 
   return (
     <div className="fixed inset-0 z-[80] flex flex-col" onClick={onClose}>
@@ -58,7 +60,7 @@ export function RecurrencePickerSheet({ value, onSelect, onCustomize, customRule
         </div>
 
         <div className="divide-y divide-stone-100 dark:divide-stone-800 mx-4 mt-3 mb-3 rounded-xl overflow-hidden bg-stone-50 dark:bg-stone-800">
-          {PRESETS.map(({ label, rule }) => {
+          {presets.map(({ label, rule }) => {
             const checked = !isCustom(value) && isSameRule(value, rule)
             return (
               <button

--- a/src/components/tabs/CalendarTab.tsx
+++ b/src/components/tabs/CalendarTab.tsx
@@ -16,6 +16,7 @@ import {
   setCalendarMembers,
   getFamilyMembers,
   getReminders,
+  getRecurrenceRule,
   type CalendarEvent,
   type FamilyMember,
   type SaveResult,
@@ -29,7 +30,7 @@ import { EventFormModal } from '@/components/calendar/EventFormModal'
 import { CalendarFormModal } from '@/components/calendar/CalendarFormModal'
 import { YearMonthPickerSheet } from '@/components/calendar/YearMonthPickerSheet'
 import { RecurrenceScopeSheet } from '@/components/calendar/RecurrenceScopeSheet'
-import type { RecurrenceScope } from '@/types/recurrence'
+import type { RecurrenceRule, RecurrenceScope } from '@/types/recurrence'
 import { useRealtimeSync } from '@/hooks/useRealtimeSync'
 import { postJsonWithAuth, patchJsonWithAuth, deleteWithAuth } from '@/lib/api-client'
 import type { Calendar } from '@/lib/calendar'
@@ -594,18 +595,25 @@ export function CalendarTab({
           editingEvent.event.series_occurrence_date &&
           params.localStartDate !== editingEvent.event.series_occurrence_date
         )
+        const isFollowingRecurrenceChange = Boolean(
+          isScopedSeriesEdit &&
+          scope === 'following' &&
+          params.recurrence
+        )
+        const shouldSplitFollowingSeries = isFollowingDateChange || isFollowingRecurrenceChange
         await Promise.all([
           patchJsonWithAuth(`/api/events/${editingEvent.event.id}`, {
             calendarId: params.calendarId,
             title: params.title,
             description: params.description,
-            startAt: isScopedSeriesEdit && !isFollowingDateChange ? undefined : params.startAt,
-            endAt: isScopedSeriesEdit && !isFollowingDateChange ? undefined : params.endAt,
+            startAt: isScopedSeriesEdit && !shouldSplitFollowingSeries ? undefined : params.startAt,
+            endAt: isScopedSeriesEdit && !shouldSplitFollowingSeries ? undefined : params.endAt,
             localStartDate: params.localStartDate,
             localEndDate: params.localEndDate,
             isAllDay: params.isAllDay,
             reminderMinutes: params.reminderMinutes,
             labelColor: params.labelColor,
+            ...(isFollowingRecurrenceChange ? { recurrence: params.recurrence } : {}),
             ...(isScopedSeriesEdit && !params.isAllDay ? {
               startTime: getLocalTimePart(params.startAt),
               endTime: params.endAt ? getLocalTimePart(params.endAt) : null,
@@ -869,7 +877,9 @@ export function CalendarTab({
 
       {editingEvent && (
         <EventFormModalWithReminders
-          key={editingEvent.event?.id ?? 'new'}
+          key={editingEvent.event
+            ? `${editingEvent.event.id}:${(editingEvent.event as CalendarEvent & { _seriesScope?: RecurrenceScope })._seriesScope ?? 'single'}`
+            : 'new'}
           event={editingEvent.event}
           date={editingEvent.date}
           defaultLabelColor={preferences?.last_label_color ?? null}
@@ -954,6 +964,10 @@ function EventFormModalWithReminders({
 }) {
   const [reminderMinutes, setReminderMinutes] = useState<number[] | null>(event ? null : [])
   const recurrenceScope = (event as (CalendarEvent & { _seriesScope?: RecurrenceScope }) | undefined)?._seriesScope
+  const shouldLoadRecurrence = Boolean(event?.series_id && recurrenceScope === 'following')
+  const [initialRecurrence, setInitialRecurrence] = useState<RecurrenceRule | null | undefined>(
+    shouldLoadRecurrence ? undefined : null
+  )
 
   useEffect(() => {
     if (!event) return
@@ -962,13 +976,22 @@ function EventFormModalWithReminders({
       .catch(() => setReminderMinutes([]))
   }, [event])
 
-  if (reminderMinutes === null) return null
+  useEffect(() => {
+    if (!event?.series_id || recurrenceScope !== 'following') return
+
+    getRecurrenceRule(event.series_id)
+      .then((rule) => setInitialRecurrence(rule))
+      .catch(() => setInitialRecurrence(null))
+  }, [event?.series_id, recurrenceScope])
+
+  if (reminderMinutes === null || initialRecurrence === undefined) return null
 
   return (
     <EventFormModal
       initial={event}
       initialDate={date}
       initialReminderMinutes={reminderMinutes}
+      initialRecurrence={initialRecurrence}
       recurrenceScope={recurrenceScope}
       defaultLabelColor={defaultLabelColor}
       calendars={calendars}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -820,6 +820,7 @@ export type Database = {
           p_days_of_week?: number[] | null
           p_day_of_month?: number | null
           p_end_date?: string | null
+          p_should_update_end_date?: boolean
         }
         Returns: Json
       }

--- a/supabase/migrations/20260507001000_update_following_split_end_date_override.sql
+++ b/supabase/migrations/20260507001000_update_following_split_end_date_override.sql
@@ -1,0 +1,270 @@
+-- Allow following recurrence edits to explicitly clear an existing end_date.
+-- A NULL p_end_date can mean either "clear the end date" or "keep the old
+-- rule end date", so p_should_update_end_date disambiguates the two cases.
+
+DROP FUNCTION IF EXISTS split_recurring_series_following_authorized(
+  uuid, uuid, date, date, text, text, boolean, timestamptz, timestamptz, boolean,
+  boolean, uuid, boolean, int[], text, boolean, text, int, int[], int, date
+);
+
+CREATE OR REPLACE FUNCTION split_recurring_series_following_authorized(
+  p_actor_user_id          uuid,
+  p_event_id               uuid,
+  p_anchor_occurrence_date date,
+  p_local_start_date        date,
+  p_title                  text,
+  p_description            text,
+  p_has_description        boolean,
+  p_start_at               timestamptz,
+  p_end_at                 timestamptz,
+  p_has_end_at             boolean,
+  p_is_all_day             boolean,
+  p_calendar_id            uuid,
+  p_has_calendar_id        boolean,
+  p_reminder_minutes       int[],
+  p_label_color            text DEFAULT NULL,
+  p_has_label_color        boolean DEFAULT false,
+  p_freq                   text DEFAULT NULL,
+  p_interval               int DEFAULT NULL,
+  p_days_of_week           int[] DEFAULT NULL,
+  p_day_of_month           int DEFAULT NULL,
+  p_end_date               date DEFAULT NULL,
+  p_should_update_end_date boolean DEFAULT false
+)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_event            events%rowtype;
+  v_series           recurrence_series%rowtype;
+  v_rule             recurrence_rules%rowtype;
+  v_has_access       boolean;
+  v_new_rule_id      uuid;
+  v_new_series_id    uuid;
+  v_family_id        uuid;
+  v_calendar_id      uuid;
+  v_title            text;
+  v_description      text;
+  v_is_all_day       boolean;
+  v_start_date       date;
+  v_horizon          date;
+  v_start_time       time;
+  v_end_time         time;
+  v_reminder_minutes int[];
+  v_label_color      text;
+  v_freq             text;
+  v_interval         int;
+  v_days_of_week     int[];
+  v_day_of_month     int;
+  v_end_date         date;
+  v_current_date     date;
+  v_eff_days         int[];
+  v_dow              int;
+  v_week_start       date;
+  v_dom              int;
+  v_occ              date;
+  v_count            int := 0;
+BEGIN
+  SELECT * INTO v_event FROM events WHERE id = p_event_id;
+  IF NOT FOUND THEN RAISE EXCEPTION 'not_found'; END IF;
+  IF v_event.series_id IS NULL THEN RAISE EXCEPTION 'not_series_event'; END IF;
+
+  IF p_anchor_occurrence_date IS NULL THEN RAISE EXCEPTION 'anchor_required'; END IF;
+  IF p_local_start_date IS NULL THEN RAISE EXCEPTION 'local_start_date_required'; END IF;
+  IF p_start_at IS NULL THEN RAISE EXCEPTION 'start_at_required'; END IF;
+
+  SELECT * INTO v_series FROM recurrence_series WHERE id = v_event.series_id;
+  IF NOT FOUND OR v_series.deleted_at IS NOT NULL THEN RAISE EXCEPTION 'not_found'; END IF;
+
+  SELECT * INTO v_rule FROM recurrence_rules WHERE id = v_series.rule_id;
+  IF NOT FOUND THEN RAISE EXCEPTION 'not_found'; END IF;
+
+  IF v_event.calendar_id IS NOT NULL THEN
+    SELECT (
+      EXISTS(SELECT 1 FROM calendars WHERE id = v_event.calendar_id AND family_id = v_event.family_id)
+      AND EXISTS(SELECT 1 FROM calendar_members WHERE calendar_id = v_event.calendar_id AND user_id = p_actor_user_id)
+    ) INTO v_has_access;
+  ELSE
+    SELECT EXISTS(
+      SELECT 1 FROM family_members WHERE family_id = v_event.family_id AND user_id = p_actor_user_id
+    ) INTO v_has_access;
+  END IF;
+  IF NOT v_has_access THEN RAISE EXCEPTION 'forbidden'; END IF;
+
+  v_calendar_id := CASE WHEN p_has_calendar_id THEN p_calendar_id ELSE v_event.calendar_id END;
+
+  IF p_has_calendar_id AND p_calendar_id IS NOT NULL AND p_calendar_id IS DISTINCT FROM v_event.calendar_id THEN
+    SELECT (
+      EXISTS(SELECT 1 FROM calendars WHERE id = p_calendar_id AND family_id = v_event.family_id)
+      AND EXISTS(SELECT 1 FROM calendar_members WHERE calendar_id = p_calendar_id AND user_id = p_actor_user_id)
+    ) INTO v_has_access;
+    IF NOT v_has_access THEN RAISE EXCEPTION 'forbidden'; END IF;
+  END IF;
+
+  v_start_date := p_local_start_date;
+  IF v_start_date < p_anchor_occurrence_date THEN
+    RAISE EXCEPTION 'invalid_start_date';
+  END IF;
+
+  v_family_id := v_event.family_id;
+  v_title := COALESCE(p_title, v_event.title);
+  v_description := CASE WHEN p_has_description THEN p_description ELSE v_event.description END;
+  v_is_all_day := COALESCE(p_is_all_day, v_event.is_all_day);
+  v_reminder_minutes := COALESCE(p_reminder_minutes, v_series.reminder_minutes);
+  v_label_color := CASE WHEN p_has_label_color THEN p_label_color ELSE v_event.label_color END;
+
+  IF NOT v_is_all_day THEN
+    v_start_time := p_start_at::time;
+    v_end_time := COALESCE(
+      CASE WHEN p_has_end_at THEN p_end_at ELSE v_event.end_at END,
+      p_start_at
+    )::time;
+  END IF;
+
+  v_freq := COALESCE(p_freq, v_rule.freq);
+  v_interval := COALESCE(p_interval, v_rule.interval);
+  IF v_freq NOT IN ('daily', 'weekly', 'monthly', 'yearly') THEN RAISE EXCEPTION 'invalid_frequency'; END IF;
+  IF v_interval < 1 THEN RAISE EXCEPTION 'invalid_interval'; END IF;
+
+  v_days_of_week := CASE
+    WHEN v_freq = 'weekly' THEN COALESCE(
+      CASE WHEN p_days_of_week IS NOT NULL AND cardinality(p_days_of_week) > 0 THEN p_days_of_week END,
+      ARRAY[EXTRACT(DOW FROM v_start_date)::int]
+    )
+    ELSE COALESCE(p_days_of_week, v_rule.days_of_week)
+  END;
+
+  v_day_of_month := CASE
+    WHEN v_freq = 'monthly' THEN COALESCE(p_day_of_month, EXTRACT(DAY FROM v_start_date)::int)
+    ELSE COALESCE(p_day_of_month, v_rule.day_of_month)
+  END;
+
+  v_end_date := CASE
+    WHEN p_should_update_end_date THEN p_end_date
+    ELSE v_rule.end_date
+  END;
+  IF v_end_date IS NOT NULL AND v_end_date < v_start_date THEN
+    RAISE EXCEPTION 'no_future_occurrences';
+  END IF;
+
+  v_horizon := LEAST(
+    COALESCE(v_end_date, (v_start_date + INTERVAL '1 year')::date),
+    (v_start_date + INTERVAL '2 years')::date
+  );
+
+  INSERT INTO recurrence_rules (freq, interval, days_of_week, day_of_month, end_date)
+  VALUES (v_freq, v_interval, v_days_of_week, v_day_of_month, v_end_date)
+  RETURNING id INTO v_new_rule_id;
+
+  INSERT INTO recurrence_series (
+    family_id, calendar_id, title, description, is_all_day,
+    start_time, end_time, reminder_minutes, rule_id, created_by
+  ) VALUES (
+    v_family_id, v_calendar_id, v_title, v_description, v_is_all_day,
+    v_start_time, v_end_time, v_reminder_minutes, v_new_rule_id, p_actor_user_id
+  )
+  RETURNING id INTO v_new_series_id;
+
+  IF v_freq = 'daily' THEN
+    v_current_date := v_start_date;
+    WHILE v_current_date <= v_horizon LOOP
+      PERFORM insert_series_event_instance(
+        v_new_series_id, v_family_id, p_actor_user_id, v_calendar_id,
+        v_title, v_description, v_is_all_day,
+        v_start_time, v_end_time, v_current_date, v_reminder_minutes, v_label_color
+      );
+      v_count := v_count + 1;
+      v_current_date := v_current_date + (v_interval || ' days')::INTERVAL;
+    END LOOP;
+
+  ELSIF v_freq = 'weekly' THEN
+    v_eff_days := v_days_of_week;
+    v_week_start := v_start_date - EXTRACT(DOW FROM v_start_date)::int;
+    WHILE v_week_start <= v_horizon LOOP
+      FOREACH v_dow IN ARRAY v_eff_days LOOP
+        v_current_date := v_week_start + v_dow;
+        IF v_current_date >= v_start_date AND v_current_date <= v_horizon THEN
+          PERFORM insert_series_event_instance(
+            v_new_series_id, v_family_id, p_actor_user_id, v_calendar_id,
+            v_title, v_description, v_is_all_day,
+            v_start_time, v_end_time, v_current_date, v_reminder_minutes, v_label_color
+          );
+          v_count := v_count + 1;
+        END IF;
+      END LOOP;
+      v_week_start := v_week_start + (v_interval * 7 || ' days')::INTERVAL;
+    END LOOP;
+
+  ELSIF v_freq = 'monthly' THEN
+    v_dom := COALESCE(v_day_of_month, EXTRACT(DAY FROM v_start_date)::int);
+    v_current_date := v_start_date;
+    WHILE DATE_TRUNC('month', v_current_date)::date <= DATE_TRUNC('month', v_horizon)::date LOOP
+      v_occ := (DATE_TRUNC('month', v_current_date) + (v_dom - 1) * INTERVAL '1 day')::date;
+      IF EXTRACT(MONTH FROM v_occ) = EXTRACT(MONTH FROM DATE_TRUNC('month', v_current_date))
+         AND v_occ >= v_start_date AND v_occ <= v_horizon
+      THEN
+        PERFORM insert_series_event_instance(
+          v_new_series_id, v_family_id, p_actor_user_id, v_calendar_id,
+          v_title, v_description, v_is_all_day,
+          v_start_time, v_end_time, v_occ, v_reminder_minutes, v_label_color
+        );
+        v_count := v_count + 1;
+      END IF;
+      v_current_date := (DATE_TRUNC('month', v_current_date) + (v_interval || ' months')::INTERVAL)::date;
+    END LOOP;
+
+  ELSIF v_freq = 'yearly' THEN
+    v_current_date := v_start_date;
+    WHILE v_current_date <= v_horizon LOOP
+      PERFORM insert_series_event_instance(
+        v_new_series_id, v_family_id, p_actor_user_id, v_calendar_id,
+        v_title, v_description, v_is_all_day,
+        v_start_time, v_end_time, v_current_date, v_reminder_minutes, v_label_color
+      );
+      v_count := v_count + 1;
+      v_current_date := (v_current_date + (v_interval || ' years')::INTERVAL)::date;
+    END LOOP;
+  ELSE
+    RAISE EXCEPTION 'invalid_frequency';
+  END IF;
+
+  IF v_count = 0 THEN
+    RAISE EXCEPTION 'no_future_occurrences';
+  END IF;
+
+  UPDATE events SET is_cancelled = true
+  WHERE series_id = v_event.series_id
+    AND NOT is_cancelled
+    AND series_occurrence_date >= p_anchor_occurrence_date;
+
+  DELETE FROM event_reminders er
+  USING events ev
+  WHERE er.event_id = ev.id
+    AND ev.series_id = v_event.series_id
+    AND ev.series_occurrence_date >= p_anchor_occurrence_date;
+
+  UPDATE recurrence_rules
+  SET end_date = p_anchor_occurrence_date - 1
+  WHERE id = v_series.rule_id
+    AND (end_date IS NULL OR end_date > p_anchor_occurrence_date - 1);
+
+  RETURN json_build_object(
+    'is_changed',      true,
+    'family_id',       v_family_id,
+    'series_id',       v_new_series_id,
+    'old_series_id',   v_event.series_id,
+    'scope',           'following',
+    'event_count',     v_count,
+    'new_calendar_id', v_calendar_id,
+    'new_title',       v_title,
+    'new_start_at',    p_start_at
+  );
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION split_recurring_series_following_authorized(
+  uuid, uuid, date, date, text, text, boolean, timestamptz, timestamptz, boolean,
+  boolean, uuid, boolean, int[], text, boolean, text, int, int[], int, date, boolean
+) FROM public, anon, authenticated;


### PR DESCRIPTION
## Summary
- `이 일정 및 이후 일정` 편집에서 기존 반복 규칙을 불러와 수정 모달에 표시합니다.
- following 범위에서 반복 규칙이 실제로 바뀐 경우에만 `recurrence` payload를 보내고, 기존 split RPC 경로로 새 series를 생성합니다.
- 기존 종료일이 있는 반복 규칙에서 종료일을 제거할 수 있도록 split RPC에 end date 갱신 플래그를 추가합니다.
- following 반복 규칙 편집에서는 아직 지원하지 않는 `안 함` 선택을 숨겨 반복 해제 경로를 열지 않습니다.
- 반복 규칙 변경이 API split RPC로 전달되는지 route/component 테스트를 추가했습니다.

Refs #116

## Testing
- `npm run test -- --runTestsByPath src/__tests__/api/events/recurring.test.ts src/__tests__/lib/recurrence-following-split-sql.test.ts`
- `npm run test -- --runTestsByPath src/__tests__/api/events/recurring.test.ts src/__tests__/components/EventFormModal.test.tsx src/__tests__/components/CalendarTab.test.tsx`
- `npx tsc --noEmit`
- `npm run lint` (이번 변경과 무관한 기존 warning 4개만 남아 있습니다)

Manual:
- [x] 반복 일정 하나를 선택해 `이 일정 및 이후 일정`으로 수정할 때 기존 반복 규칙이 표시되는지 확인합니다.
- [x] 반복 간격, 요일, 종료일 중 하나를 바꿔 저장하면 선택한 일정 및 이후 일정만 새 반복 규칙으로 보이는지 확인합니다.
- [x] 기존 종료일이 있는 반복 일정에서 `이 일정 및 이후 일정`으로 종료일을 끈 뒤 저장하면 새 이후 반복 일정의 종료일이 제거되는지 확인합니다.
- [x] `이 일정 및 이후 일정` 반복 규칙 편집에서 `안 함` 선택지가 보이지 않는지 확인합니다.
- [x] 선택한 일정 이전 occurrence는 기존 반복 규칙을 유지하는지 확인합니다.
