### PR TITLE
feat: change reminder list groups

### DIFF
--- a/src/__tests__/lib/reminder-groups-sql.test.ts
+++ b/src/__tests__/lib/reminder-groups-sql.test.ts
@@ -17,11 +17,16 @@ const lockDirectInsertMigrationPath = path.join(
   process.cwd(),
   'supabase/migrations/20260509002000_lock_shopping_list_direct_insert.sql'
 )
+const updateListGroupMigrationPath = path.join(
+  process.cwd(),
+  'supabase/migrations/20260509003000_update_shopping_list_group_authorized.sql'
+)
 
 const sql = () => fs.readFileSync(migrationPath, 'utf8')
 const ownerAccessSql = () => fs.readFileSync(ownerAccessMigrationPath, 'utf8')
 const createListSql = () => fs.readFileSync(createListMigrationPath, 'utf8')
 const lockDirectInsertSql = () => fs.readFileSync(lockDirectInsertMigrationPath, 'utf8')
+const updateListGroupSql = () => fs.readFileSync(updateListGroupMigrationPath, 'utf8')
 
 describe('reminder groups migration', () => {
   it('does not expose grouped lists by clearing reminder_group_id on group delete', () => {
@@ -77,5 +82,20 @@ describe('reminder groups migration', () => {
     expect(migration).toContain('drop policy if exists "members can insert reminder lists"')
     expect(migration).toContain('on shopping_lists for insert')
     expect(migration).toContain('with check (false)')
+  })
+
+  it('updates reminder list groups only through an authorized RPC', () => {
+    const migration = updateListGroupSql()
+
+    expect(migration).toContain('create or replace function prevent_reminder_list_scope_change()')
+    expect(migration).toContain("current_setting('app.allow_reminder_list_scope_change', true) = 'on'")
+    expect(migration).toContain('create or replace function update_shopping_list_group_authorized')
+    expect(migration).toContain('v_actor_id uuid := auth.uid()')
+    expect(migration).toContain('from family_members fm')
+    expect(migration).toContain('from reminder_groups rg')
+    expect(migration).toContain('from reminder_group_members rgm')
+    expect(migration).toContain("set_config('app.allow_reminder_list_scope_change', 'on', true)")
+    expect(migration).toContain('set reminder_group_id = p_reminder_group_id')
+    expect(migration).toContain('grant execute on function update_shopping_list_group_authorized')
   })
 })

--- a/src/__tests__/lib/reminder-groups-sql.test.ts
+++ b/src/__tests__/lib/reminder-groups-sql.test.ts
@@ -92,6 +92,7 @@ describe('reminder groups migration', () => {
     expect(migration).toContain('create or replace function update_shopping_list_group_authorized')
     expect(migration).toContain('v_actor_id uuid := auth.uid()')
     expect(migration).toContain('from family_members fm')
+    expect(migration).toContain('where rg.id = v_list.reminder_group_id')
     expect(migration).toContain('from reminder_groups rg')
     expect(migration).toContain('from reminder_group_members rgm')
     expect(migration).toContain("set_config('app.allow_reminder_list_scope_change', 'on', true)")

--- a/src/__tests__/lib/shopping.test.ts
+++ b/src/__tests__/lib/shopping.test.ts
@@ -15,6 +15,7 @@ import {
   checkShoppingItem,
   deleteShoppingItem,
   renameShoppingList,
+  updateShoppingListGroup,
   renameShoppingItem,
   reorderShoppingLists,
   reorderShoppingItems,
@@ -245,6 +246,51 @@ describe('createShoppingList', () => {
   it('error가 있으면 throw한다', async () => {
     mockRpc.mockResolvedValueOnce({ data: null, error: { message: 'insert error' } })
     await expect(createShoppingList('fam-1', 'user-1', '이마트', 'strikethrough')).rejects.toEqual({ message: 'insert error' })
+  })
+})
+
+describe('updateShoppingListGroup', () => {
+  it('리마인더 그룹 변경 RPC를 호출하고 변경된 리스트를 반환한다', async () => {
+    const mockList = {
+      id: 'list-1',
+      name: '이마트',
+      reminder_group_id: 'group-1',
+    }
+    mockRpc.mockResolvedValueOnce({ data: mockList, error: null })
+
+    const result = await updateShoppingListGroup('list-1', 'user-1', 'group-1')
+
+    expect(result).toEqual(mockList)
+    expect(mockRpc).toHaveBeenCalledWith('update_shopping_list_group_authorized', {
+      p_actor_user_id: 'user-1',
+      p_list_id: 'list-1',
+      p_reminder_group_id: 'group-1',
+    })
+  })
+
+  it('가족 전체로 변경할 때 null을 전달한다', async () => {
+    const mockList = {
+      id: 'list-1',
+      name: '이마트',
+      reminder_group_id: null,
+    }
+    mockRpc.mockResolvedValueOnce({ data: mockList, error: null })
+
+    await expect(updateShoppingListGroup('list-1', 'user-1', null)).resolves.toEqual(mockList)
+
+    expect(mockRpc).toHaveBeenCalledWith('update_shopping_list_group_authorized', {
+      p_actor_user_id: 'user-1',
+      p_list_id: 'list-1',
+      p_reminder_group_id: null,
+    })
+  })
+
+  it('error가 있으면 throw한다', async () => {
+    mockRpc.mockResolvedValueOnce({ data: null, error: { message: 'group update error' } })
+
+    await expect(updateShoppingListGroup('list-1', 'user-1', 'group-1')).rejects.toEqual({
+      message: 'group update error',
+    })
   })
 })
 

--- a/src/__tests__/shopping/ShoppingDetailView.test.tsx
+++ b/src/__tests__/shopping/ShoppingDetailView.test.tsx
@@ -272,6 +272,31 @@ describe('ShoppingDetailView', () => {
     expect(onListGroupChange).toHaveBeenLastCalledWith('list-1', null)
   })
 
+  it('가족 목록 refresh에서 접근할 수 없으면 not found 상태로 전환하고 preview를 비운다', async () => {
+    render(
+      <ShoppingDetailView
+        listId="list-1"
+        user={mockUser}
+        onClose={onClose}
+        onPreviewItemsChange={onPreviewItemsChange}
+      />
+    )
+
+    expect(await screen.findByText('이마트')).toBeInTheDocument()
+
+    const calls = mockUseRealtimeSync.mock.calls as unknown as Array<[unknown, () => void, unknown]>
+    const familyRefresh = calls.find(([channelName]) => channelName === 'family_lists_fam-1')?.[1]
+    expect(familyRefresh).toBeDefined()
+
+    mockGetShoppingList.mockResolvedValueOnce(null)
+    await act(async () => {
+      familyRefresh?.()
+    })
+
+    expect(await screen.findByText('삭제되었거나 접근할 수 없는 리마인더예요.')).toBeInTheDocument()
+    expect(onPreviewItemsChange).toHaveBeenLastCalledWith('list-1', [])
+  })
+
   it('아이템이 많아도 목록만 스크롤되고 추가 입력란은 화면 안에 유지된다', async () => {
     mockGetShoppingItems.mockResolvedValueOnce(
       Array.from({ length: 40 }, (_, index) => ({

--- a/src/__tests__/shopping/ShoppingDetailView.test.tsx
+++ b/src/__tests__/shopping/ShoppingDetailView.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor, act, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { User } from '@supabase/supabase-js'
 import { ShoppingDetailView } from '@/components/shopping/ShoppingDetailView'
-import { getShoppingItems, getShoppingList } from '@/lib/shopping'
+import { getShoppingItems, getShoppingList, updateShoppingListGroup } from '@/lib/shopping'
 
 const mockBroadcast = jest.fn()
 const mockUseRealtimeSync = jest.fn((...args: unknown[]) => {
@@ -24,6 +24,7 @@ jest.mock('@/lib/shopping', () => ({
   deleteShoppingItem: jest.fn(),
   renameShoppingItem: jest.fn(),
   reorderShoppingItems: jest.fn(),
+  updateShoppingListGroup: jest.fn(),
 }))
 
 jest.mock('@dnd-kit/core', () => ({
@@ -54,6 +55,7 @@ jest.mock('@dnd-kit/utilities', () => ({
 
 const mockGetShoppingList = getShoppingList as jest.MockedFunction<typeof getShoppingList>
 const mockGetShoppingItems = getShoppingItems as jest.MockedFunction<typeof getShoppingItems>
+const mockUpdateShoppingListGroup = updateShoppingListGroup as jest.MockedFunction<typeof updateShoppingListGroup>
 
 describe('ShoppingDetailView', () => {
   const mockUser = { id: 'user-1' } as User
@@ -67,11 +69,22 @@ describe('ShoppingDetailView', () => {
       family_id: 'fam-1',
       created_by: 'user-1',
       name: '이마트',
+      reminder_group_id: null,
       type: 'strikethrough',
       sort_order: 0,
       created_at: '2026-01-01T00:00:00Z',
     } as never)
     mockGetShoppingItems.mockResolvedValue([] as never)
+    mockUpdateShoppingListGroup.mockResolvedValue({
+      id: 'list-1',
+      family_id: 'fam-1',
+      created_by: 'user-1',
+      name: '이마트',
+      reminder_group_id: 'group-1',
+      type: 'strikethrough',
+      sort_order: 0,
+      created_at: '2026-01-01T00:00:00Z',
+    } as never)
   })
 
   afterAll(() => {
@@ -188,6 +201,75 @@ describe('ShoppingDetailView', () => {
         expect.arrayContaining([expect.objectContaining({ id: 'item-1', name: '우유' })])
       )
     })
+  })
+
+  it('리마인더 그룹을 변경하고 부모 목록 상태에 반영한다', async () => {
+    const user = userEvent.setup()
+    const onListGroupChange = jest.fn()
+
+    render(
+      <ShoppingDetailView
+        listId="list-1"
+        user={mockUser}
+        groups={[
+          {
+            id: 'group-1',
+            family_id: 'fam-1',
+            created_by: 'user-1',
+            name: '개인',
+            color: '#3b82f6',
+            sort_order: 0,
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z',
+          },
+        ]}
+        onClose={onClose}
+        onListGroupChange={onListGroupChange}
+        onPreviewItemsChange={onPreviewItemsChange}
+      />
+    )
+
+    await user.selectOptions(await screen.findByLabelText('그룹'), 'group-1')
+
+    expect(mockUpdateShoppingListGroup).toHaveBeenCalledWith('list-1', 'user-1', 'group-1')
+    await waitFor(() => {
+      expect(onListGroupChange).toHaveBeenCalledWith('list-1', 'group-1')
+    })
+  })
+
+  it('리마인더 그룹 변경 실패 시 이전 그룹으로 되돌리고 에러를 표시한다', async () => {
+    const user = userEvent.setup()
+    const onListGroupChange = jest.fn()
+    mockUpdateShoppingListGroup.mockRejectedValueOnce(new Error('update failed'))
+
+    render(
+      <ShoppingDetailView
+        listId="list-1"
+        user={mockUser}
+        groups={[
+          {
+            id: 'group-1',
+            family_id: 'fam-1',
+            created_by: 'user-1',
+            name: '개인',
+            color: '#3b82f6',
+            sort_order: 0,
+            created_at: '2026-01-01T00:00:00Z',
+            updated_at: '2026-01-01T00:00:00Z',
+          },
+        ]}
+        onClose={onClose}
+        onListGroupChange={onListGroupChange}
+        onPreviewItemsChange={onPreviewItemsChange}
+      />
+    )
+
+    const select = await screen.findByLabelText('그룹')
+    await user.selectOptions(select, 'group-1')
+
+    expect(await screen.findByText('그룹을 변경하지 못했어요')).toBeInTheDocument()
+    expect(select).toHaveValue('')
+    expect(onListGroupChange).toHaveBeenLastCalledWith('list-1', null)
   })
 
   it('아이템이 많아도 목록만 스크롤되고 추가 입력란은 화면 안에 유지된다', async () => {

--- a/src/components/shopping/ShoppingDetailView.tsx
+++ b/src/components/shopping/ShoppingDetailView.tsx
@@ -19,11 +19,13 @@ import {
   deleteShoppingItem,
   renameShoppingItem,
   reorderShoppingItems,
+  updateShoppingListGroup,
 } from '@/lib/shopping'
 import { ShoppingItem } from '@/components/shopping/ShoppingItem'
 import { AddItemInput } from '@/components/shopping/AddItemInput'
 import { useRealtimeSync } from '@/hooks/useRealtimeSync'
-import type { ShoppingItem as ShoppingItemType, ShoppingList } from '@/lib/shopping'
+import { toDisplayColor } from '@/lib/label-colors'
+import type { ShoppingItem as ShoppingItemType, ShoppingList, ReminderGroup } from '@/lib/shopping'
 import type { User } from '@supabase/supabase-js'
 
 type DetailStatus = 'loading' | 'ready' | 'not-found' | 'fetch-error'
@@ -31,20 +33,25 @@ type DetailStatus = 'loading' | 'ready' | 'not-found' | 'fetch-error'
 interface Props {
   listId: string
   user: User
+  groups?: ReminderGroup[]
   onClose: () => void
+  onListGroupChange?: (listId: string, reminderGroupId: string | null) => void
   onPreviewItemsChange: (listId: string, items: ShoppingItemType[]) => void
 }
 
 export function ShoppingDetailView({
   listId,
   user,
+  groups = [],
   onClose,
+  onListGroupChange,
   onPreviewItemsChange,
 }: Props) {
   const [list, setList] = useState<ShoppingList | null>(null)
   const [items, setItems] = useState<ShoppingItemType[]>([])
   const [status, setStatus] = useState<DetailStatus>('loading')
   const [mutationError, setMutationError] = useState<string | null>(null)
+  const [groupSaving, setGroupSaving] = useState(false)
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
@@ -67,7 +74,22 @@ export function ShoppingDetailView({
       .catch((e) => console.error('[ShoppingDetailView] getShoppingItems failed:', e))
   }, [listId, syncPreview])
 
+  const refreshList = useCallback(() => {
+    getShoppingList(listId)
+      .then((nextList) => {
+        if (nextList) {
+          setList(nextList)
+          onListGroupChange?.(listId, nextList.reminder_group_id)
+        }
+      })
+      .catch((e) => console.error('[ShoppingDetailView] getShoppingList failed:', e))
+  }, [listId, onListGroupChange])
+
   const broadcast = useRealtimeSync(`list_items_${listId}`, refreshItems)
+  const broadcastListChange = useRealtimeSync(
+    list ? `family_lists_${list.family_id}` : null,
+    refreshList
+  )
 
   const fetchDetailData = useCallback(async () => {
     const shoppingList = await getShoppingList(listId)
@@ -283,6 +305,33 @@ export function ShoppingDetailView({
     }
   }
 
+  const handleGroupChange = async (nextValue: string) => {
+    if (!list || groupSaving) return
+
+    const nextGroupId = nextValue === '' ? null : nextValue
+    if (nextGroupId === list.reminder_group_id) return
+
+    setMutationError(null)
+    setGroupSaving(true)
+    const previousList = list
+    setList({ ...list, reminder_group_id: nextGroupId })
+    onListGroupChange?.(list.id, nextGroupId)
+
+    try {
+      const updatedList = await updateShoppingListGroup(list.id, user.id, nextGroupId)
+      setList(updatedList)
+      onListGroupChange?.(updatedList.id, updatedList.reminder_group_id)
+      broadcastListChange()
+    } catch (e) {
+      console.error('[ShoppingDetailView] updateShoppingListGroup failed:', e)
+      setList(previousList)
+      onListGroupChange?.(previousList.id, previousList.reminder_group_id)
+      setMutationError('그룹을 변경하지 못했어요')
+    } finally {
+      setGroupSaving(false)
+    }
+  }
+
   const uncheckedItems = useMemo(
     () => items.filter((item) => !item.is_checked),
     [items]
@@ -291,6 +340,9 @@ export function ShoppingDetailView({
     () => items.filter((item) => item.is_checked),
     [items]
   )
+  const currentGroup = list?.reminder_group_id
+    ? groups.find((group) => group.id === list.reminder_group_id) ?? null
+    : null
 
   return (
     <div
@@ -343,6 +395,35 @@ export function ShoppingDetailView({
               </p>
             </div>
           </div>
+
+          {list && groups.length > 0 && (
+            <div className="flex items-center gap-3 border-b border-stone-100 px-4 py-3 dark:border-stone-800">
+              <div
+                className="h-2.5 w-2.5 shrink-0 rounded-full bg-stone-300 dark:bg-stone-600"
+                style={currentGroup ? { backgroundColor: toDisplayColor(currentGroup.color) } : undefined}
+              />
+              <label
+                htmlFor="shopping-list-group"
+                className="shrink-0 text-xs font-semibold text-stone-400 dark:text-stone-500"
+              >
+                그룹
+              </label>
+              <select
+                id="shopping-list-group"
+                value={list.reminder_group_id ?? ''}
+                disabled={groupSaving}
+                onChange={(event) => void handleGroupChange(event.target.value)}
+                className="min-w-0 flex-1 rounded-lg border border-stone-200 bg-stone-50 px-2.5 py-2 text-sm font-medium text-stone-700 outline-none transition-colors focus:ring-2 focus:ring-accent-300 disabled:opacity-50 dark:border-stone-700 dark:bg-stone-900 dark:text-stone-200"
+              >
+                <option value="">가족 전체</option>
+                {groups.map((group) => (
+                  <option key={group.id} value={group.id}>
+                    {group.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
 
           <div data-testid="shopping-detail-scroll" className="flex-1 min-h-0 overflow-y-auto py-2">
             {mutationError && (

--- a/src/components/shopping/ShoppingDetailView.tsx
+++ b/src/components/shopping/ShoppingDetailView.tsx
@@ -80,10 +80,15 @@ export function ShoppingDetailView({
         if (nextList) {
           setList(nextList)
           onListGroupChange?.(listId, nextList.reminder_group_id)
+        } else {
+          setList(null)
+          setItems([])
+          setStatus('not-found')
+          syncPreview([])
         }
       })
       .catch((e) => console.error('[ShoppingDetailView] getShoppingList failed:', e))
-  }, [listId, onListGroupChange])
+  }, [listId, onListGroupChange, syncPreview])
 
   const broadcast = useRealtimeSync(`list_items_${listId}`, refreshItems)
   const broadcastListChange = useRealtimeSync(

--- a/src/components/tabs/ShoppingTab.tsx
+++ b/src/components/tabs/ShoppingTab.tsx
@@ -213,6 +213,14 @@ export function ShoppingTab({ user, familyId, isInitializing }: Props) {
     }
   }
 
+  const handleListGroupChange = useCallback((listId: string, reminderGroupId: string | null) => {
+    updateLists((prev) =>
+      prev.map((list) =>
+        list.id === listId ? { ...list, reminder_group_id: reminderGroupId } : list
+      )
+    )
+  }, [updateLists])
+
   const handleGroupCreate = async (
     name: string,
     color: string,
@@ -370,7 +378,9 @@ export function ShoppingTab({ user, familyId, isInitializing }: Props) {
           key={activeListId}
           listId={activeListId}
           user={user}
+          groups={groups}
           onClose={closeShoppingDetail}
+          onListGroupChange={handleListGroupChange}
           onPreviewItemsChange={handlePreviewItemsChange}
         />
       )}

--- a/src/lib/shopping.ts
+++ b/src/lib/shopping.ts
@@ -266,6 +266,21 @@ export async function renameShoppingList(listId: string, name: string): Promise<
   if (error) throw error
 }
 
+export async function updateShoppingListGroup(
+  listId: string,
+  userId: string,
+  reminderGroupId: string | null
+): Promise<ShoppingList> {
+  const { data, error } = await supabase.rpc('update_shopping_list_group_authorized', {
+    p_actor_user_id: userId,
+    p_list_id: listId,
+    p_reminder_group_id: reminderGroupId,
+  })
+
+  if (error) throw error
+  return data
+}
+
 export async function renameShoppingItem(itemId: string, name: string): Promise<void> {
   const { error } = await supabase
     .from('shopping_items')

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -765,6 +765,14 @@ export type Database = {
         }
         Returns: Database["public"]["Tables"]["shopping_lists"]["Row"]
       }
+      update_shopping_list_group_authorized: {
+        Args: {
+          p_actor_user_id: string
+          p_list_id: string
+          p_reminder_group_id?: string | null
+        }
+        Returns: Database["public"]["Tables"]["shopping_lists"]["Row"]
+      }
       get_my_calendar_ids: {
         Args: Record<PropertyKey, never>
         Returns: string[]

--- a/supabase/migrations/20260509003000_update_shopping_list_group_authorized.sql
+++ b/supabase/migrations/20260509003000_update_shopping_list_group_authorized.sql
@@ -1,0 +1,99 @@
+-- ================================================================
+-- Authorized shopping list group updates
+--
+-- 리마인더 목록의 공개 범위 변경은 직접 update를 막고, 권한 검증 RPC로만
+-- 수행한다. RPC 내부에서만 trigger를 통과할 수 있도록 세션 설정을 사용한다.
+-- ================================================================
+
+create or replace function prevent_reminder_list_scope_change()
+returns trigger
+language plpgsql
+as $$
+begin
+  if current_setting('app.allow_reminder_list_scope_change', true) = 'on' then
+    return new;
+  end if;
+
+  if new.family_id is distinct from old.family_id
+     or new.reminder_group_id is distinct from old.reminder_group_id then
+    raise exception 'reminder_list_scope_change_not_allowed'
+      using errcode = '42501';
+  end if;
+
+  return new;
+end;
+$$;
+
+create or replace function update_shopping_list_group_authorized(
+  p_actor_user_id uuid,
+  p_list_id uuid,
+  p_reminder_group_id uuid default null
+)
+returns shopping_lists
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_actor_id uuid := auth.uid();
+  v_list shopping_lists;
+  v_updated shopping_lists;
+begin
+  if v_actor_id is null or v_actor_id <> p_actor_user_id then
+    raise exception 'forbidden' using errcode = '42501';
+  end if;
+
+  select *
+  into v_list
+  from shopping_lists
+  where id = p_list_id;
+
+  if not found then
+    raise exception 'not_found' using errcode = 'P0002';
+  end if;
+
+  if not exists (
+    select 1
+    from family_members fm
+    where fm.family_id = v_list.family_id
+      and fm.user_id = v_actor_id
+  ) then
+    raise exception 'forbidden' using errcode = '42501';
+  end if;
+
+  if p_reminder_group_id is not null and not exists (
+    select 1
+    from reminder_groups rg
+    where rg.id = p_reminder_group_id
+      and rg.family_id = v_list.family_id
+      and (
+        rg.created_by = v_actor_id
+        or exists (
+          select 1
+          from reminder_group_members rgm
+          where rgm.reminder_group_id = rg.id
+            and rgm.user_id = v_actor_id
+        )
+      )
+  ) then
+    raise exception 'forbidden' using errcode = '42501';
+  end if;
+
+  perform set_config('app.allow_reminder_list_scope_change', 'on', true);
+
+  update shopping_lists
+  set reminder_group_id = p_reminder_group_id
+  where id = p_list_id
+  returning * into v_updated;
+
+  return v_updated;
+end;
+$$;
+
+revoke execute on function update_shopping_list_group_authorized(
+  uuid, uuid, uuid
+) from public, anon;
+
+grant execute on function update_shopping_list_group_authorized(
+  uuid, uuid, uuid
+) to authenticated;

--- a/supabase/migrations/20260509003000_update_shopping_list_group_authorized.sql
+++ b/supabase/migrations/20260509003000_update_shopping_list_group_authorized.sql
@@ -61,6 +61,24 @@ begin
     raise exception 'forbidden' using errcode = '42501';
   end if;
 
+  if v_list.reminder_group_id is not null and not exists (
+    select 1
+    from reminder_groups rg
+    where rg.id = v_list.reminder_group_id
+      and rg.family_id = v_list.family_id
+      and (
+        rg.created_by = v_actor_id
+        or exists (
+          select 1
+          from reminder_group_members rgm
+          where rgm.reminder_group_id = rg.id
+            and rgm.user_id = v_actor_id
+        )
+      )
+  ) then
+    raise exception 'forbidden' using errcode = '42501';
+  end if;
+
   if p_reminder_group_id is not null and not exists (
     select 1
     from reminder_groups rg


### PR DESCRIPTION
## Summary
- 기존 리마인더 상세 화면에서 그룹을 변경할 수 있게 했습니다.
- 리마인더 그룹 변경은 권한 검증 RPC를 통해서만 수행하도록 추가했습니다.
- 그룹 변경 후 목록 캐시와 가족 목록 realtime refresh가 갱신되도록 연결했습니다.
- 관련 SQL, lib, 상세 화면 테스트를 추가했습니다.

## Testing
- `npm run test -- --runTestsByPath src/__tests__/lib/shopping.test.ts src/__tests__/lib/reminder-groups-sql.test.ts src/__tests__/shopping/ShoppingDetailView.test.tsx src/__tests__/shopping/ShoppingTab.test.tsx`
- `npm run lint` 통과. 기존 `src/app/api/cron/daily-digest/route.ts`의 unused warning 1건은 남아 있습니다.
- `npx tsc --noEmit`

## Manual Testing
- [x] 리마인더 그룹이 1개 이상 있는 상태에서 기존 리마인더 상세 화면에 그룹 선택 UI가 보이는지 확인합니다.
- [x] 가족 전체 리마인더를 특정 그룹으로 변경하면 해당 그룹 필터에서 보이는지 확인합니다.
- [x] 그룹 리마인더를 가족 전체로 변경하면 가족 전체 필터에서 보이는지 확인합니다.
- [x] 그룹 A 리마인더를 그룹 B로 변경하면 각 필터에서 목록 이동이 반영되는지 확인합니다.
- [x] 권한 없는 그룹으로 직접 변경할 수 없는지 확인합니다.

Refs #116