### PR TITLE
polish: rename shopping tab to reminders

### DIFF
--- a/src/__tests__/components/BottomNav.test.tsx
+++ b/src/__tests__/components/BottomNav.test.tsx
@@ -9,24 +9,24 @@ import { usePathname } from 'next/navigation'
 const mockUsePathname = usePathname as jest.Mock
 
 describe('BottomNav', () => {
-  it('장바구니와 설정 탭이 렌더링된다', () => {
+  it('리마인더와 설정 탭이 렌더링된다', () => {
     mockUsePathname.mockReturnValue('/')
     render(<BottomNav />)
-    expect(screen.getByText('장바구니')).toBeInTheDocument()
+    expect(screen.getByText('리마인더')).toBeInTheDocument()
     expect(screen.getByText('설정')).toBeInTheDocument()
   })
 
-  it('/shopping 경로에서 장바구니 탭이 활성화된다', () => {
+  it('/shopping 경로에서 리마인더 탭이 활성화된다', () => {
     mockUsePathname.mockReturnValue('/shopping')
     render(<BottomNav />)
-    const shoppingLink = screen.getByText('장바구니').closest('a')
+    const shoppingLink = screen.getByText('리마인더').closest('a')
     expect(shoppingLink).toHaveClass('text-accent-500')
   })
 
-  it('/shopping/list-1 경로에서도 장바구니 탭이 활성화된다', () => {
+  it('/shopping/list-1 경로에서도 리마인더 탭이 활성화된다', () => {
     mockUsePathname.mockReturnValue('/shopping/list-1')
     render(<BottomNav />)
-    const shoppingLink = screen.getByText('장바구니').closest('a')
+    const shoppingLink = screen.getByText('리마인더').closest('a')
     expect(shoppingLink).toHaveClass('text-accent-500')
   })
 
@@ -47,7 +47,7 @@ describe('BottomNav', () => {
   it('링크의 href가 올바르다', () => {
     mockUsePathname.mockReturnValue('/')
     render(<BottomNav />)
-    expect(screen.getByText('장바구니').closest('a')).toHaveAttribute('href', '/shopping')
+    expect(screen.getByText('리마인더').closest('a')).toHaveAttribute('href', '/shopping')
     expect(screen.getByText('설정').closest('a')).toHaveAttribute('href', '/settings')
   })
 })

--- a/src/__tests__/lib/shopping.test.ts
+++ b/src/__tests__/lib/shopping.test.ts
@@ -87,7 +87,7 @@ describe('deleteShoppingList', () => {
 })
 
 describe('getShoppingList', () => {
-  it('단일 장바구니를 반환한다', async () => {
+  it('단일 리마인더를 반환한다', async () => {
     const mockData = { id: 'list-1', name: '이마트', type: 'strikethrough' }
     mockFrom.mockReturnValue(makeChain({ data: mockData, error: null }))
     const result = await getShoppingList('list-1')

--- a/src/__tests__/shopping/ShoppingDetailView.test.tsx
+++ b/src/__tests__/shopping/ShoppingDetailView.test.tsx
@@ -120,9 +120,9 @@ describe('ShoppingDetailView', () => {
     )
 
     expect(
-      await screen.findByText('삭제되었거나 접근할 수 없는 장바구니예요.')
+      await screen.findByText('삭제되었거나 접근할 수 없는 리마인더예요.')
     ).toBeInTheDocument()
-    expect(screen.getByText('삭제되었거나 접근할 수 없는 장바구니예요.')).toBeInTheDocument()
+    expect(screen.getByText('삭제되었거나 접근할 수 없는 리마인더예요.')).toBeInTheDocument()
   })
 
   it('로드 실패 시 fetch error 상태와 재시도 버튼을 보여준다', async () => {

--- a/src/__tests__/shopping/ShoppingListCard.test.tsx
+++ b/src/__tests__/shopping/ShoppingListCard.test.tsx
@@ -46,7 +46,7 @@ describe('ShoppingListCard', () => {
 
     fireEvent.click(screen.getByLabelText('삭제'))
 
-    expect(screen.getByText('장바구니 삭제')).toBeInTheDocument()
+    expect(screen.getByText('리마인더 삭제')).toBeInTheDocument()
     expect(screen.getByLabelText('삭제 확인')).toBeInTheDocument()
     expect(screen.getByLabelText('취소')).toBeInTheDocument()
   })
@@ -69,7 +69,7 @@ describe('ShoppingListCard', () => {
     fireEvent.click(screen.getByLabelText('취소'))
 
     expect(onDelete).not.toHaveBeenCalled()
-    expect(screen.queryByText('장바구니 삭제')).not.toBeInTheDocument()
+    expect(screen.queryByText('리마인더 삭제')).not.toBeInTheDocument()
   })
 
   it('목록 이름이 렌더링된다', () => {
@@ -144,13 +144,13 @@ describe('ShoppingListCard', () => {
 
   it('카드 본문이 키보드로 접근 가능하다 (tabIndex=0)', () => {
     render(<ShoppingListCard list={mockList} onDelete={jest.fn()} onRename={jest.fn()} onOpen={mockOnOpen} />)
-    const cardBody = screen.getByLabelText('이마트 장바구니 열기')
+    const cardBody = screen.getByLabelText('이마트 리마인더 열기')
     expect(cardBody).toHaveAttribute('tabindex', '0')
   })
 
   it('카드 본문에서 Enter 키 입력 시 onOpen이 호출된다', () => {
     render(<ShoppingListCard list={mockList} onDelete={jest.fn()} onRename={jest.fn()} onOpen={mockOnOpen} />)
-    const cardBody = screen.getByLabelText('이마트 장바구니 열기')
+    const cardBody = screen.getByLabelText('이마트 리마인더 열기')
     fireEvent.keyDown(cardBody, { key: 'Enter' })
     expect(mockOnOpen).toHaveBeenCalledWith('list-1')
   })

--- a/src/__tests__/shopping/ShoppingTab.test.tsx
+++ b/src/__tests__/shopping/ShoppingTab.test.tsx
@@ -119,7 +119,7 @@ describe('ShoppingTab', () => {
       />
     )
 
-    await user.click(await screen.findByLabelText('새 장바구니 추가'))
+    await user.click(await screen.findByLabelText('새 리마인더 추가'))
     await user.type(screen.getByPlaceholderText('예: 이마트, 코스트코'), '이마트')
     await user.click(screen.getByRole('button', { name: '만들기' }))
 

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -2,12 +2,12 @@
 
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { CalendarDays, ShoppingCart, Settings } from 'lucide-react'
+import { CalendarDays, ListChecks, Settings } from 'lucide-react'
 import type { Tab } from '@/types/tabs'
 
 const navItems = [
   { href: '/calendar', icon: CalendarDays, label: '캘린더' },
-  { href: '/shopping', icon: ShoppingCart, label: '장바구니' },
+  { href: '/shopping', icon: ListChecks, label: '리마인더' },
   { href: '/settings', icon: Settings, label: '설정' },
 ]
 

--- a/src/components/shopping/CreateListModal.tsx
+++ b/src/components/shopping/CreateListModal.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { X, ShoppingCart, Trash2 } from 'lucide-react'
+import { X, ListChecks, Trash2 } from 'lucide-react'
 import type { ListType } from '@/lib/shopping'
 
 interface Props {
@@ -33,7 +33,7 @@ export function CreateListModal({ onClose, onCreate }: Props) {
       <div className="absolute inset-0 bg-black/40 backdrop-blur-sm" onClick={onClose} />
       <div className="relative w-full sm:max-w-sm bg-white dark:bg-stone-900 rounded-t-3xl sm:rounded-2xl shadow-xl max-h-[90vh] flex flex-col">
         <div className="flex items-center justify-between px-6 pt-6 pb-4 shrink-0">
-          <h2 className="text-lg font-semibold text-stone-800 dark:text-stone-100">새 장바구니</h2>
+          <h2 className="text-lg font-semibold text-stone-800 dark:text-stone-100">새 리마인더</h2>
           <button
             onClick={onClose}
             className="p-1.5 rounded-full text-stone-400 hover:text-stone-600 dark:hover:text-stone-200 hover:bg-stone-100 dark:hover:bg-stone-800 transition-colors"
@@ -71,7 +71,7 @@ export function CreateListModal({ onClose, onCreate }: Props) {
                     : 'border-stone-200 dark:border-stone-700 text-stone-500 dark:text-stone-400 hover:border-stone-300'
                 }`}
               >
-                <ShoppingCart size={20} />
+                <ListChecks size={20} />
                 <span className="text-xs font-medium">취소선</span>
                 <span className="text-[10px] text-stone-400 dark:text-stone-500">체크 후 남아있음</span>
               </button>

--- a/src/components/shopping/ShoppingDetailView.tsx
+++ b/src/components/shopping/ShoppingDetailView.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { ArrowLeft } from 'lucide-react'
+import { ArrowLeft, ListChecks } from 'lucide-react'
 import {
   DndContext,
   PointerSensor,
@@ -304,13 +304,13 @@ export function ShoppingDetailView({
       ) : status === 'not-found' ? (
         <DetailStateShell
           title="목록을 찾을 수 없어요"
-          description="삭제되었거나 접근할 수 없는 장바구니예요."
+          description="삭제되었거나 접근할 수 없는 리마인더예요."
           actionLabel="목록으로 돌아가기"
           onAction={onClose}
         />
       ) : status === 'fetch-error' ? (
         <DetailStateShell
-          title="장바구니를 불러오지 못했어요"
+          title="리마인더를 불러오지 못했어요"
           description="잠시 후 다시 시도해주세요."
           actionLabel="다시 시도"
           onAction={handleRetry}
@@ -332,7 +332,7 @@ export function ShoppingDetailView({
             </button>
             <div>
               <h2 className="text-xl font-bold text-stone-800 dark:text-stone-100">
-                {list?.name ?? '장바구니'}
+                {list?.name ?? '리마인더'}
               </h2>
               <p className="text-xs text-stone-400 dark:text-stone-500 mt-0.5">
                 {uncheckedItems.length > 0
@@ -441,13 +441,13 @@ function DetailStateShell({
           <ArrowLeft size={20} />
         </button>
         <div>
-          <h2 className="text-xl font-bold text-stone-800 dark:text-stone-100">장바구니</h2>
+          <h2 className="text-xl font-bold text-stone-800 dark:text-stone-100">리마인더</h2>
           <p className="text-xs text-stone-400 dark:text-stone-500 mt-0.5">{title}</p>
         </div>
       </div>
 
       <div className="flex-1 min-h-0 flex flex-col items-center justify-center px-6 text-center">
-        <div className="text-5xl mb-4">🧺</div>
+        <ListChecks size={48} className="mb-4 text-stone-300 dark:text-stone-600" />
         <p className="text-stone-600 dark:text-stone-300 font-medium">{title}</p>
         <p className="text-sm text-stone-400 dark:text-stone-500 mt-2">{description}</p>
         <div className="mt-6 flex gap-2">

--- a/src/components/shopping/ShoppingListCard.tsx
+++ b/src/components/shopping/ShoppingListCard.tsx
@@ -118,7 +118,7 @@ export function ShoppingListCard({ list, previewItems = [], onDelete, onRename, 
         {...attributes}
         {...listeners}
         tabIndex={confirming || editing ? -1 : 0}
-        aria-label={`${list.name} 장바구니 열기`}
+        aria-label={`${list.name} 리마인더 열기`}
         onClick={() => !confirming && !editing && onOpen(list.id)}
         onKeyDown={handleCardKeyDown}
         className="group flex flex-col p-3.5 rounded-2xl bg-stone-50 dark:bg-stone-900 border border-stone-100 dark:border-stone-800 shadow-sm hover:border-accent-200 dark:hover:border-accent-900 hover:shadow-md hover:-translate-y-0.5 transition-all min-h-[160px] cursor-grab active:cursor-grabbing outline-none focus-visible:ring-2 focus-visible:ring-accent-400 focus-visible:ring-offset-1"
@@ -205,7 +205,7 @@ export function ShoppingListCard({ list, previewItems = [], onDelete, onRename, 
             onClick={handleCancel}
           />
           <div className="relative bg-stone-50 dark:bg-stone-900 rounded-2xl w-full sm:max-w-xs p-6 shadow-xl">
-            <p id={modalTitleId} className="font-semibold text-stone-800 dark:text-stone-100 mb-1">장바구니 삭제</p>
+            <p id={modalTitleId} className="font-semibold text-stone-800 dark:text-stone-100 mb-1">리마인더 삭제</p>
             <p className="text-sm text-stone-500 dark:text-stone-400 mb-6">
               &ldquo;{list.name}&rdquo;을(를) 삭제할까요?
             </p>

--- a/src/components/tabs/ShoppingTab.tsx
+++ b/src/components/tabs/ShoppingTab.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { Plus, ShoppingCart, AlertTriangle } from 'lucide-react'
+import { Plus, ListChecks, AlertTriangle } from 'lucide-react'
 import {
   DndContext,
   PointerSensor,
@@ -279,15 +279,15 @@ function ShoppingListView({
     <>
       <div className="flex items-center justify-between mb-6">
         <div>
-          <h1 className="text-2xl font-bold text-stone-800 dark:text-stone-100">장바구니</h1>
+          <h1 className="text-2xl font-bold text-stone-800 dark:text-stone-100">리마인더</h1>
           <p className="text-sm text-stone-400 dark:text-stone-500 mt-0.5">
-            {lists.length > 0 ? `${lists.length}개의 목록` : '장바구니를 만들어보세요'}
+            {lists.length > 0 ? `${lists.length}개의 목록` : '리마인더를 만들어보세요'}
           </p>
         </div>
         <button
           onClick={onCreateClick}
           className="w-11 h-11 flex items-center justify-center rounded-full bg-accent-400 hover:bg-accent-500 text-white shadow-sm transition-colors"
-          aria-label="새 장바구니 추가"
+          aria-label="새 리마인더 추가"
         >
           <Plus size={20} />
         </button>
@@ -307,8 +307,8 @@ function ShoppingListView({
         </div>
       ) : lists.length === 0 ? (
         <div className="flex flex-col items-center justify-center py-24 text-center">
-          <ShoppingCart size={40} className="text-stone-300 dark:text-stone-600 mb-4" />
-          <p className="text-stone-500 dark:text-stone-400 font-medium">아직 장바구니가 없어요</p>
+          <ListChecks size={40} className="text-stone-300 dark:text-stone-600 mb-4" />
+          <p className="text-stone-500 dark:text-stone-400 font-medium">아직 리마인더가 없어요</p>
           <p className="text-sm text-stone-400 dark:text-stone-500 mt-1">위의 + 버튼을 눌러보세요</p>
         </div>
       ) : (


### PR DESCRIPTION
## Summary
- 장바구니 탭의 표시 이름을 리마인더로 변경했습니다.
- 새 목록 작성 모달의 제목을 새 리마인더로 변경했습니다.
- 장바구니 카트 아이콘을 iOS 미리알림 앱에 가까운 체크 리스트 아이콘으로 교체했습니다.
- 관련 접근성 라벨, 빈 상태, 에러/삭제 문구 테스트를 리마인더 기준으로 갱신했습니다.

## Testing
- npm run test -- --runTestsByPath src/__tests__/components/BottomNav.test.tsx src/__tests__/shopping/ShoppingTab.test.tsx src/__tests__/shopping/ShoppingDetailView.test.tsx src/__tests__/shopping/ShoppingListCard.test.tsx
- npx tsc --noEmit
- npm run lint (기존 warning 4개만 확인, error 없음)