### PR TITLE
fix: prevent reminder input zoom on ios

### DIFF
--- a/src/__tests__/reminders/AddItemInput.test.tsx
+++ b/src/__tests__/reminders/AddItemInput.test.tsx
@@ -9,6 +9,13 @@ describe('AddItemInput', () => {
     expect(screen.getByLabelText('추가')).toBeInTheDocument()
   })
 
+  it('입력창은 text-base 클래스를 가진다 (iOS Safari zoom 방지)', () => {
+    render(<AddItemInput onAdd={jest.fn()} />)
+    const input = screen.getByPlaceholderText('아이템 추가...')
+    expect(input).toHaveClass('text-base')
+    expect(input).not.toHaveClass('text-sm')
+  })
+
   it('빈 값으로는 onAdd가 호출되지 않는다', async () => {
     const onAdd = jest.fn()
     render(<AddItemInput onAdd={onAdd} />)

--- a/src/components/reminders/AddItemInput.tsx
+++ b/src/components/reminders/AddItemInput.tsx
@@ -32,7 +32,7 @@ export function AddItemInput({ onAdd }: Props) {
         value={value}
         onChange={(e) => setValue(e.target.value)}
         placeholder="아이템 추가..."
-        className="flex-1 px-4 py-2.5 rounded-xl border border-stone-200 dark:border-stone-700 bg-stone-50 dark:bg-stone-800 text-stone-900 dark:text-stone-100 placeholder-stone-400 focus:outline-none focus:ring-2 focus:ring-accent-300 dark:focus:ring-accent-500 transition text-sm"
+        className="flex-1 px-4 py-2.5 rounded-xl border border-stone-200 dark:border-stone-700 bg-stone-50 dark:bg-stone-800 text-stone-900 dark:text-stone-100 placeholder-stone-400 focus:outline-none focus:ring-2 focus:ring-accent-300 dark:focus:ring-accent-500 transition text-base"
       />
       <button
         type="submit"


### PR DESCRIPTION
## Summary
- 리마인더 상세 하단의 아이템 추가 입력창을 text-base로 변경해 iOS Safari 포커스 확대를 방지했습니다.
- 입력창 font-size 회귀 방지 테스트를 추가했습니다.

## Testing
- npm run test -- --runTestsByPath src/__tests__/reminders/AddItemInput.test.tsx
- npx tsc --noEmit