### PR TITLE
feat: apply reminder groups to lists

### DIFF
--- a/src/__tests__/lib/reminder-groups-sql.test.ts
+++ b/src/__tests__/lib/reminder-groups-sql.test.ts
@@ -9,9 +9,14 @@ const ownerAccessMigrationPath = path.join(
   process.cwd(),
   'supabase/migrations/20260509000000_fix_reminder_group_owner_access.sql'
 )
+const createListMigrationPath = path.join(
+  process.cwd(),
+  'supabase/migrations/20260509001000_create_shopping_list_authorized.sql'
+)
 
 const sql = () => fs.readFileSync(migrationPath, 'utf8')
 const ownerAccessSql = () => fs.readFileSync(ownerAccessMigrationPath, 'utf8')
+const createListSql = () => fs.readFileSync(createListMigrationPath, 'utf8')
 
 describe('reminder groups migration', () => {
   it('does not expose grouped lists by clearing reminder_group_id on group delete', () => {
@@ -47,5 +52,17 @@ describe('reminder groups migration', () => {
     expect(migration).toContain('select id')
     expect(migration).toContain('from reminder_groups')
     expect(migration).toContain('where created_by = auth.uid()')
+  })
+
+  it('creates reminder lists through an authorized RPC', () => {
+    const migration = createListSql()
+
+    expect(migration).toContain('create or replace function create_shopping_list_authorized')
+    expect(migration).toContain('v_actor_id uuid := auth.uid()')
+    expect(migration).toContain('from family_members fm')
+    expect(migration).toContain('from reminder_groups rg')
+    expect(migration).toContain('from reminder_group_members rgm')
+    expect(migration).toContain('insert into shopping_lists')
+    expect(migration).toContain('grant execute on function create_shopping_list_authorized')
   })
 })

--- a/src/__tests__/lib/reminder-groups-sql.test.ts
+++ b/src/__tests__/lib/reminder-groups-sql.test.ts
@@ -13,10 +13,15 @@ const createListMigrationPath = path.join(
   process.cwd(),
   'supabase/migrations/20260509001000_create_shopping_list_authorized.sql'
 )
+const lockDirectInsertMigrationPath = path.join(
+  process.cwd(),
+  'supabase/migrations/20260509002000_lock_shopping_list_direct_insert.sql'
+)
 
 const sql = () => fs.readFileSync(migrationPath, 'utf8')
 const ownerAccessSql = () => fs.readFileSync(ownerAccessMigrationPath, 'utf8')
 const createListSql = () => fs.readFileSync(createListMigrationPath, 'utf8')
+const lockDirectInsertSql = () => fs.readFileSync(lockDirectInsertMigrationPath, 'utf8')
 
 describe('reminder groups migration', () => {
   it('does not expose grouped lists by clearing reminder_group_id on group delete', () => {
@@ -64,5 +69,13 @@ describe('reminder groups migration', () => {
     expect(migration).toContain('from reminder_group_members rgm')
     expect(migration).toContain('insert into shopping_lists')
     expect(migration).toContain('grant execute on function create_shopping_list_authorized')
+  })
+
+  it('blocks direct shopping list inserts outside the authorized RPC', () => {
+    const migration = lockDirectInsertSql()
+
+    expect(migration).toContain('drop policy if exists "members can insert reminder lists"')
+    expect(migration).toContain('on shopping_lists for insert')
+    expect(migration).toContain('with check (false)')
   })
 })

--- a/src/__tests__/lib/reminder-groups-sql.test.ts
+++ b/src/__tests__/lib/reminder-groups-sql.test.ts
@@ -5,8 +5,13 @@ const migrationPath = path.join(
   process.cwd(),
   'supabase/migrations/20260508000000_reminder_groups_groundwork.sql'
 )
+const ownerAccessMigrationPath = path.join(
+  process.cwd(),
+  'supabase/migrations/20260509000000_fix_reminder_group_owner_access.sql'
+)
 
 const sql = () => fs.readFileSync(migrationPath, 'utf8')
+const ownerAccessSql = () => fs.readFileSync(ownerAccessMigrationPath, 'utf8')
 
 describe('reminder groups migration', () => {
   it('does not expose grouped lists by clearing reminder_group_id on group delete', () => {
@@ -31,5 +36,16 @@ describe('reminder groups migration', () => {
     expect(migration).toContain('create or replace function get_my_reminder_group_ids()')
     expect(migration).toContain('create or replace function get_my_list_ids()')
     expect(migration).toContain('sl.reminder_group_id in (select get_my_reminder_group_ids())')
+  })
+
+  it('backfills group owners and includes created groups in access helpers', () => {
+    const migration = ownerAccessSql()
+
+    expect(migration).toContain('insert into reminder_group_members')
+    expect(migration).toContain('from reminder_groups rg')
+    expect(migration).toContain('on conflict (reminder_group_id, user_id) do update')
+    expect(migration).toContain('select id')
+    expect(migration).toContain('from reminder_groups')
+    expect(migration).toContain('where created_by = auth.uid()')
   })
 })

--- a/src/__tests__/lib/shopping.test.ts
+++ b/src/__tests__/lib/shopping.test.ts
@@ -36,14 +36,19 @@ function makeChain(result: { data: unknown; error: unknown }) {
 }
 
 const mockFrom = jest.fn()
+const mockRpc = jest.fn()
 
 jest.mock('@/lib/supabase', () => ({
-  supabase: { from: (...args: unknown[]) => mockFrom(...args) },
+  supabase: {
+    from: (...args: unknown[]) => mockFrom(...args),
+    rpc: (...args: unknown[]) => mockRpc(...args),
+  },
 }))
 
 beforeEach(() => {
   jest.clearAllMocks()
   mockFrom.mockImplementation(() => makeChain({ data: null, error: null }))
+  mockRpc.mockResolvedValue({ data: null, error: null })
 })
 
 describe('getReminderGroups', () => {
@@ -198,9 +203,16 @@ describe('getShoppingLists', () => {
 describe('createShoppingList', () => {
   it('생성된 리스트를 반환한다', async () => {
     const mockList = { id: 'list-1', name: '이마트', type: 'strikethrough' }
-    mockFrom.mockReturnValue(makeChain({ data: mockList, error: null }))
+    mockRpc.mockResolvedValueOnce({ data: mockList, error: null })
     const result = await createShoppingList('fam-1', 'user-1', '이마트', 'strikethrough')
     expect(result).toEqual(mockList)
+    expect(mockRpc).toHaveBeenCalledWith('create_shopping_list_authorized', {
+      p_actor_user_id: 'user-1',
+      p_family_id: 'fam-1',
+      p_name: '이마트',
+      p_type: 'strikethrough',
+      p_reminder_group_id: null,
+    })
   })
 
   it('리마인더 그룹 id를 함께 저장할 수 있다', async () => {
@@ -210,8 +222,7 @@ describe('createShoppingList', () => {
       type: 'strikethrough',
       reminder_group_id: 'group-1',
     }
-    const chain = makeChain({ data: mockList, error: null })
-    mockFrom.mockReturnValue(chain)
+    mockRpc.mockResolvedValueOnce({ data: mockList, error: null })
 
     const result = await createShoppingList(
       'fam-1',
@@ -222,17 +233,17 @@ describe('createShoppingList', () => {
     )
 
     expect(result).toEqual(mockList)
-    expect(chain.insert).toHaveBeenCalledWith({
-      family_id: 'fam-1',
-      created_by: 'user-1',
-      name: '이마트',
-      type: 'strikethrough',
-      reminder_group_id: 'group-1',
+    expect(mockRpc).toHaveBeenCalledWith('create_shopping_list_authorized', {
+      p_actor_user_id: 'user-1',
+      p_family_id: 'fam-1',
+      p_name: '이마트',
+      p_type: 'strikethrough',
+      p_reminder_group_id: 'group-1',
     })
   })
 
   it('error가 있으면 throw한다', async () => {
-    mockFrom.mockReturnValue(makeChain({ data: null, error: { message: 'insert error' } }))
+    mockRpc.mockResolvedValueOnce({ data: null, error: { message: 'insert error' } })
     await expect(createShoppingList('fam-1', 'user-1', '이마트', 'strikethrough')).rejects.toEqual({ message: 'insert error' })
   })
 })

--- a/src/__tests__/shopping/CreateListModal.test.tsx
+++ b/src/__tests__/shopping/CreateListModal.test.tsx
@@ -30,7 +30,39 @@ describe('CreateListModal', () => {
     fireEvent.click(screen.getByRole('button', { name: '만들기' }))
 
     await waitFor(() => {
-      expect(onCreate).toHaveBeenCalledWith('이마트', 'strikethrough')
+      expect(onCreate).toHaveBeenCalledWith('이마트', 'strikethrough', null)
+    })
+  })
+
+  it('그룹 선택 후 생성하면 선택한 그룹 id를 전달한다', async () => {
+    const onCreate = jest.fn().mockResolvedValue(true)
+    render(
+      <CreateListModal
+        groups={[
+          {
+            id: 'group-1',
+            family_id: 'fam-1',
+            created_by: 'user-1',
+            name: '집',
+            color: '#3b82f6',
+            sort_order: 0,
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z',
+          },
+        ]}
+        onClose={jest.fn()}
+        onCreate={onCreate}
+      />
+    )
+
+    fireEvent.change(screen.getByPlaceholderText('예: 이마트, 코스트코'), {
+      target: { value: '이마트' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: '집' }))
+    fireEvent.click(screen.getByRole('button', { name: '만들기' }))
+
+    await waitFor(() => {
+      expect(onCreate).toHaveBeenCalledWith('이마트', 'strikethrough', 'group-1')
     })
   })
 

--- a/src/__tests__/shopping/ReminderGroupListSheet.test.tsx
+++ b/src/__tests__/shopping/ReminderGroupListSheet.test.tsx
@@ -190,4 +190,19 @@ describe('ReminderGroupListSheet', () => {
       expect(defaultProps.onDelete).toHaveBeenCalledWith('group-1')
     })
   })
+
+  it('그룹 삭제 실패 시 리마인더가 있으면 삭제할 수 없다는 안내를 표시한다', async () => {
+    defaultProps.onDelete.mockRejectedValueOnce(new Error('delete restricted'))
+    render(<ReminderGroupListSheet {...defaultProps} />)
+
+    fireEvent.click(screen.getByText('집'))
+    expect(await screen.findByText('그룹 삭제')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('그룹 삭제'))
+    fireEvent.click(screen.getByText('삭제 확인'))
+
+    expect(
+      await screen.findByText('그룹에 포함된 리마인더가 있으면 삭제할 수 없어요.')
+    ).toBeInTheDocument()
+  })
 })

--- a/src/__tests__/shopping/ShoppingListCard.test.tsx
+++ b/src/__tests__/shopping/ShoppingListCard.test.tsx
@@ -78,6 +78,29 @@ describe('ShoppingListCard', () => {
     expect(screen.getByText('이마트')).toBeInTheDocument()
   })
 
+  it('그룹이 있으면 그룹 이름을 표시한다', () => {
+    render(
+      <ShoppingListCard
+        list={mockList}
+        group={{
+          id: 'group-1',
+          family_id: 'fam-1',
+          created_by: 'user-1',
+          name: '집',
+          color: '#3b82f6',
+          sort_order: 0,
+          created_at: '2026-01-01T00:00:00Z',
+          updated_at: '2026-01-01T00:00:00Z',
+        }}
+        onDelete={jest.fn()}
+        onRename={jest.fn()}
+        onOpen={mockOnOpen}
+      />
+    )
+
+    expect(screen.getByText('집')).toBeInTheDocument()
+  })
+
   it('이름 클릭 시 인라인 편집 입력창이 나타난다', () => {
     render(<ShoppingListCard list={mockList} onDelete={jest.fn()} onRename={jest.fn()} onOpen={mockOnOpen} />)
     fireEvent.click(screen.getByText('이마트'))

--- a/src/__tests__/shopping/ShoppingTab.test.tsx
+++ b/src/__tests__/shopping/ShoppingTab.test.tsx
@@ -15,7 +15,10 @@ const mockDeleteShoppingList = jest.fn()
 const mockRenameShoppingList = jest.fn()
 const mockReorderShoppingLists = jest.fn()
 const mockBroadcast = jest.fn()
-const mockUseRealtimeSync = jest.fn((_c: unknown, _r: unknown, _o: unknown) => mockBroadcast)
+const mockUseRealtimeSync = jest.fn((...args: unknown[]) => {
+  void args
+  return mockBroadcast
+})
 const mockPush = jest.fn()
 const mockReplace = jest.fn()
 let mockListParam: string | null = null
@@ -283,6 +286,101 @@ describe('ShoppingTab', () => {
     await user.click(await screen.findByLabelText('리마인더 그룹 관리'))
 
     expect(await screen.findByText('groups:1')).toBeInTheDocument()
+  })
+
+  it('그룹 필터를 선택하면 해당 그룹 목록만 보여준다', async () => {
+    const user = userEvent.setup()
+    const mockUser = { id: 'user-1' } as User
+    mockGetReminderGroups.mockResolvedValueOnce([
+      {
+        id: 'group-1',
+        family_id: 'fam-1',
+        created_by: 'user-1',
+        name: '개인',
+        color: '#3b82f6',
+        sort_order: 0,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      },
+    ])
+    mockGetShoppingListsWithPreviews.mockResolvedValueOnce([
+      {
+        id: 'list-1',
+        family_id: 'fam-1',
+        created_by: 'user-1',
+        name: '가족 목록',
+        reminder_group_id: null,
+        type: 'strikethrough',
+        sort_order: 0,
+        created_at: '2026-01-01T00:00:00Z',
+        previewItems: [],
+      },
+      {
+        id: 'list-2',
+        family_id: 'fam-1',
+        created_by: 'user-1',
+        name: '개인 목록',
+        reminder_group_id: 'group-1',
+        type: 'strikethrough',
+        sort_order: 1,
+        created_at: '2026-01-01T00:00:00Z',
+        previewItems: [],
+      },
+    ])
+
+    render(<ShoppingTab user={mockUser} familyId="fam-1" isInitializing={false} />)
+
+    expect(await screen.findByRole('button', { name: '가족 목록' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '개인 목록' })).toBeInTheDocument()
+
+    await user.click(await screen.findByRole('button', { name: '개인' }))
+
+    expect(screen.queryByRole('button', { name: '가족 목록' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '개인 목록' })).toBeInTheDocument()
+  })
+
+  it('그룹을 선택해 리마인더를 만들면 생성 API에 그룹 id를 전달한다', async () => {
+    const user = userEvent.setup()
+    const mockUser = { id: 'user-1' } as User
+    mockGetReminderGroups.mockResolvedValueOnce([
+      {
+        id: 'group-1',
+        family_id: 'fam-1',
+        created_by: 'user-1',
+        name: '개인',
+        color: '#3b82f6',
+        sort_order: 0,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      },
+    ])
+    mockCreateShoppingList.mockResolvedValueOnce({
+      id: 'list-1',
+      family_id: 'fam-1',
+      created_by: 'user-1',
+      name: '이마트',
+      reminder_group_id: 'group-1',
+      type: 'strikethrough',
+      sort_order: 0,
+      created_at: '2026-01-01T00:00:00Z',
+    })
+
+    render(<ShoppingTab user={mockUser} familyId="fam-1" isInitializing={false} />)
+
+    await user.click(await screen.findByLabelText('새 리마인더 추가'))
+    await user.type(screen.getByPlaceholderText('예: 이마트, 코스트코'), '이마트')
+    await user.click(screen.getAllByRole('button', { name: '개인' })[1])
+    await user.click(screen.getByRole('button', { name: '만들기' }))
+
+    await waitFor(() => {
+      expect(mockCreateShoppingList).toHaveBeenCalledWith(
+        'fam-1',
+        'user-1',
+        '이마트',
+        'strikethrough',
+        'group-1'
+      )
+    })
   })
 
   it('그룹 조회가 실패해도 가족 멤버는 그룹 시트에 전달한다', async () => {

--- a/src/components/shopping/CreateListModal.tsx
+++ b/src/components/shopping/CreateListModal.tsx
@@ -2,16 +2,19 @@
 
 import { useState } from 'react'
 import { X, ListChecks, Trash2 } from 'lucide-react'
-import type { ListType } from '@/lib/shopping'
+import type { ListType, ReminderGroup } from '@/lib/shopping'
+import { toDisplayColor } from '@/lib/label-colors'
 
 interface Props {
+  groups?: ReminderGroup[]
   onClose: () => void
-  onCreate: (name: string, type: ListType) => Promise<boolean>
+  onCreate: (name: string, type: ListType, reminderGroupId: string | null) => Promise<boolean>
 }
 
-export function CreateListModal({ onClose, onCreate }: Props) {
+export function CreateListModal({ groups = [], onClose, onCreate }: Props) {
   const [name, setName] = useState('')
   const [type, setType] = useState<ListType>('strikethrough')
+  const [reminderGroupId, setReminderGroupId] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -19,9 +22,10 @@ export function CreateListModal({ onClose, onCreate }: Props) {
     if (!name.trim()) return
     setLoading(true)
     try {
-      const created = await onCreate(name.trim(), type)
+      const created = await onCreate(name.trim(), type, reminderGroupId)
       if (created) {
         setName('')
+        setReminderGroupId(null)
       }
     } finally {
       setLoading(false)
@@ -56,6 +60,50 @@ export function CreateListModal({ onClose, onCreate }: Props) {
               className="w-full px-4 py-2.5 rounded-xl border border-stone-200 dark:border-stone-700 bg-stone-50 dark:bg-stone-800 text-stone-900 dark:text-stone-100 placeholder-stone-400 focus:outline-none focus:ring-2 focus:ring-accent-300 dark:focus:ring-accent-500 transition"
             />
           </div>
+
+          {groups.length > 0 && (
+            <div>
+              <label className="block text-sm font-medium text-stone-600 dark:text-stone-400 mb-2">
+                그룹
+              </label>
+              <div className="flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  onClick={() => setReminderGroupId(null)}
+                  className={`rounded-full border px-3 py-1.5 text-xs font-semibold transition-colors ${
+                    reminderGroupId === null
+                      ? 'border-accent-300 bg-accent-50 text-accent-600 dark:border-accent-700 dark:bg-accent-950/30 dark:text-accent-400'
+                      : 'border-stone-200 text-stone-500 hover:border-stone-300 dark:border-stone-700 dark:text-stone-400'
+                  }`}
+                >
+                  가족 전체
+                </button>
+                {groups.map((group) => {
+                  const selected = reminderGroupId === group.id
+                  const displayColor = toDisplayColor(group.color)
+                  return (
+                    <button
+                      key={group.id}
+                      type="button"
+                      onClick={() => setReminderGroupId(group.id)}
+                      className={`flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-semibold transition-colors ${
+                        selected
+                          ? 'border-transparent text-white'
+                          : 'border-stone-200 text-stone-500 hover:border-stone-300 dark:border-stone-700 dark:text-stone-400'
+                      }`}
+                      style={selected ? { backgroundColor: displayColor } : undefined}
+                    >
+                      <span
+                        className="h-2 w-2 rounded-full"
+                        style={{ backgroundColor: selected ? 'rgba(255,255,255,0.75)' : displayColor }}
+                      />
+                      {group.name}
+                    </button>
+                  )
+                })}
+              </div>
+            </div>
+          )}
 
           <div>
             <label className="block text-sm font-medium text-stone-600 dark:text-stone-400 mb-2">

--- a/src/components/shopping/ShoppingListCard.tsx
+++ b/src/components/shopping/ShoppingListCard.tsx
@@ -4,17 +4,19 @@ import { useState, useRef, useEffect } from 'react'
 import { Trash2 } from 'lucide-react'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import type { ShoppingList, ItemPreview } from '@/lib/shopping'
+import type { ShoppingList, ItemPreview, ReminderGroup } from '@/lib/shopping'
+import { toDisplayColor } from '@/lib/label-colors'
 
 interface Props {
   list: ShoppingList
+  group?: ReminderGroup | null
   previewItems?: ItemPreview[]
   onDelete: (listId: string) => void
   onRename: (listId: string, name: string) => void
   onOpen: (listId: string) => void
 }
 
-export function ShoppingListCard({ list, previewItems = [], onDelete, onRename, onOpen }: Props) {
+export function ShoppingListCard({ list, group, previewItems = [], onDelete, onRename, onOpen }: Props) {
   const [confirming, setConfirming] = useState(false)
   const [editing, setEditing] = useState(false)
   const [editValue, setEditValue] = useState(list.name)
@@ -109,6 +111,7 @@ export function ShoppingListCard({ list, previewItems = [], onDelete, onRename, 
 
   const visibleItems = previewItems.slice(0, 3)
   const hiddenCount = previewItems.length - visibleItems.length
+  const groupColor = group ? toDisplayColor(group.color) : null
 
   return (
     <>
@@ -163,6 +166,13 @@ export function ShoppingListCard({ list, previewItems = [], onDelete, onRename, 
             </button>
           )}
         </div>
+
+        {group && groupColor && (
+          <div className="mb-2 flex min-w-0 items-center gap-1.5 text-[11px] font-semibold text-stone-400 dark:text-stone-500">
+            <span className="h-2 w-2 flex-shrink-0 rounded-full" style={{ backgroundColor: groupColor }} />
+            <span className="truncate">{group.name}</span>
+          </div>
+        )}
 
         {/* Preview items — divider always at same position (no mt-auto) */}
         <div className="border-t border-stone-100 dark:border-stone-800 pt-2 space-y-1">

--- a/src/components/tabs/ShoppingTab.tsx
+++ b/src/components/tabs/ShoppingTab.tsx
@@ -32,6 +32,7 @@ import { CreateListModal } from '@/components/shopping/CreateListModal'
 import { ReminderGroupListSheet } from '@/components/shopping/ReminderGroupListSheet'
 import { useRealtimeSync } from '@/hooks/useRealtimeSync'
 import type { ShoppingListWithPreview, ListType, ShoppingItem, ReminderGroup } from '@/lib/shopping'
+import { toDisplayColor } from '@/lib/label-colors'
 
 // 라우트 이동으로 컴포넌트가 언마운트되어도 데이터를 유지하는 세션 캐시.
 const cachedListsByFamily = new Map<string, ShoppingListWithPreview[]>()
@@ -46,6 +47,7 @@ export function clearShoppingTabCache() {
 }
 
 type Props = AuthState
+type ReminderGroupFilter = 'all' | 'family' | string
 
 export function ShoppingTab({ user, familyId, isInitializing }: Props) {
   const router = useRouter()
@@ -59,6 +61,7 @@ export function ShoppingTab({ user, familyId, isInitializing }: Props) {
   const [mutationError, setMutationError] = useState<string | null>(null)
   const [showModal, setShowModal] = useState(false)
   const [showGroupList, setShowGroupList] = useState(false)
+  const [activeGroupId, setActiveGroupId] = useState<ReminderGroupFilter>('all')
 
   const activeListId = useMemo(() => {
     const raw = searchParams.get('list')?.trim()
@@ -67,6 +70,18 @@ export function ShoppingTab({ user, familyId, isInitializing }: Props) {
 
   // 현재 family 기준 캐시가 없으면 첫 진입으로 간주한다.
   const loading = isInitializing && getCachedLists(familyId) === null
+  const groupMap = useMemo(() => new Map(groups.map((group) => [group.id, group])), [groups])
+  const effectiveActiveGroupId =
+    activeGroupId !== 'all' && activeGroupId !== 'family' && !groupMap.has(activeGroupId)
+      ? 'all'
+      : activeGroupId
+  const visibleLists = useMemo(() => {
+    if (effectiveActiveGroupId === 'all') return lists
+    if (effectiveActiveGroupId === 'family') {
+      return lists.filter((list) => list.reminder_group_id === null)
+    }
+    return lists.filter((list) => list.reminder_group_id === effectiveActiveGroupId)
+  }, [effectiveActiveGroupId, lists])
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
@@ -133,7 +148,11 @@ export function ShoppingTab({ user, familyId, isInitializing }: Props) {
     void refreshGroups()
   }, [refreshGroups])
 
-  const handleCreate = async (name: string, type: ListType): Promise<boolean> => {
+  const handleCreate = async (
+    name: string,
+    type: ListType,
+    reminderGroupId: string | null
+  ): Promise<boolean> => {
     if (!familyId || !user) return false
 
     setMutationError(null)
@@ -142,7 +161,7 @@ export function ShoppingTab({ user, familyId, isInitializing }: Props) {
       family_id: familyId,
       created_by: user.id,
       name,
-      reminder_group_id: null,
+      reminder_group_id: reminderGroupId,
       type,
       sort_order: 0,
       created_at: new Date().toISOString(),
@@ -151,7 +170,7 @@ export function ShoppingTab({ user, familyId, isInitializing }: Props) {
     updateLists((prev) => [optimisticList, ...prev])
 
     try {
-      const realList = await createShoppingList(familyId, user.id, name, type)
+      const realList = await createShoppingList(familyId, user.id, name, type, reminderGroupId)
       updateLists((prev) => prev.map((l) => l.id === optimisticList.id ? { ...realList, previewItems: [] } : l))
       setShowModal(false)
       broadcast()
@@ -313,11 +332,16 @@ export function ShoppingTab({ user, familyId, isInitializing }: Props) {
     <div data-testid="shopping-tab-container" className="px-4 pt-2 pb-24 min-h-screen">
       <ShoppingListView
         lists={lists}
+        visibleLists={visibleLists}
         fetchError={fetchError}
         mutationError={mutationError}
+        groups={groups}
+        groupMap={groupMap}
         groupCount={groups.length}
+        activeGroupId={effectiveActiveGroupId}
         sensors={sensors}
         onGroupManageClick={() => setShowGroupList(true)}
+        onGroupFilterChange={setActiveGroupId}
         onCreateClick={() => setShowModal(true)}
         onDelete={handleDelete}
         onRename={handleRename}
@@ -326,7 +350,7 @@ export function ShoppingTab({ user, familyId, isInitializing }: Props) {
       />
 
       {showModal && (
-        <CreateListModal onClose={() => setShowModal(false)} onCreate={handleCreate} />
+        <CreateListModal groups={groups} onClose={() => setShowModal(false)} onCreate={handleCreate} />
       )}
 
       {showGroupList && user && (
@@ -356,11 +380,16 @@ export function ShoppingTab({ user, familyId, isInitializing }: Props) {
 
 interface ShoppingListViewProps {
   lists: ShoppingListWithPreview[]
+  visibleLists: ShoppingListWithPreview[]
   fetchError: boolean
   mutationError: string | null
+  groups: ReminderGroup[]
+  groupMap: Map<string, ReminderGroup>
   groupCount: number
+  activeGroupId: ReminderGroupFilter
   sensors: ReturnType<typeof useSensors>
   onGroupManageClick: () => void
+  onGroupFilterChange: (groupId: ReminderGroupFilter) => void
   onCreateClick: () => void
   onDelete: (listId: string) => void
   onRename: (listId: string, name: string) => void
@@ -370,11 +399,16 @@ interface ShoppingListViewProps {
 
 function ShoppingListView({
   lists,
+  visibleLists,
   fetchError,
   mutationError,
+  groups,
+  groupMap,
   groupCount,
+  activeGroupId,
   sensors,
   onGroupManageClick,
+  onGroupFilterChange,
   onCreateClick,
   onDelete,
   onRename,
@@ -411,6 +445,58 @@ function ShoppingListView({
         </div>
       </div>
 
+      {groups.length > 0 && (
+        <div className="mb-5 -mx-1 overflow-x-auto px-1 pb-1">
+          <div className="flex min-w-max gap-2">
+            <button
+              type="button"
+              onClick={() => onGroupFilterChange('all')}
+              className={`rounded-full border px-3 py-1.5 text-xs font-semibold transition-colors ${
+                activeGroupId === 'all'
+                  ? 'border-accent-300 bg-accent-50 text-accent-600 dark:border-accent-700 dark:bg-accent-950/30 dark:text-accent-400'
+                  : 'border-stone-200 text-stone-500 hover:border-stone-300 dark:border-stone-700 dark:text-stone-400'
+              }`}
+            >
+              전체
+            </button>
+            <button
+              type="button"
+              onClick={() => onGroupFilterChange('family')}
+              className={`rounded-full border px-3 py-1.5 text-xs font-semibold transition-colors ${
+                activeGroupId === 'family'
+                  ? 'border-accent-300 bg-accent-50 text-accent-600 dark:border-accent-700 dark:bg-accent-950/30 dark:text-accent-400'
+                  : 'border-stone-200 text-stone-500 hover:border-stone-300 dark:border-stone-700 dark:text-stone-400'
+              }`}
+            >
+              가족 전체
+            </button>
+            {groups.map((group) => {
+              const selected = activeGroupId === group.id
+              const displayColor = toDisplayColor(group.color)
+              return (
+                <button
+                  key={group.id}
+                  type="button"
+                  onClick={() => onGroupFilterChange(group.id)}
+                  className={`flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-semibold transition-colors ${
+                    selected
+                      ? 'border-transparent text-white'
+                      : 'border-stone-200 text-stone-500 hover:border-stone-300 dark:border-stone-700 dark:text-stone-400'
+                  }`}
+                  style={selected ? { backgroundColor: displayColor } : undefined}
+                >
+                  <span
+                    className="h-2 w-2 rounded-full"
+                    style={{ backgroundColor: selected ? 'rgba(255,255,255,0.75)' : displayColor }}
+                  />
+                  {group.name}
+                </button>
+              )
+            })}
+          </div>
+        </div>
+      )}
+
       {mutationError && (
         <div className="mb-4 rounded-xl border border-red-100 bg-red-50 px-4 py-3 text-sm text-red-500 dark:border-red-900/40 dark:bg-red-950/30 dark:text-red-400">
           {mutationError}
@@ -429,14 +515,21 @@ function ShoppingListView({
           <p className="text-stone-500 dark:text-stone-400 font-medium">아직 리마인더가 없어요</p>
           <p className="text-sm text-stone-400 dark:text-stone-500 mt-1">위의 + 버튼을 눌러보세요</p>
         </div>
+      ) : visibleLists.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-24 text-center">
+          <ListChecks size={40} className="text-stone-300 dark:text-stone-600 mb-4" />
+          <p className="text-stone-500 dark:text-stone-400 font-medium">이 그룹에는 리마인더가 없어요</p>
+          <p className="text-sm text-stone-400 dark:text-stone-500 mt-1">새 리마인더를 추가해보세요</p>
+        </div>
       ) : (
         <DndContext sensors={sensors} onDragEnd={onDragEnd}>
-          <SortableContext items={lists.map((list) => list.id)} strategy={rectSortingStrategy}>
+          <SortableContext items={visibleLists.map((list) => list.id)} strategy={rectSortingStrategy}>
             <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
-              {lists.map((list) => (
+              {visibleLists.map((list) => (
                 <ShoppingListCard
                   key={list.id}
                   list={list}
+                  group={list.reminder_group_id ? groupMap.get(list.reminder_group_id) : null}
                   previewItems={list.previewItems}
                   onDelete={onDelete}
                   onRename={onRename}

--- a/src/lib/shopping.ts
+++ b/src/lib/shopping.ts
@@ -181,17 +181,13 @@ export async function createShoppingList(
   type: ListType,
   reminderGroupId: string | null = null
 ): Promise<ShoppingList> {
-  const { data, error } = await supabase
-    .from('shopping_lists')
-    .insert({
-      family_id: familyId,
-      created_by: userId,
-      name,
-      type,
-      reminder_group_id: reminderGroupId,
-    })
-    .select()
-    .single()
+  const { data, error } = await supabase.rpc('create_shopping_list_authorized', {
+    p_actor_user_id: userId,
+    p_family_id: familyId,
+    p_name: name,
+    p_type: type,
+    p_reminder_group_id: reminderGroupId,
+  })
 
   if (error) throw error
   return data

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -755,6 +755,16 @@ export type Database = {
         }
         Returns: boolean
       }
+      create_shopping_list_authorized: {
+        Args: {
+          p_actor_user_id: string
+          p_family_id: string
+          p_name: string
+          p_type: string
+          p_reminder_group_id?: string | null
+        }
+        Returns: Database["public"]["Tables"]["shopping_lists"]["Row"]
+      }
       get_my_calendar_ids: {
         Args: Record<PropertyKey, never>
         Returns: string[]

--- a/supabase/migrations/20260509000000_fix_reminder_group_owner_access.sql
+++ b/supabase/migrations/20260509000000_fix_reminder_group_owner_access.sql
@@ -1,0 +1,52 @@
+-- ================================================================
+-- Fix reminder group owner access
+--
+-- 그룹 생성자가 멤버 row 없이 created_by 조건으로만 그룹을 볼 수 있으면
+-- 해당 그룹으로 리마인더 목록을 만들 때 shopping_lists RLS를 통과하지 못한다.
+-- 기존 데이터의 owner 멤버십을 보강하고 helper에서도 생성자 그룹을 포함한다.
+-- ================================================================
+
+insert into reminder_group_members (reminder_group_id, user_id, role)
+select rg.id, rg.created_by, 'owner'
+from reminder_groups rg
+where rg.created_by is not null
+on conflict (reminder_group_id, user_id) do update
+set role = case
+  when reminder_group_members.role = 'owner' then reminder_group_members.role
+  else 'owner'
+end;
+
+create or replace function get_my_reminder_group_ids()
+returns setof uuid
+language sql
+security definer
+stable
+as $$
+  select reminder_group_id
+  from reminder_group_members
+  where user_id = auth.uid()
+
+  union
+
+  select id
+  from reminder_groups
+  where created_by = auth.uid()
+$$;
+
+create or replace function get_my_owned_reminder_group_ids()
+returns setof uuid
+language sql
+security definer
+stable
+as $$
+  select reminder_group_id
+  from reminder_group_members
+  where user_id = auth.uid()
+    and role = 'owner'
+
+  union
+
+  select id
+  from reminder_groups
+  where created_by = auth.uid()
+$$;

--- a/supabase/migrations/20260509001000_create_shopping_list_authorized.sql
+++ b/supabase/migrations/20260509001000_create_shopping_list_authorized.sql
@@ -1,0 +1,89 @@
+-- ================================================================
+-- Authorized shopping list creation
+--
+-- 그룹 지정 리마인더 생성은 클라이언트 직접 insert 대신 명시 RPC에서
+-- actor/family/group 권한을 확인한 뒤 서버 측에서 생성한다.
+-- ================================================================
+
+create or replace function create_shopping_list_authorized(
+  p_actor_user_id uuid,
+  p_family_id uuid,
+  p_name text,
+  p_type text,
+  p_reminder_group_id uuid default null
+)
+returns shopping_lists
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_actor_id uuid := auth.uid();
+  v_list shopping_lists;
+begin
+  if v_actor_id is null or v_actor_id <> p_actor_user_id then
+    raise exception 'forbidden' using errcode = '42501';
+  end if;
+
+  if p_name is null or btrim(p_name) = '' then
+    raise exception 'invalid_name' using errcode = '22023';
+  end if;
+
+  if p_type not in ('strikethrough', 'delete') then
+    raise exception 'invalid_type' using errcode = '22023';
+  end if;
+
+  if not exists (
+    select 1
+    from family_members fm
+    where fm.family_id = p_family_id
+      and fm.user_id = v_actor_id
+  ) then
+    raise exception 'forbidden' using errcode = '42501';
+  end if;
+
+  if p_reminder_group_id is not null and not exists (
+    select 1
+    from reminder_groups rg
+    where rg.id = p_reminder_group_id
+      and rg.family_id = p_family_id
+      and (
+        rg.created_by = v_actor_id
+        or exists (
+          select 1
+          from reminder_group_members rgm
+          where rgm.reminder_group_id = rg.id
+            and rgm.user_id = v_actor_id
+        )
+      )
+  ) then
+    raise exception 'forbidden' using errcode = '42501';
+  end if;
+
+  insert into shopping_lists (
+    family_id,
+    created_by,
+    name,
+    type,
+    reminder_group_id
+  )
+  values (
+    p_family_id,
+    v_actor_id,
+    btrim(p_name),
+    p_type,
+    p_reminder_group_id
+  )
+  returning * into v_list;
+
+  return v_list;
+end;
+$$;
+
+revoke execute on function create_shopping_list_authorized(
+  uuid, uuid, text, text, uuid
+) from public, anon;
+
+grant execute on function create_shopping_list_authorized(
+  uuid, uuid, text, text, uuid
+) to authenticated;

--- a/supabase/migrations/20260509002000_lock_shopping_list_direct_insert.sql
+++ b/supabase/migrations/20260509002000_lock_shopping_list_direct_insert.sql
@@ -1,0 +1,12 @@
+-- ================================================================
+-- Lock direct shopping list inserts
+--
+-- 리마인더 목록 생성은 create_shopping_list_authorized RPC로만 허용한다.
+-- 클라이언트 직접 insert는 RLS 정책에서 닫아 생성 권한 검증 경로를 단일화한다.
+-- ================================================================
+
+drop policy if exists "members can insert reminder lists" on shopping_lists;
+
+create policy "shopping list inserts require authorized rpc"
+  on shopping_lists for insert
+  with check (false);


### PR DESCRIPTION
## Summary
- 새 리마인더 생성 화면에서 리마인더 그룹을 선택할 수 있게 했습니다.
- 리마인더 탭 상단에 전체/가족 전체/그룹별 필터를 추가했습니다.
- 리마인더 카드에 그룹 색상과 이름을 표시합니다.
- 그룹 지정 리마인더 생성은 권한 검증 RPC를 통해 저장하도록 변경했습니다.
- `shopping_lists` 직접 insert 정책을 닫아 생성 경로를 RPC로 단일화했습니다.
- 그룹에 리마인더가 남아 있으면 그룹 삭제가 막히고 안내 문구가 표시되도록 테스트로 고정했습니다.

## Testing
- `npm run test -- --runTestsByPath src/__tests__/lib/reminder-groups-sql.test.ts src/__tests__/lib/shopping.test.ts src/__tests__/shopping/ShoppingTab.test.tsx`
- `npm run test -- --runTestsByPath src/__tests__/shopping/ReminderGroupListSheet.test.tsx src/__tests__/shopping/ShoppingTab.test.tsx`
- `npm run lint` 통과. 기존 `src/app/api/cron/daily-digest/route.ts`의 unused warning 1건은 남아 있습니다.
- `npx tsc --noEmit`

## Manual Testing
- [x] 리마인더 그룹이 있는 상태에서 새 리마인더 생성 화면에 그룹 선택 칩이 보이는지 확인합니다.
- [x] 그룹을 선택해 새 리마인더를 만들면 해당 그룹 필터에서 목록이 보이는지 확인합니다.
- [x] 가족 전체로 만든 리마인더가 가족 전체 필터에서 보이는지 확인합니다.
- [x] 전체 필터에서는 가족 전체 목록과 그룹 목록이 모두 보이는지 확인합니다.
- [ ] 그룹에 포함된 리마인더가 있는 상태에서 해당 그룹 삭제를 시도하면 삭제되지 않고 안내 문구가 보이는지 확인합니다.
- [ ] 리마인더가 없는 그룹은 삭제할 수 있는지 확인합니다.

Refs #116