### PR TITLE
clarify: explain all series edit limits

### DIFF
--- a/src/__tests__/components/EventFormModal.test.tsx
+++ b/src/__tests__/components/EventFormModal.test.tsx
@@ -472,7 +472,7 @@ describe('EventFormModal', () => {
     const dateInputs = document.querySelectorAll('input[type="date"]')
     expect((dateInputs[0] as HTMLInputElement).disabled).toBe(true)
     expect((dateInputs[1] as HTMLInputElement).disabled).toBe(true)
-    expect(screen.getByText('전체 반복 일정은 날짜 이동 없이 시간과 내용만 변경할 수 있어요.')).toBeInTheDocument()
+    expect(screen.getByText('전체 반복 일정에서는 제목, 시간, 알림 등 공통 정보만 변경할 수 있어요.')).toBeInTheDocument()
   })
 
   it('사용자화 반복 간격을 수정해 저장할 수 있다', async () => {

--- a/src/components/calendar/EventFormModal.tsx
+++ b/src/components/calendar/EventFormModal.tsx
@@ -422,7 +422,7 @@ export function EventFormModal({
             <div className="py-3 pr-4 sm:py-5 sm:pr-5">
               {isAllSeriesEdit && (
                 <p className="mb-3 rounded-2xl bg-stone-100 px-4 py-3 text-sm text-stone-500 dark:bg-stone-900 dark:text-stone-400">
-                  전체 반복 일정은 날짜 이동 없이 시간과 내용만 변경할 수 있어요.
+                  전체 반복 일정에서는 제목, 시간, 알림 등 공통 정보만 변경할 수 있어요.
                 </p>
               )}
 


### PR DESCRIPTION
## Summary
- `전체 반복 일정` 수정 모달의 안내 문구를 실제 허용 범위에 맞게 정리했습니다.
- 선택지 시트는 단순하게 유지하고, 제한이 필요한 수정 모달 안에서만 공통 정보 수정 범위를 안내합니다.

Refs #116

## Testing
- `npm run test -- --runTestsByPath src/__tests__/components/EventFormModal.test.tsx`
- `npx tsc --noEmit`
- `npm run lint` (이번 변경과 무관한 기존 warning 4개만 남아 있습니다)

Manual:
- [ ] 반복 일정 수정에서 `전체 반복 일정`을 선택했을 때 수정 모달에 “제목, 시간, 알림 등 공통 정보만 변경” 안내가 보이는지 확인합니다.
