### PR TITLE
feat: focus add input after reminder item edit

### DIFF
--- a/src/__tests__/reminders/ReminderDetailView.test.tsx
+++ b/src/__tests__/reminders/ReminderDetailView.test.tsx
@@ -2,7 +2,12 @@ import { render, screen, waitFor, act, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { User } from '@supabase/supabase-js'
 import { ReminderDetailView } from '@/components/reminders/ReminderDetailView'
-import { getReminderItems, getReminderList, updateReminderListGroup } from '@/lib/reminder-lists'
+import {
+  getReminderItems,
+  getReminderList,
+  renameReminderItem,
+  updateReminderListGroup,
+} from '@/lib/reminder-lists'
 
 const mockBroadcast = jest.fn()
 const mockUseRealtimeSync = jest.fn((...args: unknown[]) => {
@@ -55,6 +60,7 @@ jest.mock('@dnd-kit/utilities', () => ({
 
 const mockGetReminderList = getReminderList as jest.MockedFunction<typeof getReminderList>
 const mockGetReminderItems = getReminderItems as jest.MockedFunction<typeof getReminderItems>
+const mockRenameReminderItem = renameReminderItem as jest.MockedFunction<typeof renameReminderItem>
 const mockUpdateReminderListGroup = updateReminderListGroup as jest.MockedFunction<typeof updateReminderListGroup>
 
 describe('ReminderDetailView', () => {
@@ -75,6 +81,7 @@ describe('ReminderDetailView', () => {
       created_at: '2026-01-01T00:00:00Z',
     } as never)
     mockGetReminderItems.mockResolvedValue([] as never)
+    mockRenameReminderItem.mockResolvedValue(undefined as never)
     mockUpdateReminderListGroup.mockResolvedValue({
       id: 'list-1',
       family_id: 'fam-1',
@@ -235,6 +242,267 @@ describe('ReminderDetailView', () => {
     await waitFor(() => {
       expect(onListGroupChange).toHaveBeenCalledWith('list-1', 'group-1')
     })
+  })
+
+  it('아이템 이름 수정 후 Enter를 누르면 새 아이템 입력창으로 이동한다', async () => {
+    const user = userEvent.setup()
+    mockGetReminderItems.mockResolvedValueOnce([
+      {
+        id: 'item-1',
+        list_id: 'list-1',
+        created_by: 'user-1',
+        name: '우유',
+        is_checked: false,
+        checked_by: null,
+        checked_at: null,
+        sort_order: 0,
+        created_at: '2026-01-01T00:00:00Z',
+      },
+      {
+        id: 'item-2',
+        list_id: 'list-1',
+        created_by: 'user-1',
+        name: '달걀',
+        is_checked: false,
+        checked_by: null,
+        checked_at: null,
+        sort_order: 1,
+        created_at: '2026-01-01T00:00:00Z',
+      },
+    ] as never)
+
+    render(
+      <ReminderDetailView
+        listId="list-1"
+        user={mockUser}
+        onClose={onClose}
+        onPreviewItemsChange={onPreviewItemsChange}
+      />
+    )
+
+    await user.click(await screen.findByText('우유'))
+    const firstInput = screen.getByLabelText('아이템 이름 수정')
+    await user.clear(firstInput)
+    await user.type(firstInput, '두유')
+    await user.keyboard('{Enter}')
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('아이템 추가...')).toHaveFocus()
+    })
+    expect(screen.queryByLabelText('아이템 이름 수정')).not.toBeInTheDocument()
+    expect(mockRenameReminderItem).toHaveBeenCalledWith('item-1', '두유')
+  })
+
+  it('마지막 아이템 이름 수정 후 Enter를 눌러도 새 아이템 입력창으로 이동한다', async () => {
+    const user = userEvent.setup()
+    mockGetReminderItems.mockResolvedValueOnce([
+      {
+        id: 'item-1',
+        list_id: 'list-1',
+        created_by: 'user-1',
+        name: '우유',
+        is_checked: false,
+        checked_by: null,
+        checked_at: null,
+        sort_order: 0,
+        created_at: '2026-01-01T00:00:00Z',
+      },
+    ] as never)
+
+    render(
+      <ReminderDetailView
+        listId="list-1"
+        user={mockUser}
+        onClose={onClose}
+        onPreviewItemsChange={onPreviewItemsChange}
+      />
+    )
+
+    await user.click(await screen.findByText('우유'))
+    const editInput = screen.getByLabelText('아이템 이름 수정')
+    await user.clear(editInput)
+    await user.type(editInput, '두유')
+    await user.keyboard('{Enter}')
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('아이템 추가...')).toHaveFocus()
+    })
+    expect(mockRenameReminderItem).toHaveBeenCalledWith('item-1', '두유')
+  })
+
+  it('이전 아이템 blur 저장이 늦게 완료되어도 새 편집 세션을 닫지 않는다', async () => {
+    const user = userEvent.setup()
+    let resolveRename: () => void = () => {}
+    mockGetReminderItems.mockResolvedValueOnce([
+      {
+        id: 'item-1',
+        list_id: 'list-1',
+        created_by: 'user-1',
+        name: '우유',
+        is_checked: false,
+        checked_by: null,
+        checked_at: null,
+        sort_order: 0,
+        created_at: '2026-01-01T00:00:00Z',
+      },
+      {
+        id: 'item-2',
+        list_id: 'list-1',
+        created_by: 'user-1',
+        name: '달걀',
+        is_checked: false,
+        checked_by: null,
+        checked_at: null,
+        sort_order: 1,
+        created_at: '2026-01-01T00:00:00Z',
+      },
+    ] as never)
+    mockRenameReminderItem.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRename = resolve
+        }) as never
+    )
+
+    render(
+      <ReminderDetailView
+        listId="list-1"
+        user={mockUser}
+        onClose={onClose}
+        onPreviewItemsChange={onPreviewItemsChange}
+      />
+    )
+
+    await user.click(await screen.findByText('우유'))
+    const firstInput = screen.getByLabelText('아이템 이름 수정')
+    await user.clear(firstInput)
+    await user.type(firstInput, '두유')
+    await user.click(screen.getByText('달걀'))
+
+    const secondInput = screen.getByLabelText('아이템 이름 수정')
+    expect(secondInput).toHaveValue('달걀')
+
+    await act(async () => {
+      resolveRename()
+    })
+
+    await waitFor(() => {
+      const currentInput = screen.getByLabelText('아이템 이름 수정')
+      expect(currentInput).toHaveValue('달걀')
+      expect(currentInput).toHaveFocus()
+    })
+  })
+
+  it('이전 아이템 Enter 저장이 늦게 완료되어도 새 편집 세션을 닫지 않는다', async () => {
+    const user = userEvent.setup()
+    let resolveRename: () => void = () => {}
+    mockGetReminderItems.mockResolvedValueOnce([
+      {
+        id: 'item-1',
+        list_id: 'list-1',
+        created_by: 'user-1',
+        name: '우유',
+        is_checked: false,
+        checked_by: null,
+        checked_at: null,
+        sort_order: 0,
+        created_at: '2026-01-01T00:00:00Z',
+      },
+      {
+        id: 'item-2',
+        list_id: 'list-1',
+        created_by: 'user-1',
+        name: '달걀',
+        is_checked: false,
+        checked_by: null,
+        checked_at: null,
+        sort_order: 1,
+        created_at: '2026-01-01T00:00:00Z',
+      },
+    ] as never)
+    mockRenameReminderItem.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRename = resolve
+        }) as never
+    )
+
+    render(
+      <ReminderDetailView
+        listId="list-1"
+        user={mockUser}
+        onClose={onClose}
+        onPreviewItemsChange={onPreviewItemsChange}
+      />
+    )
+
+    await user.click(await screen.findByText('우유'))
+    const firstInput = screen.getByLabelText('아이템 이름 수정')
+    await user.clear(firstInput)
+    await user.type(firstInput, '두유')
+    await user.keyboard('{Enter}')
+    await user.click(screen.getByText('달걀'))
+
+    expect(screen.getByLabelText('아이템 이름 수정')).toHaveValue('달걀')
+
+    await act(async () => {
+      resolveRename()
+    })
+
+    await waitFor(() => {
+      const currentInput = screen.getByLabelText('아이템 이름 수정')
+      expect(currentInput).toHaveValue('달걀')
+      expect(currentInput).toHaveFocus()
+    })
+    expect(screen.getByPlaceholderText('아이템 추가...')).not.toHaveFocus()
+  })
+
+  it('아이템 이름 저장 실패 시 다음 입력으로 이동하지 않고 현재 편집을 유지한다', async () => {
+    const user = userEvent.setup()
+    mockGetReminderItems.mockResolvedValueOnce([
+      {
+        id: 'item-1',
+        list_id: 'list-1',
+        created_by: 'user-1',
+        name: '우유',
+        is_checked: false,
+        checked_by: null,
+        checked_at: null,
+        sort_order: 0,
+        created_at: '2026-01-01T00:00:00Z',
+      },
+      {
+        id: 'item-2',
+        list_id: 'list-1',
+        created_by: 'user-1',
+        name: '달걀',
+        is_checked: false,
+        checked_by: null,
+        checked_at: null,
+        sort_order: 1,
+        created_at: '2026-01-01T00:00:00Z',
+      },
+    ] as never)
+    mockRenameReminderItem.mockRejectedValueOnce(new Error('rename failed'))
+
+    render(
+      <ReminderDetailView
+        listId="list-1"
+        user={mockUser}
+        onClose={onClose}
+        onPreviewItemsChange={onPreviewItemsChange}
+      />
+    )
+
+    await user.click(await screen.findByText('우유'))
+    const firstInput = screen.getByLabelText('아이템 이름 수정')
+    await user.clear(firstInput)
+    await user.type(firstInput, '두유')
+    await user.keyboard('{Enter}')
+
+    expect(await screen.findByText('아이템 이름을 저장하지 못했어요')).toBeInTheDocument()
+    expect(screen.getByLabelText('아이템 이름 수정')).toHaveValue('두유')
+    expect(screen.getByLabelText('아이템 이름 수정')).toHaveFocus()
   })
 
   it('리마인더 그룹 변경 실패 시 이전 그룹으로 되돌리고 에러를 표시한다', async () => {

--- a/src/components/reminders/AddItemInput.tsx
+++ b/src/components/reminders/AddItemInput.tsx
@@ -1,13 +1,13 @@
 'use client'
 
-import { useState } from 'react'
+import { forwardRef, useState } from 'react'
 import { Plus } from 'lucide-react'
 
 interface Props {
   onAdd: (name: string) => Promise<boolean>
 }
 
-export function AddItemInput({ onAdd }: Props) {
+export const AddItemInput = forwardRef<HTMLInputElement, Props>(function AddItemInput({ onAdd }, ref) {
   const [value, setValue] = useState('')
   const [loading, setLoading] = useState(false)
 
@@ -28,6 +28,7 @@ export function AddItemInput({ onAdd }: Props) {
   return (
     <form onSubmit={handleSubmit} className="flex gap-2 px-4 py-3">
       <input
+        ref={ref}
         type="text"
         value={value}
         onChange={(e) => setValue(e.target.value)}
@@ -44,4 +45,4 @@ export function AddItemInput({ onAdd }: Props) {
       </button>
     </form>
   )
-}
+})

--- a/src/components/reminders/ReminderDetailView.tsx
+++ b/src/components/reminders/ReminderDetailView.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { ArrowLeft, ListChecks } from 'lucide-react'
 import {
   DndContext,
@@ -52,6 +52,8 @@ export function ReminderDetailView({
   const [status, setStatus] = useState<DetailStatus>('loading')
   const [mutationError, setMutationError] = useState<string | null>(null)
   const [groupSaving, setGroupSaving] = useState(false)
+  const [editingItemId, setEditingItemId] = useState<string | null>(null)
+  const addInputRef = useRef<HTMLInputElement>(null)
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
@@ -264,7 +266,7 @@ export function ReminderDetailView({
     }
   }
 
-  const handleRename = async (itemId: string, name: string) => {
+  const handleRename = async (itemId: string, name: string): Promise<boolean> => {
     setMutationError(null)
     const previousItems = items
     setItemsWithPreview((prev) =>
@@ -274,10 +276,12 @@ export function ReminderDetailView({
     try {
       await renameReminderItem(itemId, name)
       broadcast()
+      return true
     } catch (e) {
       console.error('[ReminderDetailView] renameReminderItem failed:', e)
       setItemsWithPreview(previousItems)
       setMutationError('아이템 이름을 저장하지 못했어요')
+      return false
     }
   }
 
@@ -348,6 +352,19 @@ export function ReminderDetailView({
   const currentGroup = list?.reminder_group_id
     ? groups.find((group) => group.id === list.reminder_group_id) ?? null
     : null
+  const handleAdvanceEdit = useCallback((itemId: string) => {
+    setEditingItemId((currentItemId) => {
+      if (currentItemId !== itemId) return currentItemId
+
+      requestAnimationFrame(() => {
+        addInputRef.current?.focus()
+      })
+      return null
+    })
+  }, [])
+  const handleEditEnd = useCallback((itemId: string) => {
+    setEditingItemId((currentItemId) => (currentItemId === itemId ? null : currentItemId))
+  }, [])
 
   return (
     <div
@@ -460,6 +477,10 @@ export function ReminderDetailView({
                     onCheck={handleCheck}
                     onDelete={handleDelete}
                     onRename={handleRename}
+                    isEditing={editingItemId === item.id}
+                    onEditStart={setEditingItemId}
+                    onEditEnd={handleEditEnd}
+                    onAdvanceEdit={handleAdvanceEdit}
                     draggable
                   />
                 ))}
@@ -481,6 +502,10 @@ export function ReminderDetailView({
                     onCheck={handleCheck}
                     onDelete={handleDelete}
                     onRename={handleRename}
+                    isEditing={editingItemId === item.id}
+                    onEditStart={setEditingItemId}
+                    onEditEnd={handleEditEnd}
+                    onAdvanceEdit={handleAdvanceEdit}
                   />
                 ))}
               </>
@@ -491,7 +516,7 @@ export function ReminderDetailView({
             data-testid="reminder-detail-footer"
             className="shrink-0 border-t border-stone-100 dark:border-stone-800 bg-white dark:bg-stone-950 pb-safe"
           >
-            <AddItemInput onAdd={handleAdd} />
+            <AddItemInput ref={addInputRef} onAdd={handleAdd} />
           </div>
         </div>
       )}

--- a/src/components/reminders/ReminderItem.tsx
+++ b/src/components/reminders/ReminderItem.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { GripVertical, Trash2 } from 'lucide-react'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
@@ -11,14 +11,32 @@ interface Props {
   listType: 'strikethrough' | 'delete'
   onCheck: (itemId: string, checked: boolean) => void
   onDelete: (itemId: string) => void
-  onRename: (itemId: string, name: string) => void
+  onRename: (itemId: string, name: string) => Promise<boolean | void> | boolean | void
+  isEditing?: boolean
+  onEditStart?: (itemId: string) => void
+  onEditEnd?: (itemId: string) => void
+  onAdvanceEdit?: (itemId: string) => void
   draggable?: boolean
 }
 
-export function ReminderItem({ item, listType, onCheck, onDelete, onRename, draggable = false }: Props) {
-  const [editing, setEditing] = useState(false)
+export function ReminderItem({
+  item,
+  listType,
+  onCheck,
+  onDelete,
+  onRename,
+  isEditing,
+  onEditStart,
+  onEditEnd,
+  onAdvanceEdit,
+  draggable = false,
+}: Props) {
+  const [internalEditing, setInternalEditing] = useState(false)
   const [editValue, setEditValue] = useState(item.name)
   const [confirming, setConfirming] = useState(false)
+  const committingRef = useRef(false)
+  const wasEditingRef = useRef(false)
+  const editing = isEditing ?? internalEditing
 
   const {
     attributes,
@@ -37,24 +55,68 @@ export function ReminderItem({ item, listType, onCheck, onDelete, onRename, drag
 
   const handleNameClick = () => {
     setEditValue(item.name)
-    setEditing(true)
+    if (onEditStart) {
+      onEditStart(item.id)
+    } else {
+      setInternalEditing(true)
+    }
   }
 
-  const commitEdit = () => {
-    const trimmed = editValue.trim()
-    if (trimmed && trimmed !== item.name) {
-      onRename(item.id, trimmed)
-    } else {
+  useEffect(() => {
+    if (editing && !wasEditingRef.current) {
       setEditValue(item.name)
     }
-    setEditing(false)
+    wasEditingRef.current = editing
+  }, [editing, item.name])
+
+  const endEditing = () => {
+    if (onEditEnd) {
+      onEditEnd(item.id)
+    } else {
+      setInternalEditing(false)
+    }
+  }
+
+  const commitEdit = async (advanceAfterSave = false) => {
+    const trimmed = editValue.trim()
+    if (!trimmed) {
+      setEditValue(item.name)
+      endEditing()
+      return
+    }
+
+    if (trimmed === item.name) {
+      if (advanceAfterSave && onAdvanceEdit) {
+        onAdvanceEdit(item.id)
+      } else {
+        endEditing()
+      }
+      return
+    }
+
+    committingRef.current = true
+    try {
+      const renamed = await onRename(item.id, trimmed)
+      if (renamed === false) return
+
+      if (advanceAfterSave && onAdvanceEdit) {
+        onAdvanceEdit(item.id)
+      } else {
+        endEditing()
+      }
+    } finally {
+      committingRef.current = false
+    }
   }
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') commitEdit()
+    if (e.key === 'Enter') {
+      e.preventDefault()
+      void commitEdit(true)
+    }
     if (e.key === 'Escape') {
       setEditValue(item.name)
-      setEditing(false)
+      endEditing()
     }
   }
 
@@ -112,7 +174,9 @@ export function ReminderItem({ item, listType, onCheck, onDelete, onRename, drag
             const len = e.target.value.length
             e.target.setSelectionRange(len, len)
           }}
-          onBlur={commitEdit}
+          onBlur={() => {
+            if (!committingRef.current) void commitEdit(false)
+          }}
           onKeyDown={handleKeyDown}
           className="flex-1 text-stone-800 dark:text-stone-100 bg-transparent border-b border-accent-400 outline-none"
           aria-label="아이템 이름 수정"


### PR DESCRIPTION
## Summary
- 리마인더 아이템 이름 수정 중 Enter를 누르면 저장 성공 후 새 아이템 입력창으로 포커스하도록 변경했습니다.
- 수정 중 다른 곳을 눌러 벗어나면 현재 값으로 저장하고, 저장 실패 시 현재 편집 상태를 유지합니다.
- 추가 입력창 focus 연결과 편집 이동 동작을 검증하는 테스트를 추가했습니다.

## Testing
- npm run test -- --runTestsByPath src/__tests__/reminders/ReminderItem.test.tsx src/__tests__/reminders/ReminderDetailView.test.tsx src/__tests__/reminders/AddItemInput.test.tsx
- npm run lint
- npx tsc --noEmit