### PR TITLE
feat: add reminder group management UI

### DIFF
--- a/src/__tests__/shopping/ReminderGroupListSheet.test.tsx
+++ b/src/__tests__/shopping/ReminderGroupListSheet.test.tsx
@@ -1,0 +1,193 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ReminderGroupListSheet } from '@/components/shopping/ReminderGroupListSheet'
+import type { ReminderGroup, ReminderGroupMember } from '@/lib/shopping'
+import type { FamilyMember } from '@/lib/calendar'
+
+const mockGetReminderGroupMembers = jest.fn()
+const mockGetReminderGroupMembersForGroups = jest.fn()
+
+jest.mock('@/lib/shopping', () => ({
+  getReminderGroupMembers: (...args: unknown[]) => mockGetReminderGroupMembers(...args),
+  getReminderGroupMembersForGroups: (...args: unknown[]) => mockGetReminderGroupMembersForGroups(...args),
+  REMINDER_GROUP_COLORS: ['#3b82f6', '#22c55e'],
+  REMINDER_GROUP_COLOR_NAMES: {
+    '#3b82f6': '파란색',
+    '#22c55e': '초록색',
+  },
+}))
+
+const groups: ReminderGroup[] = [
+  {
+    id: 'group-1',
+    family_id: 'fam-1',
+    created_by: 'user-1',
+    name: '집',
+    color: '#3b82f6',
+    sort_order: 0,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  },
+]
+
+const familyMembers: FamilyMember[] = [
+  {
+    id: 'member-1',
+    family_id: 'fam-1',
+    user_id: 'user-1',
+    display_name: '나',
+    role: 'admin',
+    created_at: '2026-01-01T00:00:00Z',
+  },
+  {
+    id: 'member-2',
+    family_id: 'fam-1',
+    user_id: 'user-2',
+    display_name: '엄마',
+    role: 'member',
+    created_at: '2026-01-01T00:00:00Z',
+  },
+]
+
+const groupMembers: ReminderGroupMember[] = [
+  {
+    reminder_group_id: 'group-1',
+    user_id: 'user-1',
+    role: 'owner',
+    created_at: '2026-01-01T00:00:00Z',
+  },
+  {
+    reminder_group_id: 'group-1',
+    user_id: 'user-2',
+    role: 'member',
+    created_at: '2026-01-01T00:00:00Z',
+  },
+]
+
+const defaultProps = {
+  groups,
+  familyMembers,
+  currentUserId: 'user-1',
+  onClose: jest.fn(),
+  onCreate: jest.fn().mockResolvedValue(undefined),
+  onSave: jest.fn().mockResolvedValue({ status: 'success' }),
+  onDelete: jest.fn().mockResolvedValue(undefined),
+}
+
+describe('ReminderGroupListSheet', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetReminderGroupMembers.mockResolvedValue(groupMembers)
+    mockGetReminderGroupMembersForGroups.mockResolvedValue(groupMembers)
+    defaultProps.onCreate.mockResolvedValue(undefined)
+    defaultProps.onSave.mockResolvedValue({ status: 'success' })
+    defaultProps.onDelete.mockResolvedValue(undefined)
+  })
+
+  it('그룹 목록을 렌더링한다', async () => {
+    render(<ReminderGroupListSheet {...defaultProps} />)
+
+    expect(screen.getByText('리마인더 그룹')).toBeInTheDocument()
+    expect(screen.getByText('집')).toBeInTheDocument()
+    expect(await screen.findByText('엄')).toBeInTheDocument()
+  })
+
+  it('새로운 그룹 만들기에서 그룹을 생성한다', async () => {
+    const user = userEvent.setup()
+    render(<ReminderGroupListSheet {...defaultProps} />)
+
+    await user.click(screen.getByText('새로운 그룹 만들기'))
+    await user.type(screen.getByPlaceholderText('그룹 이름'), '회사')
+    await user.click(screen.getByRole('button', { name: '저장' }))
+
+    await waitFor(() => {
+      expect(defaultProps.onCreate).toHaveBeenCalledWith('회사', '#22c55e', ['user-2'])
+    })
+  })
+
+  it('새 그룹에서 멤버가 늦게 로드되면 기본 선택을 가족 전체로 갱신한다', async () => {
+    const user = userEvent.setup()
+    const { rerender } = render(
+      <ReminderGroupListSheet
+        {...defaultProps}
+        groups={[]}
+        familyMembers={[]}
+      />
+    )
+
+    await user.click(screen.getByText('새로운 그룹 만들기'))
+
+    rerender(
+      <ReminderGroupListSheet
+        {...defaultProps}
+        groups={[]}
+        familyMembers={familyMembers}
+      />
+    )
+
+    await user.type(screen.getByPlaceholderText('그룹 이름'), '회사')
+    await user.click(screen.getByRole('button', { name: '저장' }))
+
+    await waitFor(() => {
+      expect(defaultProps.onCreate).toHaveBeenCalledWith('회사', '#22c55e', ['user-2'])
+    })
+  })
+
+  it('새 그룹에서 사용자가 멤버 선택을 바꾼 뒤에는 기본 선택을 덮어쓰지 않는다', async () => {
+    const user = userEvent.setup()
+    const { rerender } = render(
+      <ReminderGroupListSheet
+        {...defaultProps}
+        groups={[]}
+        familyMembers={familyMembers}
+      />
+    )
+
+    await user.click(screen.getByText('새로운 그룹 만들기'))
+    await user.click(screen.getByRole('checkbox', { name: '엄마' }))
+
+    rerender(
+      <ReminderGroupListSheet
+        {...defaultProps}
+        groups={[]}
+        familyMembers={familyMembers}
+      />
+    )
+
+    await user.type(screen.getByPlaceholderText('그룹 이름'), '회사')
+    await user.click(screen.getByRole('button', { name: '저장' }))
+
+    await waitFor(() => {
+      expect(defaultProps.onCreate).toHaveBeenCalledWith('회사', '#22c55e', [])
+    })
+  })
+
+  it('기존 그룹 저장 시 변경 값을 전달한다', async () => {
+    const user = userEvent.setup()
+    render(<ReminderGroupListSheet {...defaultProps} />)
+
+    await user.click(screen.getByText('집'))
+    const input = await screen.findByDisplayValue('집')
+    await user.clear(input)
+    await user.type(input, '개인')
+    await user.click(screen.getByRole('button', { name: '저장' }))
+
+    await waitFor(() => {
+      expect(defaultProps.onSave).toHaveBeenCalledWith('group-1', '개인', '#3b82f6', ['user-2'])
+    })
+  })
+
+  it('삭제 확인 후 그룹 삭제를 호출한다', async () => {
+    render(<ReminderGroupListSheet {...defaultProps} />)
+
+    fireEvent.click(screen.getByText('집'))
+    expect(await screen.findByText('그룹 삭제')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('그룹 삭제'))
+    fireEvent.click(screen.getByText('삭제 확인'))
+
+    await waitFor(() => {
+      expect(defaultProps.onDelete).toHaveBeenCalledWith('group-1')
+    })
+  })
+})

--- a/src/__tests__/shopping/ShoppingTab.test.tsx
+++ b/src/__tests__/shopping/ShoppingTab.test.tsx
@@ -4,6 +4,12 @@ import type { User } from '@supabase/supabase-js'
 import { ShoppingTab, clearShoppingTabCache } from '@/components/tabs/ShoppingTab'
 
 const mockCreateShoppingList = jest.fn()
+const mockGetReminderGroups = jest.fn()
+const mockCreateReminderGroup = jest.fn()
+const mockUpdateReminderGroup = jest.fn()
+const mockDeleteReminderGroup = jest.fn()
+const mockSetReminderGroupMembers = jest.fn()
+const mockGetFamilyMembers = jest.fn()
 const mockGetShoppingListsWithPreviews = jest.fn()
 const mockDeleteShoppingList = jest.fn()
 const mockRenameShoppingList = jest.fn()
@@ -16,11 +22,38 @@ let mockListParam: string | null = null
 const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
 
 jest.mock('@/lib/shopping', () => ({
+  getReminderGroups: (...args: unknown[]) => mockGetReminderGroups(...args),
+  createReminderGroup: (...args: unknown[]) => mockCreateReminderGroup(...args),
+  updateReminderGroup: (...args: unknown[]) => mockUpdateReminderGroup(...args),
+  deleteReminderGroup: (...args: unknown[]) => mockDeleteReminderGroup(...args),
+  setReminderGroupMembers: (...args: unknown[]) => mockSetReminderGroupMembers(...args),
   getShoppingListsWithPreviews: (...args: unknown[]) => mockGetShoppingListsWithPreviews(...args),
   createShoppingList: (...args: unknown[]) => mockCreateShoppingList(...args),
   deleteShoppingList: (...args: unknown[]) => mockDeleteShoppingList(...args),
   renameShoppingList: (...args: unknown[]) => mockRenameShoppingList(...args),
   reorderShoppingLists: (...args: unknown[]) => mockReorderShoppingLists(...args),
+}))
+
+jest.mock('@/lib/calendar', () => ({
+  getFamilyMembers: (...args: unknown[]) => mockGetFamilyMembers(...args),
+}))
+
+jest.mock('@/components/shopping/ReminderGroupListSheet', () => ({
+  ReminderGroupListSheet: ({
+    groups,
+    familyMembers,
+    onClose,
+  }: {
+    groups: Array<{ id: string; name: string }>
+    familyMembers: Array<{ user_id: string }>
+    onClose: () => void
+  }) => (
+    <div>
+      <p>groups:{groups.length}</p>
+      <p>members:{familyMembers.length}</p>
+      <button onClick={onClose}>close-groups</button>
+    </div>
+  ),
 }))
 
 jest.mock('@/hooks/useRealtimeSync', () => ({
@@ -80,6 +113,12 @@ describe('ShoppingTab', () => {
     clearShoppingTabCache()
     mockListParam = null
     mockGetShoppingListsWithPreviews.mockResolvedValue([])
+    mockGetReminderGroups.mockResolvedValue([])
+    mockGetFamilyMembers.mockResolvedValue([])
+    mockCreateReminderGroup.mockResolvedValue({ id: 'group-1' })
+    mockUpdateReminderGroup.mockResolvedValue(undefined)
+    mockDeleteReminderGroup.mockResolvedValue(undefined)
+    mockSetReminderGroupMembers.mockResolvedValue(undefined)
   })
 
   afterAll(() => {
@@ -94,6 +133,27 @@ describe('ShoppingTab', () => {
     const calls = mockUseRealtimeSync.mock.calls as unknown as Array<[unknown, unknown, { refreshOnSubscribed?: boolean } | undefined]>
     const options = calls[0]?.[2]
     expect(options?.refreshOnSubscribed).not.toBe(false)
+  })
+
+  it('realtime refresh에서 목록과 그룹을 함께 다시 읽는다', async () => {
+    render(
+      <ShoppingTab user={{ id: 'user-1' } as User} familyId="fam-1" isInitializing={false} />
+    )
+
+    await act(async () => {})
+    const calls = mockUseRealtimeSync.mock.calls as unknown as Array<[unknown, () => void, unknown]>
+    const refreshCallback = calls[0]?.[1]
+    mockGetShoppingListsWithPreviews.mockClear()
+    mockGetReminderGroups.mockClear()
+    mockGetFamilyMembers.mockClear()
+
+    await act(async () => {
+      refreshCallback()
+    })
+
+    expect(mockGetShoppingListsWithPreviews).toHaveBeenCalledWith('fam-1')
+    expect(mockGetReminderGroups).toHaveBeenCalledWith('fam-1')
+    expect(mockGetFamilyMembers).toHaveBeenCalledWith('fam-1')
   })
 
   it('상단 여백을 다른 탭과 같은 압축 기준으로 사용한다', async () => {
@@ -139,6 +199,7 @@ describe('ShoppingTab', () => {
           family_id: 'fam-1',
           created_by: 'user-1',
           name: '첫째 가족 목록',
+          reminder_group_id: null,
           type: 'strikethrough',
           sort_order: 0,
           created_at: '2026-01-01T00:00:00Z',
@@ -172,6 +233,7 @@ describe('ShoppingTab', () => {
         family_id: 'fam-1',
         created_by: 'user-1',
         name: '이마트',
+        reminder_group_id: null,
         type: 'strikethrough',
         sort_order: 0,
         created_at: '2026-01-01T00:00:00Z',
@@ -198,5 +260,58 @@ describe('ShoppingTab', () => {
     await user.click(screen.getByRole('button', { name: 'close-detail' }))
 
     expect(mockReplace).toHaveBeenCalledWith('/calendar?tab=shopping', { scroll: false })
+  })
+
+  it('리마인더 그룹 관리 시트를 연다', async () => {
+    const user = userEvent.setup()
+    const mockUser = { id: 'user-1' } as User
+    mockGetReminderGroups.mockResolvedValueOnce([
+      {
+        id: 'group-1',
+        family_id: 'fam-1',
+        created_by: 'user-1',
+        name: '집',
+        color: '#3b82f6',
+        sort_order: 0,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      },
+    ])
+
+    render(<ShoppingTab user={mockUser} familyId="fam-1" isInitializing={false} />)
+
+    await user.click(await screen.findByLabelText('리마인더 그룹 관리'))
+
+    expect(await screen.findByText('groups:1')).toBeInTheDocument()
+  })
+
+  it('그룹 조회가 실패해도 가족 멤버는 그룹 시트에 전달한다', async () => {
+    const user = userEvent.setup()
+    const mockUser = { id: 'user-1' } as User
+    mockGetReminderGroups.mockRejectedValueOnce(new Error('groups failed'))
+    mockGetFamilyMembers.mockResolvedValueOnce([
+      {
+        id: 'member-1',
+        family_id: 'fam-1',
+        user_id: 'user-1',
+        display_name: '나',
+        role: 'admin',
+        created_at: '2026-01-01T00:00:00Z',
+      },
+      {
+        id: 'member-2',
+        family_id: 'fam-1',
+        user_id: 'user-2',
+        display_name: '엄마',
+        role: 'member',
+        created_at: '2026-01-01T00:00:00Z',
+      },
+    ])
+
+    render(<ShoppingTab user={mockUser} familyId="fam-1" isInitializing={false} />)
+
+    await user.click(await screen.findByLabelText('리마인더 그룹 관리'))
+
+    expect(await screen.findByText('members:2')).toBeInTheDocument()
   })
 })

--- a/src/components/shopping/ReminderGroupListSheet.tsx
+++ b/src/components/shopping/ReminderGroupListSheet.tsx
@@ -1,0 +1,510 @@
+'use client'
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Check, ChevronLeft, Plus, X } from 'lucide-react'
+import {
+  getReminderGroupMembers,
+  getReminderGroupMembersForGroups,
+  REMINDER_GROUP_COLORS,
+  REMINDER_GROUP_COLOR_NAMES,
+  type ReminderGroup,
+  type ReminderGroupMember,
+} from '@/lib/shopping'
+import type { FamilyMember } from '@/lib/calendar'
+import { toDisplayColor } from '@/lib/label-colors'
+
+type SaveResult = { status: 'success' } | { status: 'partial' }
+type View = 'list' | 'detail' | 'new'
+type MemberMap = Record<string, ReminderGroupMember[]>
+
+interface Props {
+  groups: ReminderGroup[]
+  familyMembers: FamilyMember[]
+  currentUserId: string
+  onClose: () => void
+  onCreate: (name: string, color: string, memberIds: string[]) => Promise<void>
+  onSave: (
+    reminderGroupId: string,
+    name: string,
+    color: string,
+    memberIds: string[] | null
+  ) => Promise<SaveResult>
+  onDelete: (reminderGroupId: string) => Promise<void>
+}
+
+export function ReminderGroupListSheet({
+  groups,
+  familyMembers,
+  currentUserId,
+  onClose,
+  onCreate,
+  onSave,
+  onDelete,
+}: Props) {
+  const [memberMap, setMemberMap] = useState<MemberMap>({})
+  const [listWarning, setListWarning] = useState<string | null>(null)
+  const [view, setView] = useState<View>('list')
+  const [selectedGroup, setSelectedGroup] = useState<ReminderGroup | null>(null)
+  const [memberIds, setMemberIds] = useState<string[] | null>(null)
+  const [memberLoadError, setMemberLoadError] = useState(false)
+  const memberLoadSeqRef = useRef(0)
+
+  useEffect(() => {
+    if (groups.length === 0) {
+      return
+    }
+
+    getReminderGroupMembersForGroups(groups.map((group) => group.id))
+      .then((members) => {
+        const nextMap: MemberMap = {}
+        for (const member of members) {
+          if (!nextMap[member.reminder_group_id]) nextMap[member.reminder_group_id] = []
+          nextMap[member.reminder_group_id].push(member)
+        }
+        setMemberMap(nextMap)
+      })
+      .catch((e) => console.error('[ReminderGroupListSheet] load members failed:', e))
+  }, [groups])
+
+  const getMemberName = (userId: string) =>
+    familyMembers.find((member) => member.user_id === userId)?.display_name ?? '?'
+
+  const getInitial = (userId: string) => getMemberName(userId).charAt(0).toUpperCase()
+
+  const handleSelectGroup = (group: ReminderGroup) => {
+    setSelectedGroup(group)
+    setMemberIds(null)
+    setMemberLoadError(false)
+    setListWarning(null)
+    setView('detail')
+
+    const seq = ++memberLoadSeqRef.current
+    getReminderGroupMembers(group.id)
+      .then((members) => {
+        if (seq !== memberLoadSeqRef.current) return
+        setMemberIds(members.map((member) => member.user_id))
+      })
+      .catch((e) => {
+        if (seq !== memberLoadSeqRef.current) return
+        console.error('[ReminderGroupListSheet] getReminderGroupMembers failed:', e)
+        setMemberLoadError(true)
+      })
+  }
+
+  const handleNewGroup = () => {
+    setSelectedGroup(null)
+    setMemberIds([])
+    setMemberLoadError(false)
+    setListWarning(null)
+    setView('new')
+  }
+
+  const handleBack = () => {
+    setView('list')
+    setSelectedGroup(null)
+    setMemberIds(null)
+    setMemberLoadError(false)
+  }
+
+  const handleSave = async (
+    reminderGroupId: string,
+    name: string,
+    color: string,
+    nextMemberIds: string[] | null
+  ): Promise<SaveResult> => {
+    const result = await onSave(reminderGroupId, name, color, nextMemberIds)
+    if (result.status === 'partial') {
+      setListWarning('그룹 정보는 저장됐지만 멤버는 저장하지 못했어요')
+    }
+    return result
+  }
+
+  return (
+    <div className="fixed inset-0 z-[70] bg-white dark:bg-stone-950 overflow-hidden">
+      {view === 'list' && (
+        <div className="flex h-full flex-col">
+          <div className="flex shrink-0 items-center justify-between px-4 pt-12 pb-4">
+            <h1 className="text-xl font-bold text-stone-800 dark:text-stone-100">리마인더 그룹</h1>
+            <button
+              onClick={onClose}
+              aria-label="닫기"
+              className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-xl text-stone-400 transition-colors hover:bg-stone-100 hover:text-stone-600 dark:hover:bg-stone-800 dark:hover:text-stone-300"
+            >
+              <X size={22} />
+            </button>
+          </div>
+
+          <div className="flex-1 overflow-y-auto px-4 pb-safe space-y-2">
+            {listWarning && (
+              <div className="mb-1 rounded-xl border border-amber-100 bg-amber-50 px-4 py-3 text-sm text-amber-600 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-400">
+                {listWarning}
+              </div>
+            )}
+
+            <p className="text-xs text-stone-400 dark:text-stone-500 mb-3">
+              그룹 ({groups.length})
+            </p>
+
+            {groups.map((group) => {
+              const members = memberMap[group.id] ?? []
+              const visibleMembers = members.slice(0, 3)
+              const overflow = members.length - visibleMembers.length
+              const displayColor = toDisplayColor(group.color)
+
+              return (
+                <button
+                  key={group.id}
+                  onClick={() => handleSelectGroup(group)}
+                  className="w-full flex items-center gap-4 rounded-2xl p-3 text-left transition-colors hover:bg-stone-50 dark:hover:bg-stone-900"
+                >
+                  <div
+                    className="h-16 w-16 shrink-0 rounded-2xl"
+                    style={{ backgroundColor: displayColor }}
+                  />
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate font-semibold text-stone-800 dark:text-stone-100">
+                      {group.name}
+                    </p>
+                    {members.length > 0 && (
+                      <div className="mt-1.5 flex items-center gap-1">
+                        <div className="flex -space-x-1.5">
+                          {visibleMembers.map((member) => (
+                            <div
+                              key={member.user_id}
+                              className="flex h-6 w-6 items-center justify-center rounded-full text-[10px] font-bold text-white ring-2 ring-white dark:ring-stone-950"
+                              style={{ backgroundColor: displayColor }}
+                              title={getMemberName(member.user_id)}
+                            >
+                              {getInitial(member.user_id)}
+                            </div>
+                          ))}
+                          {overflow > 0 && (
+                            <div className="flex h-6 w-6 items-center justify-center rounded-full bg-stone-300 text-[10px] font-bold text-stone-600 ring-2 ring-white dark:bg-stone-600 dark:text-stone-300 dark:ring-stone-950">
+                              +{overflow}
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                  <span className="text-lg text-stone-300 dark:text-stone-600">›</span>
+                </button>
+              )
+            })}
+
+            <button
+              onClick={handleNewGroup}
+              className="w-full flex items-center gap-4 rounded-2xl p-3 text-left transition-colors hover:bg-stone-50 dark:hover:bg-stone-900"
+            >
+              <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-2xl bg-stone-100 dark:bg-stone-800">
+                <Plus size={28} className="text-stone-400 dark:text-stone-500" />
+              </div>
+              <p className="font-medium text-stone-400 dark:text-stone-500">새로운 그룹 만들기</p>
+            </button>
+          </div>
+        </div>
+      )}
+
+      {view === 'detail' && selectedGroup && (
+        <ReminderGroupDetailScreen
+          group={selectedGroup}
+          memberIds={memberIds}
+          memberLoadError={memberLoadError}
+          familyMembers={familyMembers}
+          currentUserId={currentUserId}
+          onBack={handleBack}
+          onSave={handleSave}
+          onDelete={onDelete}
+        />
+      )}
+
+      {view === 'new' && (
+        <ReminderGroupDetailScreen
+          group={null}
+          memberIds={[]}
+          memberLoadError={false}
+          familyMembers={familyMembers}
+          currentUserId={currentUserId}
+          onBack={handleBack}
+          onCreate={onCreate}
+        />
+      )}
+    </div>
+  )
+}
+
+interface DetailProps {
+  group: ReminderGroup | null
+  memberIds: string[] | null
+  memberLoadError: boolean
+  familyMembers: FamilyMember[]
+  currentUserId: string
+  onBack: () => void
+  onCreate?: (name: string, color: string, memberIds: string[]) => Promise<void>
+  onSave?: (
+    reminderGroupId: string,
+    name: string,
+    color: string,
+    memberIds: string[] | null
+  ) => Promise<SaveResult>
+  onDelete?: (reminderGroupId: string) => Promise<void>
+}
+
+function ReminderGroupDetailScreen({
+  group,
+  memberIds,
+  memberLoadError,
+  familyMembers,
+  currentUserId,
+  onBack,
+  onCreate,
+  onSave,
+  onDelete,
+}: DetailProps) {
+  const [name, setName] = useState(group?.name ?? '')
+  const [color, setColor] = useState(group?.color ?? REMINDER_GROUP_COLORS[1])
+  const selectableMembers = useMemo(
+    () => familyMembers.filter((member) => member.user_id !== currentUserId),
+    [familyMembers, currentUserId]
+  )
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(() => {
+    if (group) return new Set()
+    return new Set(selectableMembers.map((member) => member.user_id))
+  })
+  const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+  const [confirmDelete, setConfirmDelete] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
+  const touchedMemberSelectionRef = useRef(false)
+
+  useEffect(() => {
+    if (!group || memberIds === null) return
+    setSelectedIds(new Set(memberIds.filter((id) => id !== currentUserId)))
+  }, [group, memberIds, currentUserId])
+
+  useEffect(() => {
+    if (group || touchedMemberSelectionRef.current) return
+    setSelectedIds(new Set(selectableMembers.map((member) => member.user_id)))
+  }, [group, selectableMembers])
+
+  const membersStillLoading = memberIds === null && !memberLoadError
+  const isSaveDisabled = membersStillLoading || saving || !name.trim()
+
+  const toggleMember = (userId: string) => {
+    touchedMemberSelectionRef.current = true
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(userId)) next.delete(userId)
+      else next.add(userId)
+      return next
+    })
+  }
+
+  const handleSave = async () => {
+    if (isSaveDisabled) return
+
+    setSaving(true)
+    setSaveError(null)
+    try {
+      if (group) {
+        const memberIdsToSave = memberLoadError || memberIds === null
+          ? null
+          : Array.from(selectedIds)
+        await onSave?.(group.id, name.trim(), color, memberIdsToSave)
+      } else {
+        await onCreate?.(name.trim(), color, Array.from(selectedIds))
+      }
+      onBack()
+    } catch (e) {
+      console.error('[ReminderGroupDetailScreen] save failed:', e)
+      setSaveError('저장에 실패했습니다. 다시 시도해주세요.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (!group || !onDelete) return
+    if (!confirmDelete) {
+      setConfirmDelete(true)
+      return
+    }
+
+    setDeleting(true)
+    setDeleteError(null)
+    try {
+      await onDelete(group.id)
+      onBack()
+    } catch (e) {
+      console.error('[ReminderGroupDetailScreen] delete failed:', e)
+      setDeleteError('그룹에 포함된 리마인더가 있으면 삭제할 수 없어요.')
+      setConfirmDelete(false)
+    } finally {
+      setDeleting(false)
+    }
+  }
+
+  return (
+    <div className="absolute inset-0 flex flex-col overflow-hidden bg-stone-50 dark:bg-stone-950">
+      <div className="flex shrink-0 items-center gap-1 bg-stone-50 px-4 pt-12 pb-4 dark:bg-stone-950">
+        <button
+          onClick={onBack}
+          aria-label="뒤로"
+          className="-ml-2.5 flex min-h-[44px] min-w-[44px] items-center justify-center rounded-xl text-stone-500 transition-colors hover:bg-stone-100 dark:text-stone-400 dark:hover:bg-stone-800"
+        >
+          <ChevronLeft size={22} />
+        </button>
+        <h1 className="truncate text-xl font-bold text-stone-800 dark:text-stone-100">
+          {group ? group.name : '새 그룹'}
+        </h1>
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-4 pb-safe space-y-4">
+        <div className="rounded-2xl border border-stone-100 bg-white p-4 dark:border-stone-800 dark:bg-stone-900">
+          <p className="mb-3 text-xs font-semibold uppercase tracking-wide text-stone-400 dark:text-stone-500">
+            기본 정보
+          </p>
+
+          <div className="mb-4">
+            <label className="mb-1.5 block text-xs text-stone-500 dark:text-stone-400">이름</label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="그룹 이름"
+              maxLength={30}
+              className="w-full rounded-xl border border-stone-200 bg-stone-50 px-3 py-2.5 text-sm text-stone-800 placeholder:text-stone-400 focus:outline-none focus:ring-2 focus:ring-accent-400 dark:border-stone-700 dark:bg-stone-800 dark:text-stone-100"
+            />
+          </div>
+
+          <div>
+            <label className="mb-2 block text-xs text-stone-500 dark:text-stone-400">색상</label>
+            <div className="flex flex-wrap gap-1">
+              {REMINDER_GROUP_COLORS.map((nextColor) => (
+                <button
+                  key={nextColor}
+                  onClick={() => setColor(nextColor)}
+                  aria-pressed={color === nextColor}
+                  aria-label={REMINDER_GROUP_COLOR_NAMES[nextColor] ?? nextColor}
+                  className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-full transition-transform"
+                >
+                  <span
+                    className="block h-8 w-8 rounded-full"
+                    style={{
+                      backgroundColor: toDisplayColor(nextColor),
+                      transform: color === nextColor ? 'scale(1.25)' : 'scale(1)',
+                      outline: color === nextColor ? `2px solid ${toDisplayColor(nextColor)}` : 'none',
+                      outlineOffset: '2px',
+                      transition: 'transform 150ms ease-out',
+                    }}
+                  />
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {selectableMembers.length > 0 && (
+          <div className="rounded-2xl border border-stone-100 bg-white p-4 dark:border-stone-800 dark:bg-stone-900">
+            <p className="mb-3 text-xs font-semibold uppercase tracking-wide text-stone-400 dark:text-stone-500">
+              멤버
+            </p>
+
+            {membersStillLoading && (
+              <div className="flex items-center gap-2 py-2">
+                <div className="h-4 w-4 shrink-0 animate-spin rounded-full border-2 border-accent-300 border-t-accent-500" />
+                <p className="text-sm text-stone-400 dark:text-stone-500">멤버 정보를 불러오는 중...</p>
+              </div>
+            )}
+
+            {memberLoadError && (
+              <p className="text-sm text-stone-400 dark:text-stone-500">
+                멤버 정보를 불러오지 못했어요. 이번 저장에는 멤버 변경이 반영되지 않습니다.
+              </p>
+            )}
+
+            {!membersStillLoading && !memberLoadError && (
+              <div className="space-y-2">
+                {selectableMembers.map((member) => {
+                  const selected = selectedIds.has(member.user_id)
+                  return (
+                    <button
+                      key={member.user_id}
+                      onClick={() => toggleMember(member.user_id)}
+                      role="checkbox"
+                      aria-checked={selected}
+                      className={`w-full flex items-center gap-3 rounded-xl border px-3 py-2.5 transition-colors ${
+                        selected
+                          ? 'border-accent-300 bg-accent-50 dark:border-accent-700 dark:bg-accent-950/30'
+                          : 'border-stone-200 bg-stone-50 hover:bg-stone-100 dark:border-stone-700 dark:bg-stone-800 dark:hover:bg-stone-700'
+                      }`}
+                    >
+                      <div
+                        className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2 transition-colors ${
+                          selected
+                            ? 'border-accent-400 bg-accent-400'
+                            : 'border-stone-300 dark:border-stone-600'
+                        }`}
+                      >
+                        {selected && <Check size={12} className="text-white" />}
+                      </div>
+                      <span className="text-sm font-medium text-stone-800 dark:text-stone-100">
+                        {member.display_name}
+                      </span>
+                    </button>
+                  )
+                })}
+              </div>
+            )}
+          </div>
+        )}
+
+        <div>
+          {saveError && <p className="mb-2 text-center text-xs text-red-400">{saveError}</p>}
+          <button
+            onClick={() => void handleSave()}
+            disabled={isSaveDisabled}
+            className="w-full rounded-2xl bg-accent-400 py-3 text-sm font-semibold text-white transition-colors hover:bg-accent-500 disabled:opacity-40"
+          >
+            {saving ? '저장 중...' : '저장'}
+          </button>
+        </div>
+
+        {group && onDelete && (
+          <div className="rounded-2xl border border-red-100 p-4 dark:border-red-900/40">
+            <p className="mb-3 text-xs font-semibold uppercase tracking-wide text-red-400 dark:text-red-500">
+              위험 구역
+            </p>
+            {deleteError && <p className="mb-2 text-xs text-red-400">{deleteError}</p>}
+            {confirmDelete ? (
+              <div className="flex gap-2">
+                <button
+                  onClick={() => setConfirmDelete(false)}
+                  disabled={deleting}
+                  className="flex-1 rounded-xl bg-stone-100 py-2.5 text-sm font-semibold text-stone-600 transition-colors hover:bg-stone-200 dark:bg-stone-800 dark:text-stone-300 dark:hover:bg-stone-700"
+                >
+                  취소
+                </button>
+                <button
+                  onClick={() => void handleDelete()}
+                  disabled={deleting}
+                  className="flex-1 rounded-xl bg-red-500 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-red-600 disabled:opacity-50"
+                >
+                  {deleting ? '삭제 중...' : '삭제 확인'}
+                </button>
+              </div>
+            ) : (
+              <button
+                onClick={() => void handleDelete()}
+                className="w-full rounded-xl border border-red-200 py-2.5 text-sm font-semibold text-red-500 transition-colors hover:bg-red-50 dark:border-red-800 dark:hover:bg-red-950/30"
+              >
+                그룹 삭제
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/tabs/ShoppingTab.tsx
+++ b/src/components/tabs/ShoppingTab.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { Plus, ListChecks, AlertTriangle } from 'lucide-react'
+import { Plus, ListChecks, AlertTriangle, ListFilter } from 'lucide-react'
 import {
   DndContext,
   PointerSensor,
@@ -14,17 +14,24 @@ import {
 import { SortableContext, arrayMove, rectSortingStrategy } from '@dnd-kit/sortable'
 import type { AuthState } from '@/types/tabs'
 import {
+  getReminderGroups,
+  createReminderGroup,
+  updateReminderGroup,
+  deleteReminderGroup,
+  setReminderGroupMembers,
   getShoppingListsWithPreviews,
   createShoppingList,
   deleteShoppingList,
   renameShoppingList,
   reorderShoppingLists,
 } from '@/lib/shopping'
+import { getFamilyMembers, type FamilyMember } from '@/lib/calendar'
 import { ShoppingListCard } from '@/components/shopping/ShoppingListCard'
 import { ShoppingDetailView } from '@/components/shopping/ShoppingDetailView'
 import { CreateListModal } from '@/components/shopping/CreateListModal'
+import { ReminderGroupListSheet } from '@/components/shopping/ReminderGroupListSheet'
 import { useRealtimeSync } from '@/hooks/useRealtimeSync'
-import type { ShoppingListWithPreview, ListType, ShoppingItem } from '@/lib/shopping'
+import type { ShoppingListWithPreview, ListType, ShoppingItem, ReminderGroup } from '@/lib/shopping'
 
 // 라우트 이동으로 컴포넌트가 언마운트되어도 데이터를 유지하는 세션 캐시.
 const cachedListsByFamily = new Map<string, ShoppingListWithPreview[]>()
@@ -47,8 +54,11 @@ export function ShoppingTab({ user, familyId, isInitializing }: Props) {
     () => getCachedLists(familyId) ?? []
   )
   const [fetchError, setFetchError] = useState(false)
+  const [groups, setGroups] = useState<ReminderGroup[]>([])
+  const [familyMembers, setFamilyMembers] = useState<FamilyMember[]>([])
   const [mutationError, setMutationError] = useState<string | null>(null)
   const [showModal, setShowModal] = useState(false)
+  const [showGroupList, setShowGroupList] = useState(false)
 
   const activeListId = useMemo(() => {
     const raw = searchParams.get('list')?.trim()
@@ -87,11 +97,41 @@ export function ShoppingTab({ user, familyId, isInitializing }: Props) {
       })
   }, [familyId, updateLists])
 
-  const broadcast = useRealtimeSync(familyId ? `family_lists_${familyId}` : null, refresh)
+  const refreshGroups = useCallback(() => {
+    if (!familyId) return Promise.resolve()
+    return Promise.allSettled([getReminderGroups(familyId), getFamilyMembers(familyId)])
+      .then(([groupsResult, membersResult]) => {
+        if (groupsResult.status === 'fulfilled') {
+          setGroups(groupsResult.value)
+        } else {
+          console.error('[ShoppingTab] getReminderGroups failed:', groupsResult.reason)
+        }
+
+        if (membersResult.status === 'fulfilled') {
+          setFamilyMembers(membersResult.value)
+        } else {
+          console.error('[ShoppingTab] getFamilyMembers failed:', membersResult.reason)
+        }
+      })
+  }, [familyId])
+
+  const refreshShoppingData = useCallback(() => {
+    refresh()
+    void refreshGroups()
+  }, [refresh, refreshGroups])
+
+  const broadcast = useRealtimeSync(
+    familyId ? `family_lists_${familyId}` : null,
+    refreshShoppingData
+  )
 
   useEffect(() => {
     refresh()
   }, [refresh])
+
+  useEffect(() => {
+    void refreshGroups()
+  }, [refreshGroups])
 
   const handleCreate = async (name: string, type: ListType): Promise<boolean> => {
     if (!familyId || !user) return false
@@ -152,6 +192,53 @@ export function ShoppingTab({ user, familyId, isInitializing }: Props) {
       updateLists(previousLists)
       setMutationError('목록 이름을 저장하지 못했어요')
     }
+  }
+
+  const handleGroupCreate = async (
+    name: string,
+    color: string,
+    memberIds: string[]
+  ): Promise<void> => {
+    if (!familyId || !user) return
+    setMutationError(null)
+    await createReminderGroup(familyId, user.id, name, color, memberIds)
+    await refreshGroups()
+    broadcast()
+  }
+
+  const handleGroupSave = async (
+    reminderGroupId: string,
+    name: string,
+    color: string,
+    memberIds: string[] | null
+  ): Promise<{ status: 'success' } | { status: 'partial' }> => {
+    setMutationError(null)
+    await updateReminderGroup(reminderGroupId, { name, color })
+
+    if (memberIds === null || !user) {
+      await refreshGroups()
+      broadcast()
+      return { status: 'success' }
+    }
+
+    try {
+      await setReminderGroupMembers(reminderGroupId, user.id, memberIds)
+      await refreshGroups()
+      broadcast()
+      return { status: 'success' }
+    } catch (e) {
+      console.error('[ShoppingTab] setReminderGroupMembers failed:', e)
+      await refreshGroups()
+      broadcast()
+      return { status: 'partial' }
+    }
+  }
+
+  const handleGroupDelete = async (reminderGroupId: string): Promise<void> => {
+    setMutationError(null)
+    await deleteReminderGroup(reminderGroupId)
+    await refreshGroups()
+    broadcast()
   }
 
   const handleDragEnd = async (event: DragEndEvent) => {
@@ -228,7 +315,9 @@ export function ShoppingTab({ user, familyId, isInitializing }: Props) {
         lists={lists}
         fetchError={fetchError}
         mutationError={mutationError}
+        groupCount={groups.length}
         sensors={sensors}
+        onGroupManageClick={() => setShowGroupList(true)}
         onCreateClick={() => setShowModal(true)}
         onDelete={handleDelete}
         onRename={handleRename}
@@ -238,6 +327,18 @@ export function ShoppingTab({ user, familyId, isInitializing }: Props) {
 
       {showModal && (
         <CreateListModal onClose={() => setShowModal(false)} onCreate={handleCreate} />
+      )}
+
+      {showGroupList && user && (
+        <ReminderGroupListSheet
+          groups={groups}
+          familyMembers={familyMembers}
+          currentUserId={user.id}
+          onClose={() => setShowGroupList(false)}
+          onCreate={handleGroupCreate}
+          onSave={handleGroupSave}
+          onDelete={handleGroupDelete}
+        />
       )}
 
       {user && activeListId && (
@@ -257,7 +358,9 @@ interface ShoppingListViewProps {
   lists: ShoppingListWithPreview[]
   fetchError: boolean
   mutationError: string | null
+  groupCount: number
   sensors: ReturnType<typeof useSensors>
+  onGroupManageClick: () => void
   onCreateClick: () => void
   onDelete: (listId: string) => void
   onRename: (listId: string, name: string) => void
@@ -269,7 +372,9 @@ function ShoppingListView({
   lists,
   fetchError,
   mutationError,
+  groupCount,
   sensors,
+  onGroupManageClick,
   onCreateClick,
   onDelete,
   onRename,
@@ -285,13 +390,25 @@ function ShoppingListView({
             {lists.length > 0 ? `${lists.length}개의 목록` : '리마인더를 만들어보세요'}
           </p>
         </div>
-        <button
-          onClick={onCreateClick}
-          className="w-11 h-11 flex items-center justify-center rounded-full bg-accent-400 hover:bg-accent-500 text-white shadow-sm transition-colors"
-          aria-label="새 리마인더 추가"
-        >
-          <Plus size={20} />
-        </button>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={onGroupManageClick}
+            className="relative w-11 h-11 flex items-center justify-center rounded-full border border-stone-200 text-stone-400 transition-colors hover:bg-stone-50 hover:text-stone-600 dark:border-stone-700 dark:text-stone-500 dark:hover:bg-stone-900 dark:hover:text-stone-300"
+            aria-label="리마인더 그룹 관리"
+          >
+            <ListFilter size={19} />
+            {groupCount > 0 && (
+              <span className="absolute right-1.5 top-1.5 h-2 w-2 rounded-full bg-accent-400" />
+            )}
+          </button>
+          <button
+            onClick={onCreateClick}
+            className="w-11 h-11 flex items-center justify-center rounded-full bg-accent-400 hover:bg-accent-500 text-white shadow-sm transition-colors"
+            aria-label="새 리마인더 추가"
+          >
+            <Plus size={20} />
+          </button>
+        </div>
       </div>
 
       {mutationError && (


### PR DESCRIPTION
## Summary
- 리마인더 탭에 그룹 관리 진입 버튼을 추가했습니다.
- 리마인더 그룹 리스트/생성/수정/삭제 화면을 추가했습니다.
- 그룹 색상과 멤버 선택 UI를 추가했습니다.
- 그룹 저장 시 멤버 저장 실패는 partial 경고로 표시하도록 처리했습니다.
- realtime refresh 수신 시 리마인더 목록과 그룹 데이터를 함께 다시 읽도록 했습니다.
- 새 그룹 화면에서 가족 멤버 로드가 늦게 끝나도 기본 멤버 선택이 갱신되도록 했습니다.
- 그룹 조회가 실패해도 가족 멤버 조회 결과는 그룹 화면에 반영되도록 로드를 분리했습니다.
- 이번 PR은 그룹 자체 관리 UI까지만 포함하며, 리마인더 목록에 그룹을 배정하거나 필터링하는 동작은 후속 PR에서 연결합니다.

## Testing
- npm run test -- --runTestsByPath src/__tests__/shopping/ReminderGroupListSheet.test.tsx src/__tests__/shopping/ShoppingTab.test.tsx src/__tests__/lib/shopping.test.ts
- npx tsc --noEmit
- npm run lint (기존 warning 4개만 확인, error 없음)

## Manual Testing
- [x] 리마인더 탭에서 그룹 관리 버튼을 눌러 리마인더 그룹 화면이 열리는지 확인합니다.
- [x] 새 그룹을 만들고 이름/색상/멤버 선택이 저장되는지 확인합니다.
- [x] 기존 그룹의 이름/색상/멤버를 수정할 수 있는지 확인합니다.
- [x] 그룹 삭제 확인 UI가 동작하는지 확인합니다.

## Notes
- PR #164의 Supabase migration은 linked DB에 적용했습니다.