### PR TITLE
feat: add reminder group groundwork

### DIFF
--- a/src/__tests__/lib/reminder-groups-sql.test.ts
+++ b/src/__tests__/lib/reminder-groups-sql.test.ts
@@ -1,0 +1,35 @@
+import fs from 'fs'
+import path from 'path'
+
+const migrationPath = path.join(
+  process.cwd(),
+  'supabase/migrations/20260508000000_reminder_groups_groundwork.sql'
+)
+
+const sql = () => fs.readFileSync(migrationPath, 'utf8')
+
+describe('reminder groups migration', () => {
+  it('does not expose grouped lists by clearing reminder_group_id on group delete', () => {
+    const migration = sql()
+
+    expect(migration).toContain('references reminder_groups (id, family_id)')
+    expect(migration).toContain('on delete restrict')
+    expect(migration).not.toContain('on delete set null (reminder_group_id)')
+  })
+
+  it('blocks direct list scope changes after creation', () => {
+    const migration = sql()
+
+    expect(migration).toContain('create or replace function prevent_reminder_list_scope_change()')
+    expect(migration).toContain('reminder_list_scope_change_not_allowed')
+    expect(migration).toContain('before update of family_id, reminder_group_id on shopping_lists')
+  })
+
+  it('keeps grouped list access behind reminder group membership helpers', () => {
+    const migration = sql()
+
+    expect(migration).toContain('create or replace function get_my_reminder_group_ids()')
+    expect(migration).toContain('create or replace function get_my_list_ids()')
+    expect(migration).toContain('sl.reminder_group_id in (select get_my_reminder_group_ids())')
+  })
+})

--- a/src/__tests__/lib/shopping.test.ts
+++ b/src/__tests__/lib/shopping.test.ts
@@ -1,4 +1,11 @@
 import {
+  getReminderGroups,
+  createReminderGroup,
+  updateReminderGroup,
+  deleteReminderGroup,
+  getReminderGroupMembers,
+  getReminderGroupMembersForGroups,
+  setReminderGroupMembers,
   getShoppingLists,
   createShoppingList,
   deleteShoppingList,
@@ -17,7 +24,7 @@ import {
 function makeChain(result: { data: unknown; error: unknown }) {
   const p = Promise.resolve(result)
   const chain: Record<string, unknown> = {}
-  ;['select', 'insert', 'update', 'delete', 'eq', 'ilike', 'order'].forEach((m) => {
+  ;['select', 'insert', 'update', 'delete', 'eq', 'neq', 'in', 'ilike', 'order'].forEach((m) => {
     chain[m] = jest.fn().mockReturnValue(chain)
   })
   chain.single = jest.fn().mockReturnValue(p)
@@ -37,6 +44,134 @@ jest.mock('@/lib/supabase', () => ({
 beforeEach(() => {
   jest.clearAllMocks()
   mockFrom.mockImplementation(() => makeChain({ data: null, error: null }))
+})
+
+describe('getReminderGroups', () => {
+  it('정렬된 리마인더 그룹을 반환한다', async () => {
+    const mockData = [{ id: 'group-1', name: '집', sort_order: 0 }]
+    mockFrom.mockReturnValue(makeChain({ data: mockData, error: null }))
+    const result = await getReminderGroups('fam-1')
+    expect(result).toEqual(mockData)
+    expect(mockFrom).toHaveBeenCalledWith('reminder_groups')
+  })
+
+  it('data가 null이면 빈 배열을 반환한다', async () => {
+    mockFrom.mockReturnValue(makeChain({ data: null, error: null }))
+    const result = await getReminderGroups('fam-1')
+    expect(result).toEqual([])
+  })
+
+  it('error가 있으면 throw한다', async () => {
+    mockFrom.mockReturnValue(makeChain({ data: null, error: { message: 'group fetch error' } }))
+    await expect(getReminderGroups('fam-1')).rejects.toEqual({ message: 'group fetch error' })
+  })
+})
+
+describe('createReminderGroup', () => {
+  it('그룹 생성 후 owner와 멤버를 등록한다', async () => {
+    const mockGroup = { id: 'group-1', name: '집', color: '#3b82f6' }
+    const groupChain = makeChain({ data: mockGroup, error: null })
+    const ownerChain = makeChain({ data: null, error: null })
+    const memberChain = makeChain({ data: null, error: null })
+    mockFrom
+      .mockReturnValueOnce(groupChain)
+      .mockReturnValueOnce(ownerChain)
+      .mockReturnValueOnce(memberChain)
+
+    const result = await createReminderGroup(
+      'fam-1',
+      'user-1',
+      '집',
+      '#3b82f6',
+      ['user-1', 'user-2']
+    )
+
+    expect(result).toEqual(mockGroup)
+    expect(mockFrom).toHaveBeenNthCalledWith(1, 'reminder_groups')
+    expect(groupChain.insert).toHaveBeenCalledWith({
+      family_id: 'fam-1',
+      created_by: 'user-1',
+      name: '집',
+      color: '#3b82f6',
+    })
+    expect(mockFrom).toHaveBeenNthCalledWith(2, 'reminder_group_members')
+    expect(ownerChain.insert).toHaveBeenCalledWith({
+      reminder_group_id: 'group-1',
+      user_id: 'user-1',
+      role: 'owner',
+    })
+    expect(memberChain.insert).toHaveBeenCalledWith([
+      { reminder_group_id: 'group-1', user_id: 'user-2', role: 'member' },
+    ])
+  })
+
+  it('owner 등록 실패 시 throw한다', async () => {
+    mockFrom
+      .mockReturnValueOnce(makeChain({ data: { id: 'group-1' }, error: null }))
+      .mockReturnValueOnce(makeChain({ data: null, error: { message: 'owner error' } }))
+
+    await expect(createReminderGroup('fam-1', 'user-1', '집', '#3b82f6')).rejects.toEqual({
+      message: 'owner error',
+    })
+  })
+})
+
+describe('updateReminderGroup', () => {
+  it('updated_at과 함께 그룹 정보를 수정한다', async () => {
+    mockFrom.mockReturnValue(makeChain({ data: null, error: null }))
+    await expect(updateReminderGroup('group-1', { name: '회사' })).resolves.toBeUndefined()
+    expect(mockFrom).toHaveBeenCalledWith('reminder_groups')
+  })
+})
+
+describe('deleteReminderGroup', () => {
+  it('에러 없이 완료된다', async () => {
+    mockFrom.mockReturnValue(makeChain({ data: null, error: null }))
+    await expect(deleteReminderGroup('group-1')).resolves.toBeUndefined()
+  })
+})
+
+describe('getReminderGroupMembers', () => {
+  it('리마인더 그룹 멤버를 반환한다', async () => {
+    const mockData = [{ reminder_group_id: 'group-1', user_id: 'user-1', role: 'owner' }]
+    mockFrom.mockReturnValue(makeChain({ data: mockData, error: null }))
+    const result = await getReminderGroupMembers('group-1')
+    expect(result).toEqual(mockData)
+    expect(mockFrom).toHaveBeenCalledWith('reminder_group_members')
+  })
+})
+
+describe('getReminderGroupMembersForGroups', () => {
+  it('그룹 id가 없으면 조회하지 않고 빈 배열을 반환한다', async () => {
+    const result = await getReminderGroupMembersForGroups([])
+    expect(result).toEqual([])
+    expect(mockFrom).not.toHaveBeenCalled()
+  })
+
+  it('여러 그룹의 멤버를 조회한다', async () => {
+    const mockData = [{ reminder_group_id: 'group-1', user_id: 'user-1', role: 'owner' }]
+    mockFrom.mockReturnValue(makeChain({ data: mockData, error: null }))
+    const result = await getReminderGroupMembersForGroups(['group-1'])
+    expect(result).toEqual(mockData)
+    expect(mockFrom).toHaveBeenCalledWith('reminder_group_members')
+  })
+})
+
+describe('setReminderGroupMembers', () => {
+  it('owner 제외 멤버를 교체한다', async () => {
+    const deleteChain = makeChain({ data: null, error: null })
+    const insertChain = makeChain({ data: null, error: null })
+    mockFrom.mockReturnValueOnce(deleteChain).mockReturnValueOnce(insertChain)
+
+    await expect(
+      setReminderGroupMembers('group-1', 'user-1', ['user-1', 'user-2'])
+    ).resolves.toBeUndefined()
+
+    expect(deleteChain.neq).toHaveBeenCalledWith('user_id', 'user-1')
+    expect(insertChain.insert).toHaveBeenCalledWith([
+      { reminder_group_id: 'group-1', user_id: 'user-2', role: 'member' },
+    ])
+  })
 })
 
 describe('getShoppingLists', () => {
@@ -66,6 +201,34 @@ describe('createShoppingList', () => {
     mockFrom.mockReturnValue(makeChain({ data: mockList, error: null }))
     const result = await createShoppingList('fam-1', 'user-1', '이마트', 'strikethrough')
     expect(result).toEqual(mockList)
+  })
+
+  it('리마인더 그룹 id를 함께 저장할 수 있다', async () => {
+    const mockList = {
+      id: 'list-1',
+      name: '이마트',
+      type: 'strikethrough',
+      reminder_group_id: 'group-1',
+    }
+    const chain = makeChain({ data: mockList, error: null })
+    mockFrom.mockReturnValue(chain)
+
+    const result = await createShoppingList(
+      'fam-1',
+      'user-1',
+      '이마트',
+      'strikethrough',
+      'group-1'
+    )
+
+    expect(result).toEqual(mockList)
+    expect(chain.insert).toHaveBeenCalledWith({
+      family_id: 'fam-1',
+      created_by: 'user-1',
+      name: '이마트',
+      type: 'strikethrough',
+      reminder_group_id: 'group-1',
+    })
   })
 
   it('error가 있으면 throw한다', async () => {

--- a/src/__tests__/shopping/ShoppingListCard.test.tsx
+++ b/src/__tests__/shopping/ShoppingListCard.test.tsx
@@ -24,6 +24,7 @@ const mockList: ShoppingList = {
   family_id: 'fam-1',
   created_by: 'user-1',
   name: '이마트',
+  reminder_group_id: null,
   type: 'strikethrough',
   sort_order: 0,
   created_at: '2026-01-01T00:00:00Z',

--- a/src/components/tabs/ShoppingTab.tsx
+++ b/src/components/tabs/ShoppingTab.tsx
@@ -102,6 +102,7 @@ export function ShoppingTab({ user, familyId, isInitializing }: Props) {
       family_id: familyId,
       created_by: user.id,
       name,
+      reminder_group_id: null,
       type,
       sort_order: 0,
       created_at: new Date().toISOString(),

--- a/src/lib/shopping.ts
+++ b/src/lib/shopping.ts
@@ -3,12 +3,148 @@ import type { Database } from '@/types/database'
 
 export type ShoppingList = Database['public']['Tables']['shopping_lists']['Row']
 export type ShoppingItem = Database['public']['Tables']['shopping_items']['Row']
+export type ReminderGroup = Database['public']['Tables']['reminder_groups']['Row']
+export type ReminderGroupMember = Database['public']['Tables']['reminder_group_members']['Row']
 export type ListType = 'strikethrough' | 'delete'
 
 export type ItemPreview = Pick<ShoppingItem, 'id' | 'name' | 'is_checked' | 'sort_order'>
 export type ShoppingListWithPreview = ShoppingList & { previewItems: ItemPreview[] }
 
 type RawListWithItems = ShoppingList & { shopping_items: ItemPreview[] }
+
+export const REMINDER_GROUP_COLORS = [
+  '#f97316',
+  '#3b82f6',
+  '#22c55e',
+  '#a855f7',
+  '#ec4899',
+  '#14b8a6',
+  '#ef4444',
+  '#eab308',
+]
+
+export const REMINDER_GROUP_COLOR_NAMES: Record<string, string> = {
+  '#f97316': '주황색',
+  '#3b82f6': '파란색',
+  '#22c55e': '초록색',
+  '#a855f7': '보라색',
+  '#ec4899': '분홍색',
+  '#14b8a6': '청록색',
+  '#ef4444': '빨간색',
+  '#eab308': '노란색',
+}
+
+// ── Reminder Groups ─────────────────────────────────────────
+
+export async function getReminderGroups(familyId: string): Promise<ReminderGroup[]> {
+  const { data, error } = await supabase
+    .from('reminder_groups')
+    .select('*')
+    .eq('family_id', familyId)
+    .order('sort_order', { ascending: true })
+    .order('created_at', { ascending: true })
+
+  if (error) throw error
+  return data ?? []
+}
+
+export async function createReminderGroup(
+  familyId: string,
+  userId: string,
+  name: string,
+  color: string,
+  memberUserIds: string[] = []
+): Promise<ReminderGroup> {
+  const { data, error } = await supabase
+    .from('reminder_groups')
+    .insert({ family_id: familyId, created_by: userId, name, color })
+    .select()
+    .single()
+
+  if (error) throw error
+
+  const { error: ownerError } = await supabase
+    .from('reminder_group_members')
+    .insert({ reminder_group_id: data.id, user_id: userId, role: 'owner' })
+  if (ownerError) throw ownerError
+
+  const newMembers = memberUserIds
+    .filter((id) => id !== userId)
+    .map((id) => ({ reminder_group_id: data.id, user_id: id, role: 'member' as const }))
+
+  if (newMembers.length > 0) {
+    const { error: memberError } = await supabase.from('reminder_group_members').insert(newMembers)
+    if (memberError) throw memberError
+  }
+
+  return data
+}
+
+export async function updateReminderGroup(
+  reminderGroupId: string,
+  updates: { name?: string; color?: string }
+): Promise<void> {
+  const { error } = await supabase
+    .from('reminder_groups')
+    .update({ ...updates, updated_at: new Date().toISOString() })
+    .eq('id', reminderGroupId)
+  if (error) throw error
+}
+
+export async function deleteReminderGroup(reminderGroupId: string): Promise<void> {
+  const { error } = await supabase.from('reminder_groups').delete().eq('id', reminderGroupId)
+  if (error) throw error
+}
+
+export async function getReminderGroupMembers(
+  reminderGroupId: string
+): Promise<ReminderGroupMember[]> {
+  const { data, error } = await supabase
+    .from('reminder_group_members')
+    .select('*')
+    .eq('reminder_group_id', reminderGroupId)
+    .order('created_at', { ascending: true })
+
+  if (error) throw error
+  return data ?? []
+}
+
+export async function getReminderGroupMembersForGroups(
+  reminderGroupIds: string[]
+): Promise<ReminderGroupMember[]> {
+  if (reminderGroupIds.length === 0) return []
+
+  const { data, error } = await supabase
+    .from('reminder_group_members')
+    .select('*')
+    .in('reminder_group_id', reminderGroupIds)
+    .order('created_at', { ascending: true })
+
+  if (error) throw error
+  return data ?? []
+}
+
+export async function setReminderGroupMembers(
+  reminderGroupId: string,
+  ownerUserId: string,
+  memberUserIds: string[]
+): Promise<void> {
+  const { error: delError } = await supabase
+    .from('reminder_group_members')
+    .delete()
+    .eq('reminder_group_id', reminderGroupId)
+    .neq('user_id', ownerUserId)
+  if (delError) throw delError
+
+  const newMembers = memberUserIds
+    .filter((id) => id !== ownerUserId)
+    .map((id) => ({ reminder_group_id: reminderGroupId, user_id: id, role: 'member' as const }))
+
+  if (newMembers.length === 0) return
+
+  const { error } = await supabase.from('reminder_group_members').insert(newMembers)
+  if (error) throw error
+}
 
 export async function getShoppingLists(familyId: string): Promise<ShoppingList[]> {
   const { data, error } = await supabase
@@ -42,11 +178,18 @@ export async function createShoppingList(
   familyId: string,
   userId: string,
   name: string,
-  type: ListType
+  type: ListType,
+  reminderGroupId: string | null = null
 ): Promise<ShoppingList> {
   const { data, error } = await supabase
     .from('shopping_lists')
-    .insert({ family_id: familyId, created_by: userId, name, type })
+    .insert({
+      family_id: familyId,
+      created_by: userId,
+      name,
+      type,
+      reminder_group_id: reminderGroupId,
+    })
     .select()
     .single()
 

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -523,6 +523,76 @@ export type Database = {
         }
         Relationships: []
       }
+      reminder_group_members: {
+        Row: {
+          created_at: string
+          reminder_group_id: string
+          role: 'owner' | 'member'
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          reminder_group_id: string
+          role?: 'owner' | 'member'
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          reminder_group_id?: string
+          role?: 'owner' | 'member'
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "reminder_group_members_reminder_group_id_fkey"
+            columns: ["reminder_group_id"]
+            isOneToOne: false
+            referencedRelation: "reminder_groups"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      reminder_groups: {
+        Row: {
+          color: string
+          created_at: string
+          created_by: string | null
+          family_id: string
+          id: string
+          name: string
+          sort_order: number
+          updated_at: string
+        }
+        Insert: {
+          color?: string
+          created_at?: string
+          created_by?: string | null
+          family_id: string
+          id?: string
+          name: string
+          sort_order?: number
+          updated_at?: string
+        }
+        Update: {
+          color?: string
+          created_at?: string
+          created_by?: string | null
+          family_id?: string
+          id?: string
+          name?: string
+          sort_order?: number
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "reminder_groups_family_id_fkey"
+            columns: ["family_id"]
+            isOneToOne: false
+            referencedRelation: "families"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       shopping_items: {
         Row: {
           checked_at: string | null
@@ -592,6 +662,7 @@ export type Database = {
           family_id: string
           id: string
           name: string
+          reminder_group_id: string | null
           sort_order: number
           type: string
         }
@@ -601,6 +672,7 @@ export type Database = {
           family_id: string
           id?: string
           name: string
+          reminder_group_id?: string | null
           sort_order?: number
           type?: string
         }
@@ -610,6 +682,7 @@ export type Database = {
           family_id?: string
           id?: string
           name?: string
+          reminder_group_id?: string | null
           sort_order?: number
           type?: string
         }
@@ -620,6 +693,13 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "families"
             referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "shopping_lists_reminder_group_family_fkey"
+            columns: ["reminder_group_id", "family_id"]
+            isOneToOne: false
+            referencedRelation: "reminder_groups"
+            referencedColumns: ["id", "family_id"]
           },
         ]
       }
@@ -659,6 +739,21 @@ export type Database = {
       get_my_list_ids: {
         Args: Record<PropertyKey, never>
         Returns: string[]
+      }
+      get_my_reminder_group_ids: {
+        Args: Record<PropertyKey, never>
+        Returns: string[]
+      }
+      get_my_owned_reminder_group_ids: {
+        Args: Record<PropertyKey, never>
+        Returns: string[]
+      }
+      is_family_member_of_reminder_group: {
+        Args: {
+          p_reminder_group_id: string
+          p_user_id: string
+        }
+        Returns: boolean
       }
       get_my_calendar_ids: {
         Args: Record<PropertyKey, never>

--- a/supabase/migrations/20260508000000_reminder_groups_groundwork.sql
+++ b/supabase/migrations/20260508000000_reminder_groups_groundwork.sql
@@ -1,0 +1,222 @@
+-- ================================================================
+-- Reminder groups groundwork
+--
+-- 리마인더에도 캘린더와 같은 별도 그룹/멤버 권한 모델을 추가한다.
+-- calendar_groups 와 연동하지 않고 reminder 전용 테이블로 분리한다.
+--
+-- 기존 리마인더 목록은 reminder_group_id = NULL 로 유지하며 가족 전체
+-- 리마인더로 계속 접근 가능하다. 그룹이 지정된 목록은 해당 그룹 멤버만
+-- 접근할 수 있다.
+-- ================================================================
+
+create table reminder_groups (
+  id uuid primary key default gen_random_uuid(),
+  family_id uuid not null references families (id) on delete cascade,
+  created_by uuid references auth.users (id) on delete set null,
+  name text not null,
+  color text not null default '#3b82f6',
+  sort_order integer not null default 0,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (id, family_id)
+);
+
+create table reminder_group_members (
+  reminder_group_id uuid not null references reminder_groups (id) on delete cascade,
+  user_id uuid not null references auth.users (id) on delete cascade,
+  role text not null default 'member' check (role in ('owner', 'member')),
+  created_at timestamptz not null default now(),
+  primary key (reminder_group_id, user_id)
+);
+
+alter table shopping_lists
+  add column reminder_group_id uuid null,
+  add constraint shopping_lists_reminder_group_family_fkey
+    foreign key (reminder_group_id, family_id)
+    references reminder_groups (id, family_id)
+    on delete restrict;
+
+alter table reminder_groups enable row level security;
+alter table reminder_group_members enable row level security;
+
+-- ── SECURITY DEFINER helpers ───────────────────────────────────
+-- RLS 정책에서 family_members / reminder_group_members 중첩 조회가 재귀나
+-- permission denied 로 이어지지 않도록 helper 함수에 캡슐화한다.
+
+create or replace function get_my_reminder_group_ids()
+returns setof uuid
+language sql
+security definer
+stable
+as $$
+  select reminder_group_id
+  from reminder_group_members
+  where user_id = auth.uid()
+$$;
+
+create or replace function get_my_owned_reminder_group_ids()
+returns setof uuid
+language sql
+security definer
+stable
+as $$
+  select reminder_group_id
+  from reminder_group_members
+  where user_id = auth.uid()
+    and role = 'owner'
+$$;
+
+create or replace function is_family_member_of_reminder_group(
+  p_reminder_group_id uuid,
+  p_user_id uuid
+)
+returns boolean
+language sql
+security definer
+stable
+as $$
+  select exists (
+    select 1
+    from reminder_groups rg
+    join family_members fm on fm.family_id = rg.family_id
+    where rg.id = p_reminder_group_id
+      and fm.user_id = p_user_id
+  )
+$$;
+
+create or replace function get_my_list_ids()
+returns setof uuid
+language sql
+security definer
+stable
+as $$
+  select sl.id
+  from shopping_lists sl
+  where
+    (
+      sl.reminder_group_id is null
+      and sl.family_id in (select get_my_family_ids())
+    )
+    or sl.reminder_group_id in (select get_my_reminder_group_ids())
+$$;
+
+create or replace function prevent_reminder_list_scope_change()
+returns trigger
+language plpgsql
+as $$
+begin
+  if new.family_id is distinct from old.family_id
+     or new.reminder_group_id is distinct from old.reminder_group_id then
+    raise exception 'reminder_list_scope_change_not_allowed'
+      using errcode = '42501';
+  end if;
+
+  return new;
+end;
+$$;
+
+create trigger shopping_lists_prevent_scope_change
+before update of family_id, reminder_group_id on shopping_lists
+for each row
+execute function prevent_reminder_list_scope_change();
+
+-- ── reminder_groups RLS ────────────────────────────────────────
+
+create policy "reminder group members can view groups"
+  on reminder_groups for select
+  using (
+    created_by = auth.uid()
+    or id in (select get_my_reminder_group_ids())
+  );
+
+create policy "family members can create reminder groups"
+  on reminder_groups for insert
+  with check (family_id in (select get_my_family_ids()));
+
+create policy "reminder group owners can update groups"
+  on reminder_groups for update
+  using (id in (select get_my_owned_reminder_group_ids()))
+  with check (
+    id in (select get_my_owned_reminder_group_ids())
+    and family_id in (select get_my_family_ids())
+  );
+
+create policy "reminder group owners can delete groups"
+  on reminder_groups for delete
+  using (id in (select get_my_owned_reminder_group_ids()));
+
+-- ── reminder_group_members RLS ─────────────────────────────────
+
+create policy "reminder group members can view members"
+  on reminder_group_members for select
+  using (reminder_group_id in (select get_my_reminder_group_ids()));
+
+create policy "reminder_group_members_insert"
+  on reminder_group_members for insert
+  with check (
+    is_family_member_of_reminder_group(reminder_group_id, user_id)
+    and (
+      (
+        user_id = auth.uid()
+        and role = 'owner'
+        and reminder_group_id in (
+          select id from reminder_groups where created_by = auth.uid()
+        )
+      )
+      or reminder_group_id in (select get_my_owned_reminder_group_ids())
+    )
+  );
+
+create policy "reminder_group_members_update"
+  on reminder_group_members for update
+  using (reminder_group_id in (select get_my_owned_reminder_group_ids()))
+  with check (
+    reminder_group_id in (select get_my_owned_reminder_group_ids())
+    and is_family_member_of_reminder_group(reminder_group_id, user_id)
+  );
+
+create policy "reminder_group_members_delete"
+  on reminder_group_members for delete
+  using (reminder_group_id in (select get_my_owned_reminder_group_ids()));
+
+-- ── shopping RLS 변경 ─────────────────────────────────────────
+-- reminder_group_id = NULL: 가족 전체 리마인더
+-- reminder_group_id != NULL: 해당 리마인더 그룹 멤버만 접근
+-- 접근 범위 변경은 trigger에서 막고, 후속 PR의 명시적 RPC에서만 열어야 한다.
+
+drop policy if exists "family members can manage shopping lists" on shopping_lists;
+drop policy if exists "family members can manage shopping items" on shopping_items;
+
+create policy "members can view reminder lists"
+  on shopping_lists for select
+  using (id in (select get_my_list_ids()));
+
+create policy "members can insert reminder lists"
+  on shopping_lists for insert
+  with check (
+    (
+      reminder_group_id is null
+      and family_id in (select get_my_family_ids())
+    )
+    or reminder_group_id in (select get_my_reminder_group_ids())
+  );
+
+create policy "members can update reminder lists"
+  on shopping_lists for update
+  using (id in (select get_my_list_ids()))
+  with check (
+    (
+      reminder_group_id is null
+      and family_id in (select get_my_family_ids())
+    )
+    or reminder_group_id in (select get_my_reminder_group_ids())
+  );
+
+create policy "members can delete reminder lists"
+  on shopping_lists for delete
+  using (id in (select get_my_list_ids()));
+
+create policy "members can manage reminder items"
+  on shopping_items for all
+  using (list_id in (select get_my_list_ids()))
+  with check (list_id in (select get_my_list_ids()));


### PR DESCRIPTION
## Summary
- 리마인더 전용 그룹/멤버 테이블과 shopping_lists.reminder_group_id 기반을 추가했습니다.
- reminder_group_id가 없는 기존 리마인더는 가족 전체 리마인더로 유지하고, 그룹이 지정된 리마인더는 해당 그룹 멤버만 접근하도록 RLS helper와 정책을 추가했습니다.
- 그룹 멤버 등록 시 같은 family 구성원만 추가되도록 DB helper로 제한했습니다.
- 그룹 삭제가 기존 그룹 전용 리마인더를 가족 전체로 공개하지 않도록 shopping_lists FK를 delete restrict로 두었습니다.
- 그룹 멤버가 직접 reminder_group_id/family_id를 바꿔 목록 공개 범위를 승격하지 못하도록 DB trigger를 추가했습니다.
- 리마인더 그룹 CRUD/멤버 helper를 src/lib/shopping.ts에 추가하고 Supabase 타입을 동기화했습니다.
- 기존 리마인더 생성 경로는 기본적으로 reminder_group_id: null을 사용하도록 유지했습니다.

## Testing
- npm run test -- --runTestsByPath src/__tests__/lib/reminder-groups-sql.test.ts src/__tests__/lib/shopping.test.ts src/__tests__/shopping/ShoppingListCard.test.tsx src/__tests__/shopping/ShoppingTab.test.tsx
- npx tsc --noEmit
- npm run lint (기존 warning 4개만 확인, error 없음)
- supabase db push --linked --dry-run

## Notes
- 이 PR은 1단계 groundwork입니다. 리마인더 그룹 관리 UI와 목록 필터/선택 UI는 후속 PR에서 연결합니다.
- 현재 테스트는 lib mock과 SQL 회귀 테스트 중심입니다. 실제 DB fixture 기반 RLS 시나리오 테스트는 별도 인프라가 필요합니다.