### PR TITLE
fix: keep filtered reminder reorders scoped

### DIFF
--- a/src/__tests__/shopping/ShoppingTab.test.tsx
+++ b/src/__tests__/shopping/ShoppingTab.test.tsx
@@ -425,6 +425,98 @@ describe('ShoppingTab', () => {
     ])
   })
 
+  it('특정 그룹 필터에서도 해당 그룹 목록끼리만 순서를 바꾼다', async () => {
+    const user = userEvent.setup()
+    const mockUser = { id: 'user-1' } as User
+    mockReorderShoppingLists.mockResolvedValueOnce(undefined)
+    mockGetReminderGroups.mockResolvedValueOnce([
+      {
+        id: 'group-1',
+        family_id: 'fam-1',
+        created_by: 'user-1',
+        name: '개인',
+        color: '#3b82f6',
+        sort_order: 0,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      },
+      {
+        id: 'group-2',
+        family_id: 'fam-1',
+        created_by: 'user-1',
+        name: '회사',
+        color: '#22c55e',
+        sort_order: 1,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      },
+    ])
+    mockGetShoppingListsWithPreviews.mockResolvedValueOnce([
+      {
+        id: 'family-a',
+        family_id: 'fam-1',
+        created_by: 'user-1',
+        name: '가족 A',
+        reminder_group_id: null,
+        type: 'strikethrough',
+        sort_order: 0,
+        created_at: '2026-01-01T00:00:00Z',
+        previewItems: [],
+      },
+      {
+        id: 'group-a',
+        family_id: 'fam-1',
+        created_by: 'user-1',
+        name: '개인 A',
+        reminder_group_id: 'group-1',
+        type: 'strikethrough',
+        sort_order: 1,
+        created_at: '2026-01-01T00:00:00Z',
+        previewItems: [],
+      },
+      {
+        id: 'other-group',
+        family_id: 'fam-1',
+        created_by: 'user-1',
+        name: '회사 A',
+        reminder_group_id: 'group-2',
+        type: 'strikethrough',
+        sort_order: 2,
+        created_at: '2026-01-01T00:00:00Z',
+        previewItems: [],
+      },
+      {
+        id: 'group-b',
+        family_id: 'fam-1',
+        created_by: 'user-1',
+        name: '개인 B',
+        reminder_group_id: 'group-1',
+        type: 'strikethrough',
+        sort_order: 3,
+        created_at: '2026-01-01T00:00:00Z',
+        previewItems: [],
+      },
+    ])
+
+    render(<ShoppingTab user={mockUser} familyId="fam-1" isInitializing={false} />)
+
+    await user.click(await screen.findByRole('button', { name: '개인' }))
+
+    await act(async () => {
+      mockDndOnDragEnd?.({
+        active: { id: 'group-b' },
+        over: { id: 'group-a' },
+      })
+    })
+
+    expect(mockReorderShoppingLists).toHaveBeenCalledWith([
+      { id: 'family-a', sort_order: 0 },
+      { id: 'group-b', sort_order: 1 },
+      { id: 'other-group', sort_order: 2 },
+      { id: 'group-a', sort_order: 3 },
+    ])
+  })
+
   it('그룹을 선택해 리마인더를 만들면 생성 API에 그룹 id를 전달한다', async () => {
     const user = userEvent.setup()
     const mockUser = { id: 'user-1' } as User

--- a/src/__tests__/shopping/ShoppingTab.test.tsx
+++ b/src/__tests__/shopping/ShoppingTab.test.tsx
@@ -22,6 +22,7 @@ const mockUseRealtimeSync = jest.fn((...args: unknown[]) => {
 const mockPush = jest.fn()
 const mockReplace = jest.fn()
 let mockListParam: string | null = null
+let mockDndOnDragEnd: ((event: { active: { id: string }; over: { id: string } | null }) => void) | null = null
 const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
 
 jest.mock('@/lib/shopping', () => ({
@@ -72,7 +73,16 @@ jest.mock('next/navigation', () => ({
 }))
 
 jest.mock('@dnd-kit/core', () => ({
-  DndContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DndContext: ({
+    children,
+    onDragEnd,
+  }: {
+    children: React.ReactNode
+    onDragEnd: (event: { active: { id: string }; over: { id: string } | null }) => void
+  }) => {
+    mockDndOnDragEnd = onDragEnd
+    return <>{children}</>
+  },
   PointerSensor: class {},
   TouchSensor: class {},
   useSensor: jest.fn(),
@@ -81,7 +91,12 @@ jest.mock('@dnd-kit/core', () => ({
 
 jest.mock('@dnd-kit/sortable', () => ({
   SortableContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  arrayMove: jest.fn((items: unknown[]) => items),
+  arrayMove: jest.fn((items: unknown[], oldIndex: number, newIndex: number) => {
+    const next = [...items]
+    const [item] = next.splice(oldIndex, 1)
+    next.splice(newIndex, 0, item)
+    return next
+  }),
   rectSortingStrategy: {},
 }))
 
@@ -115,6 +130,7 @@ describe('ShoppingTab', () => {
     jest.clearAllMocks()
     clearShoppingTabCache()
     mockListParam = null
+    mockDndOnDragEnd = null
     mockGetShoppingListsWithPreviews.mockResolvedValue([])
     mockGetReminderGroups.mockResolvedValue([])
     mockGetFamilyMembers.mockResolvedValue([])
@@ -337,6 +353,76 @@ describe('ShoppingTab', () => {
 
     expect(screen.queryByRole('button', { name: '가족 목록' })).not.toBeInTheDocument()
     expect(screen.getByRole('button', { name: '개인 목록' })).toBeInTheDocument()
+  })
+
+  it('필터 상태에서 정렬하면 보이는 목록끼리만 순서를 바꾸고 숨겨진 목록 위치는 유지한다', async () => {
+    const user = userEvent.setup()
+    const mockUser = { id: 'user-1' } as User
+    mockReorderShoppingLists.mockResolvedValueOnce(undefined)
+    mockGetReminderGroups.mockResolvedValueOnce([
+      {
+        id: 'group-1',
+        family_id: 'fam-1',
+        created_by: 'user-1',
+        name: '개인',
+        color: '#3b82f6',
+        sort_order: 0,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      },
+    ])
+    mockGetShoppingListsWithPreviews.mockResolvedValueOnce([
+      {
+        id: 'family-a',
+        family_id: 'fam-1',
+        created_by: 'user-1',
+        name: '가족 A',
+        reminder_group_id: null,
+        type: 'strikethrough',
+        sort_order: 0,
+        created_at: '2026-01-01T00:00:00Z',
+        previewItems: [],
+      },
+      {
+        id: 'group-a',
+        family_id: 'fam-1',
+        created_by: 'user-1',
+        name: '개인 A',
+        reminder_group_id: 'group-1',
+        type: 'strikethrough',
+        sort_order: 1,
+        created_at: '2026-01-01T00:00:00Z',
+        previewItems: [],
+      },
+      {
+        id: 'family-b',
+        family_id: 'fam-1',
+        created_by: 'user-1',
+        name: '가족 B',
+        reminder_group_id: null,
+        type: 'strikethrough',
+        sort_order: 2,
+        created_at: '2026-01-01T00:00:00Z',
+        previewItems: [],
+      },
+    ])
+
+    render(<ShoppingTab user={mockUser} familyId="fam-1" isInitializing={false} />)
+
+    await user.click(await screen.findByRole('button', { name: '가족 전체' }))
+
+    await act(async () => {
+      mockDndOnDragEnd?.({
+        active: { id: 'family-b' },
+        over: { id: 'family-a' },
+      })
+    })
+
+    expect(mockReorderShoppingLists).toHaveBeenCalledWith([
+      { id: 'family-b', sort_order: 0 },
+      { id: 'group-a', sort_order: 1 },
+      { id: 'family-a', sort_order: 2 },
+    ])
   })
 
   it('그룹을 선택해 리마인더를 만들면 생성 API에 그룹 id를 전달한다', async () => {

--- a/src/components/tabs/ShoppingTab.tsx
+++ b/src/components/tabs/ShoppingTab.tsx
@@ -49,6 +49,15 @@ export function clearShoppingTabCache() {
 type Props = AuthState
 type ReminderGroupFilter = 'all' | 'family' | string
 
+function matchesReminderGroupFilter(
+  list: ShoppingListWithPreview,
+  activeGroupId: ReminderGroupFilter
+): boolean {
+  if (activeGroupId === 'all') return true
+  if (activeGroupId === 'family') return list.reminder_group_id === null
+  return list.reminder_group_id === activeGroupId
+}
+
 export function ShoppingTab({ user, familyId, isInitializing }: Props) {
   const router = useRouter()
   const searchParams = useSearchParams()
@@ -76,11 +85,7 @@ export function ShoppingTab({ user, familyId, isInitializing }: Props) {
       ? 'all'
       : activeGroupId
   const visibleLists = useMemo(() => {
-    if (effectiveActiveGroupId === 'all') return lists
-    if (effectiveActiveGroupId === 'family') {
-      return lists.filter((list) => list.reminder_group_id === null)
-    }
-    return lists.filter((list) => list.reminder_group_id === effectiveActiveGroupId)
+    return lists.filter((list) => matchesReminderGroupFilter(list, effectiveActiveGroupId))
   }, [effectiveActiveGroupId, lists])
 
   const sensors = useSensors(
@@ -273,9 +278,22 @@ export function ShoppingTab({ user, familyId, isInitializing }: Props) {
     if (!over || active.id === over.id) return
 
     setMutationError(null)
-    const oldIndex = lists.findIndex((l) => l.id === active.id)
-    const newIndex = lists.findIndex((l) => l.id === over.id)
-    const reordered = arrayMove(lists, oldIndex, newIndex).map((l, i) => ({ ...l, sort_order: i }))
+    const oldIndex = visibleLists.findIndex((l) => l.id === active.id)
+    const newIndex = visibleLists.findIndex((l) => l.id === over.id)
+    if (oldIndex < 0 || newIndex < 0) return
+
+    const reorderedVisibleLists = arrayMove(visibleLists, oldIndex, newIndex)
+    let visibleIndex = 0
+    const reordered = lists
+      .map((list) => {
+        if (!matchesReminderGroupFilter(list, effectiveActiveGroupId)) {
+          return list
+        }
+        const nextVisibleList = reorderedVisibleLists[visibleIndex]
+        visibleIndex += 1
+        return nextVisibleList
+      })
+      .map((l, i) => ({ ...l, sort_order: i }))
     updateLists(reordered)
 
     try {


### PR DESCRIPTION
## Summary
- 리마인더 그룹/가족 전체 필터 상태에서 드래그 정렬할 때 보이는 목록끼리만 순서를 바꾸도록 수정했습니다.
- 숨겨진 다른 그룹 목록은 기존 위치를 유지한 채 sort order를 다시 계산합니다.
- 필터 상태 정렬 회귀 테스트를 추가했습니다.

## Testing
- `npm run test -- --runTestsByPath src/__tests__/shopping/ShoppingTab.test.tsx`
- `npm run lint` 통과. 기존 `src/app/api/cron/daily-digest/route.ts`의 unused warning 1건은 남아 있습니다.
- `npx tsc --noEmit`

## Manual Testing
- [ ] 가족 전체 필터에서 리마인더를 드래그해 순서를 바꾸면 가족 전체 목록끼리만 순서가 바뀌는지 확인합니다.
- [ ] 특정 그룹 필터에서 리마인더를 드래그해 순서를 바꾸면 해당 그룹 목록끼리만 순서가 바뀌는지 확인합니다.
- [ ] 전체 필터에서는 기존처럼 전체 목록 순서를 바꿀 수 있는지 확인합니다.

Refs #116