### PR TITLE
fix: open inline add input after reminder edit

### DIFF
--- a/src/__tests__/lib/reminder-groups-sql.test.ts
+++ b/src/__tests__/lib/reminder-groups-sql.test.ts
@@ -21,12 +21,17 @@ const updateListGroupMigrationPath = path.join(
   process.cwd(),
   'supabase/migrations/20260509003000_update_shopping_list_group_authorized.sql'
 )
+const addItemMigrationPath = path.join(
+  process.cwd(),
+  'supabase/migrations/20260513000000_add_shopping_item_authorized.sql'
+)
 
 const sql = () => fs.readFileSync(migrationPath, 'utf8')
 const ownerAccessSql = () => fs.readFileSync(ownerAccessMigrationPath, 'utf8')
 const createListSql = () => fs.readFileSync(createListMigrationPath, 'utf8')
 const lockDirectInsertSql = () => fs.readFileSync(lockDirectInsertMigrationPath, 'utf8')
 const updateListGroupSql = () => fs.readFileSync(updateListGroupMigrationPath, 'utf8')
+const addItemSql = () => fs.readFileSync(addItemMigrationPath, 'utf8')
 
 describe('reminder groups migration', () => {
   it('does not expose grouped lists by clearing reminder_group_id on group delete', () => {
@@ -98,5 +103,18 @@ describe('reminder groups migration', () => {
     expect(migration).toContain("set_config('app.allow_reminder_list_scope_change', 'on', true)")
     expect(migration).toContain('set reminder_group_id = p_reminder_group_id')
     expect(migration).toContain('grant execute on function update_shopping_list_group_authorized')
+  })
+
+  it('adds reminder items below an anchor through one authorized RPC', () => {
+    const migration = addItemSql()
+
+    expect(migration).toContain('create or replace function add_shopping_item_authorized')
+    expect(migration).toContain('v_actor_id uuid := auth.uid()')
+    expect(migration).toContain('where fm.family_id = v_list.family_id')
+    expect(migration).toContain('where id = p_after_item_id')
+    expect(migration).toContain('and list_id = p_list_id')
+    expect(migration).toContain('set sort_order = sort_order + 1')
+    expect(migration).toContain('insert into shopping_items')
+    expect(migration).toContain('grant execute on function add_shopping_item_authorized')
   })
 })

--- a/src/__tests__/lib/reminder-lists.test.ts
+++ b/src/__tests__/lib/reminder-lists.test.ts
@@ -393,13 +393,19 @@ describe('getReminderItems', () => {
 describe('addReminderItem', () => {
   it('생성된 아이템을 반환한다', async () => {
     const mockItem = { id: 'item-1', name: '우유', is_checked: false }
-    mockFrom.mockReturnValue(makeChain({ data: mockItem, error: null }))
-    const result = await addReminderItem('list-1', 'user-1', '우유')
+    mockRpc.mockResolvedValue({ data: mockItem, error: null })
+    const result = await addReminderItem('list-1', 'user-1', '우유', 'item-0')
     expect(result).toEqual(mockItem)
+    expect(mockRpc).toHaveBeenCalledWith('add_shopping_item_authorized', {
+      p_actor_user_id: 'user-1',
+      p_list_id: 'list-1',
+      p_name: '우유',
+      p_after_item_id: 'item-0',
+    })
   })
 
   it('error가 있으면 throw한다', async () => {
-    mockFrom.mockReturnValue(makeChain({ data: null, error: { message: 'insert error' } }))
+    mockRpc.mockResolvedValue({ data: null, error: { message: 'insert error' } })
     await expect(addReminderItem('list-1', 'user-1', '우유')).rejects.toEqual({ message: 'insert error' })
   })
 })

--- a/src/__tests__/reminders/AddItemInput.test.tsx
+++ b/src/__tests__/reminders/AddItemInput.test.tsx
@@ -50,4 +50,28 @@ describe('AddItemInput', () => {
       expect(screen.getByLabelText('추가')).not.toBeDisabled()
     })
   })
+
+  it('inline 입력창이 비어 있는 상태로 blur되면 취소 콜백을 호출한다', async () => {
+    const onCancelEmpty = jest.fn()
+    const user = userEvent.setup()
+    render(<AddItemInput onAdd={jest.fn()} onCancelEmpty={onCancelEmpty} inline />)
+
+    const input = screen.getByPlaceholderText('아이템 추가...')
+    await user.click(input)
+    await user.tab()
+
+    expect(onCancelEmpty).toHaveBeenCalledTimes(1)
+  })
+
+  it('inline 입력창에 값이 있으면 blur되어도 취소하지 않는다', async () => {
+    const onCancelEmpty = jest.fn()
+    const user = userEvent.setup()
+    render(<AddItemInput onAdd={jest.fn()} onCancelEmpty={onCancelEmpty} inline />)
+
+    const input = screen.getByPlaceholderText('아이템 추가...')
+    await user.type(input, '우유')
+    await user.tab()
+
+    expect(onCancelEmpty).not.toHaveBeenCalled()
+  })
 })

--- a/src/__tests__/reminders/ReminderDetailView.test.tsx
+++ b/src/__tests__/reminders/ReminderDetailView.test.tsx
@@ -3,9 +3,13 @@ import userEvent from '@testing-library/user-event'
 import type { User } from '@supabase/supabase-js'
 import { ReminderDetailView } from '@/components/reminders/ReminderDetailView'
 import {
+  addReminderItem,
+  checkReminderItem,
+  deleteReminderItem,
   getReminderItems,
   getReminderList,
   renameReminderItem,
+  reorderReminderItems,
   updateReminderListGroup,
 } from '@/lib/reminder-lists'
 
@@ -60,7 +64,11 @@ jest.mock('@dnd-kit/utilities', () => ({
 
 const mockGetReminderList = getReminderList as jest.MockedFunction<typeof getReminderList>
 const mockGetReminderItems = getReminderItems as jest.MockedFunction<typeof getReminderItems>
+const mockAddReminderItem = addReminderItem as jest.MockedFunction<typeof addReminderItem>
+const mockCheckReminderItem = checkReminderItem as jest.MockedFunction<typeof checkReminderItem>
+const mockDeleteReminderItem = deleteReminderItem as jest.MockedFunction<typeof deleteReminderItem>
 const mockRenameReminderItem = renameReminderItem as jest.MockedFunction<typeof renameReminderItem>
+const mockReorderReminderItems = reorderReminderItems as jest.MockedFunction<typeof reorderReminderItems>
 const mockUpdateReminderListGroup = updateReminderListGroup as jest.MockedFunction<typeof updateReminderListGroup>
 
 describe('ReminderDetailView', () => {
@@ -81,7 +89,21 @@ describe('ReminderDetailView', () => {
       created_at: '2026-01-01T00:00:00Z',
     } as never)
     mockGetReminderItems.mockResolvedValue([] as never)
+    mockAddReminderItem.mockResolvedValue({
+      id: 'created-item',
+      list_id: 'list-1',
+      created_by: 'user-1',
+      name: '새 항목',
+      is_checked: false,
+      checked_by: null,
+      checked_at: null,
+      sort_order: 0,
+      created_at: '2026-01-01T00:00:00Z',
+    } as never)
     mockRenameReminderItem.mockResolvedValue(undefined as never)
+    mockCheckReminderItem.mockResolvedValue(undefined as never)
+    mockDeleteReminderItem.mockResolvedValue(undefined as never)
+    mockReorderReminderItems.mockResolvedValue(undefined as never)
     mockUpdateReminderListGroup.mockResolvedValue({
       id: 'list-1',
       family_id: 'fam-1',
@@ -244,7 +266,7 @@ describe('ReminderDetailView', () => {
     })
   })
 
-  it('아이템 이름 수정 후 Enter를 누르면 새 아이템 입력창으로 이동한다', async () => {
+  it('아이템 이름 수정 후 Enter를 누르면 아이템 바로 아래에 새 입력창을 연다', async () => {
     const user = userEvent.setup()
     mockGetReminderItems.mockResolvedValueOnce([
       {
@@ -286,14 +308,15 @@ describe('ReminderDetailView', () => {
     await user.type(firstInput, '두유')
     await user.keyboard('{Enter}')
 
+    const inlineAddInput = await screen.findByTestId('inline-add-item-input')
     await waitFor(() => {
-      expect(screen.getByPlaceholderText('아이템 추가...')).toHaveFocus()
+      expect(within(inlineAddInput).getByPlaceholderText('아이템 추가...')).toHaveFocus()
     })
     expect(screen.queryByLabelText('아이템 이름 수정')).not.toBeInTheDocument()
     expect(mockRenameReminderItem).toHaveBeenCalledWith('item-1', '두유')
   })
 
-  it('마지막 아이템 이름 수정 후 Enter를 눌러도 새 아이템 입력창으로 이동한다', async () => {
+  it('마지막 아이템 이름 수정 후 Enter를 눌러도 아이템 바로 아래에 새 입력창을 연다', async () => {
     const user = userEvent.setup()
     mockGetReminderItems.mockResolvedValueOnce([
       {
@@ -324,10 +347,213 @@ describe('ReminderDetailView', () => {
     await user.type(editInput, '두유')
     await user.keyboard('{Enter}')
 
+    const inlineAddInput = await screen.findByTestId('inline-add-item-input')
     await waitFor(() => {
-      expect(screen.getByPlaceholderText('아이템 추가...')).toHaveFocus()
+      expect(within(inlineAddInput).getByPlaceholderText('아이템 추가...')).toHaveFocus()
     })
     expect(mockRenameReminderItem).toHaveBeenCalledWith('item-1', '두유')
+  })
+
+  it('인라인 입력창에서 추가한 아이템을 편집한 아이템 바로 아래에 저장한다', async () => {
+    const user = userEvent.setup()
+    mockGetReminderItems.mockResolvedValueOnce([
+      {
+        id: 'item-1',
+        list_id: 'list-1',
+        created_by: 'user-1',
+        name: '우유',
+        is_checked: false,
+        checked_by: null,
+        checked_at: null,
+        sort_order: 0,
+        created_at: '2026-01-01T00:00:00Z',
+      },
+      {
+        id: 'item-2',
+        list_id: 'list-1',
+        created_by: 'user-1',
+        name: '달걀',
+        is_checked: false,
+        checked_by: null,
+        checked_at: null,
+        sort_order: 1,
+        created_at: '2026-01-01T00:00:00Z',
+      },
+    ] as never)
+    mockAddReminderItem.mockResolvedValueOnce({
+      id: 'item-new',
+      list_id: 'list-1',
+      created_by: 'user-1',
+      name: '버터',
+      is_checked: false,
+      checked_by: null,
+      checked_at: null,
+      sort_order: 1,
+      created_at: '2026-01-01T00:00:01Z',
+    } as never)
+
+    render(
+      <ReminderDetailView
+        listId="list-1"
+        user={mockUser}
+        onClose={onClose}
+        onPreviewItemsChange={onPreviewItemsChange}
+      />
+    )
+
+    await user.click(await screen.findByText('우유'))
+    const editInput = screen.getByLabelText('아이템 이름 수정')
+    await user.clear(editInput)
+    await user.type(editInput, '두유')
+    await user.keyboard('{Enter}')
+
+    const inlineAddInput = await screen.findByTestId('inline-add-item-input')
+    await user.type(within(inlineAddInput).getByPlaceholderText('아이템 추가...'), '버터')
+    await user.keyboard('{Enter}')
+
+    expect(mockAddReminderItem).toHaveBeenCalledWith('list-1', 'user-1', '버터', 'item-1')
+    expect(mockReorderReminderItems).not.toHaveBeenCalled()
+    expect(onPreviewItemsChange).toHaveBeenLastCalledWith(
+      'list-1',
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'item-1', sort_order: 0 }),
+        expect.objectContaining({ id: 'item-new', name: '버터', sort_order: 1 }),
+        expect.objectContaining({ id: 'item-2', sort_order: 2 }),
+      ])
+    )
+  })
+
+  it('인라인 입력 기준 아이템을 삭제하면 인라인 입력창을 닫는다', async () => {
+    const user = userEvent.setup()
+    mockGetReminderItems.mockResolvedValueOnce([
+      {
+        id: 'item-1',
+        list_id: 'list-1',
+        created_by: 'user-1',
+        name: '우유',
+        is_checked: false,
+        checked_by: null,
+        checked_at: null,
+        sort_order: 0,
+        created_at: '2026-01-01T00:00:00Z',
+      },
+      {
+        id: 'item-2',
+        list_id: 'list-1',
+        created_by: 'user-1',
+        name: '달걀',
+        is_checked: false,
+        checked_by: null,
+        checked_at: null,
+        sort_order: 1,
+        created_at: '2026-01-01T00:00:00Z',
+      },
+    ] as never)
+
+    render(
+      <ReminderDetailView
+        listId="list-1"
+        user={mockUser}
+        onClose={onClose}
+        onPreviewItemsChange={onPreviewItemsChange}
+      />
+    )
+
+    await user.click(await screen.findByText('우유'))
+    await user.keyboard('{Enter}')
+    expect(await screen.findByTestId('inline-add-item-input')).toBeInTheDocument()
+
+    await user.click(screen.getAllByLabelText('삭제')[0])
+    await user.click(screen.getByLabelText('삭제 확인'))
+
+    expect(mockDeleteReminderItem).toHaveBeenCalledWith('item-1')
+    await waitFor(() => {
+      expect(screen.queryByTestId('inline-add-item-input')).not.toBeInTheDocument()
+    })
+  })
+
+  it('인라인 입력 기준 아이템을 완료 처리하면 인라인 입력창을 닫는다', async () => {
+    const user = userEvent.setup()
+    mockGetReminderItems.mockResolvedValueOnce([
+      {
+        id: 'item-1',
+        list_id: 'list-1',
+        created_by: 'user-1',
+        name: '우유',
+        is_checked: false,
+        checked_by: null,
+        checked_at: null,
+        sort_order: 0,
+        created_at: '2026-01-01T00:00:00Z',
+      },
+    ] as never)
+
+    render(
+      <ReminderDetailView
+        listId="list-1"
+        user={mockUser}
+        onClose={onClose}
+        onPreviewItemsChange={onPreviewItemsChange}
+      />
+    )
+
+    await user.click(await screen.findByText('우유'))
+    await user.keyboard('{Enter}')
+    expect(await screen.findByTestId('inline-add-item-input')).toBeInTheDocument()
+
+    await user.click(screen.getByLabelText('체크'))
+
+    expect(mockCheckReminderItem).toHaveBeenCalledWith('item-1', 'user-1', true)
+    await waitFor(() => {
+      expect(screen.queryByTestId('inline-add-item-input')).not.toBeInTheDocument()
+    })
+  })
+
+  it('빈 인라인 입력창이 포커스를 잃으면 입력창을 닫는다', async () => {
+    const user = userEvent.setup()
+    mockGetReminderItems.mockResolvedValueOnce([
+      {
+        id: 'item-1',
+        list_id: 'list-1',
+        created_by: 'user-1',
+        name: '우유',
+        is_checked: false,
+        checked_by: null,
+        checked_at: null,
+        sort_order: 0,
+        created_at: '2026-01-01T00:00:00Z',
+      },
+      {
+        id: 'item-2',
+        list_id: 'list-1',
+        created_by: 'user-1',
+        name: '달걀',
+        is_checked: false,
+        checked_by: null,
+        checked_at: null,
+        sort_order: 1,
+        created_at: '2026-01-01T00:00:00Z',
+      },
+    ] as never)
+
+    render(
+      <ReminderDetailView
+        listId="list-1"
+        user={mockUser}
+        onClose={onClose}
+        onPreviewItemsChange={onPreviewItemsChange}
+      />
+    )
+
+    await user.click(await screen.findByText('우유'))
+    await user.keyboard('{Enter}')
+    expect(await screen.findByTestId('inline-add-item-input')).toBeInTheDocument()
+
+    await user.click(screen.getByText('달걀'))
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('inline-add-item-input')).not.toBeInTheDocument()
+    })
   })
 
   it('이전 아이템 blur 저장이 늦게 완료되어도 새 편집 세션을 닫지 않는다', async () => {
@@ -454,7 +680,7 @@ describe('ReminderDetailView', () => {
       expect(currentInput).toHaveValue('달걀')
       expect(currentInput).toHaveFocus()
     })
-    expect(screen.getByPlaceholderText('아이템 추가...')).not.toHaveFocus()
+    expect(screen.queryByTestId('inline-add-item-input')).not.toBeInTheDocument()
   })
 
   it('아이템 이름 저장 실패 시 다음 입력으로 이동하지 않고 현재 편집을 유지한다', async () => {

--- a/src/components/reminders/AddItemInput.tsx
+++ b/src/components/reminders/AddItemInput.tsx
@@ -5,9 +5,15 @@ import { Plus } from 'lucide-react'
 
 interface Props {
   onAdd: (name: string) => Promise<boolean>
+  onCancelEmpty?: () => void
+  inline?: boolean
+  testId?: string
 }
 
-export const AddItemInput = forwardRef<HTMLInputElement, Props>(function AddItemInput({ onAdd }, ref) {
+export const AddItemInput = forwardRef<HTMLInputElement, Props>(function AddItemInput(
+  { onAdd, onCancelEmpty, inline = false, testId },
+  ref
+) {
   const [value, setValue] = useState('')
   const [loading, setLoading] = useState(false)
 
@@ -26,23 +32,41 @@ export const AddItemInput = forwardRef<HTMLInputElement, Props>(function AddItem
   }
 
   return (
-    <form onSubmit={handleSubmit} className="flex gap-2 px-4 py-3">
+    <form
+      onSubmit={handleSubmit}
+      data-testid={testId}
+      className={inline ? 'flex items-center gap-3 px-4 py-3' : 'flex gap-2 px-4 py-3'}
+    >
+      {inline && (
+        <span className="h-6 w-6 flex-shrink-0 rounded-full border-2 border-stone-300 dark:border-stone-600" />
+      )}
       <input
         ref={ref}
         type="text"
         value={value}
         onChange={(e) => setValue(e.target.value)}
+        onBlur={() => {
+          if (inline && !loading && !value.trim()) {
+            onCancelEmpty?.()
+          }
+        }}
         placeholder="아이템 추가..."
-        className="flex-1 px-4 py-2.5 rounded-xl border border-stone-200 dark:border-stone-700 bg-stone-50 dark:bg-stone-800 text-stone-900 dark:text-stone-100 placeholder-stone-400 focus:outline-none focus:ring-2 focus:ring-accent-300 dark:focus:ring-accent-500 transition text-base"
+        className={
+          inline
+            ? 'min-w-0 flex-1 bg-transparent py-1 text-base text-stone-900 placeholder-stone-400 outline-none dark:text-stone-100'
+            : 'flex-1 px-4 py-2.5 rounded-xl border border-stone-200 dark:border-stone-700 bg-stone-50 dark:bg-stone-800 text-stone-900 dark:text-stone-100 placeholder-stone-400 focus:outline-none focus:ring-2 focus:ring-accent-300 dark:focus:ring-accent-500 transition text-base'
+        }
       />
-      <button
-        type="submit"
-        disabled={!value.trim() || loading}
-        className="p-2.5 rounded-xl bg-accent-400 hover:bg-accent-500 disabled:bg-stone-200 dark:disabled:bg-stone-700 text-white disabled:text-stone-400 transition-colors flex-shrink-0"
-        aria-label="추가"
-      >
-        <Plus size={20} />
-      </button>
+      {!inline && (
+        <button
+          type="submit"
+          disabled={!value.trim() || loading}
+          className="p-2.5 rounded-xl bg-accent-400 hover:bg-accent-500 disabled:bg-stone-200 dark:disabled:bg-stone-700 text-white disabled:text-stone-400 transition-colors flex-shrink-0"
+          aria-label="추가"
+        >
+          <Plus size={20} />
+        </button>
+      )}
     </form>
   )
 })

--- a/src/components/reminders/ReminderDetailView.tsx
+++ b/src/components/reminders/ReminderDetailView.tsx
@@ -30,6 +30,28 @@ import type { User } from '@supabase/supabase-js'
 
 type DetailStatus = 'loading' | 'ready' | 'not-found' | 'fetch-error'
 
+const withInsertedReminderItem = (
+  currentItems: ReminderItemType[],
+  itemToInsert: ReminderItemType,
+  afterItemId?: string
+): ReminderItemType[] => {
+  const orderedItems = [...currentItems].sort((a, b) => {
+    if (a.sort_order !== b.sort_order) return a.sort_order - b.sort_order
+    return a.created_at.localeCompare(b.created_at)
+  })
+  const anchorIndex = afterItemId
+    ? orderedItems.findIndex((item) => item.id === afterItemId)
+    : -1
+  const insertIndex = anchorIndex >= 0 ? anchorIndex + 1 : orderedItems.length
+  const nextItems = [
+    ...orderedItems.slice(0, insertIndex),
+    itemToInsert,
+    ...orderedItems.slice(insertIndex),
+  ]
+
+  return nextItems.map((item, index) => ({ ...item, sort_order: index }))
+}
+
 interface Props {
   listId: string
   user: User
@@ -53,7 +75,9 @@ export function ReminderDetailView({
   const [mutationError, setMutationError] = useState<string | null>(null)
   const [groupSaving, setGroupSaving] = useState(false)
   const [editingItemId, setEditingItemId] = useState<string | null>(null)
+  const [inlineAddAfterItemId, setInlineAddAfterItemId] = useState<string | null>(null)
   const addInputRef = useRef<HTMLInputElement>(null)
+  const inlineAddInputRef = useRef<HTMLInputElement>(null)
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
@@ -181,7 +205,10 @@ export function ReminderDetailView({
     [syncPreview]
   )
 
-  const handleAdd = async (name: string): Promise<boolean> => {
+  const handleAddItem = useCallback(async (
+    name: string,
+    afterItemId?: string
+  ): Promise<ReminderItemType | null> => {
     setMutationError(null)
     const optimisticItem: ReminderItemType = {
       id: crypto.randomUUID(),
@@ -195,26 +222,56 @@ export function ReminderDetailView({
       created_at: new Date().toISOString(),
     }
     const previousItems = items
-    setItemsWithPreview((prev) => [...prev, optimisticItem])
+    const optimisticItems = withInsertedReminderItem(items, optimisticItem, afterItemId)
+    setItemsWithPreview(optimisticItems)
 
     try {
-      const realItem = await addReminderItem(listId, user.id, name)
-      setItemsWithPreview((prev) =>
-        prev.map((item) => (item.id === optimisticItem.id ? realItem : item))
+      const realItem = await addReminderItem(listId, user.id, name, afterItemId ?? null)
+      const nextItems = optimisticItems.map((item) =>
+        item.id === optimisticItem.id
+          ? { ...realItem, sort_order: item.sort_order }
+          : item
       )
+      setItemsWithPreview(nextItems)
       broadcast()
-      return true
+      return nextItems.find((item) => item.id === realItem.id) ?? realItem
     } catch (e) {
       console.error('[ReminderDetailView] addReminderItem failed:', e)
       setItemsWithPreview(previousItems)
       setMutationError('아이템을 저장하지 못했어요')
-      return false
+      return null
     }
-  }
+  }, [broadcast, items, listId, setItemsWithPreview, user.id])
+
+  const handleFooterAdd = useCallback(
+    async (name: string): Promise<boolean> => {
+      const createdItem = await handleAddItem(name)
+      return createdItem !== null
+    },
+    [handleAddItem]
+  )
+
+  const handleInlineAdd = useCallback(
+    (afterItemId: string) =>
+      async (name: string): Promise<boolean> => {
+        const createdItem = await handleAddItem(name, afterItemId)
+        if (!createdItem) return false
+
+        setInlineAddAfterItemId(createdItem.id)
+        requestAnimationFrame(() => {
+          inlineAddInputRef.current?.focus()
+        })
+        return true
+      },
+    [handleAddItem]
+  )
 
   const handleCheck = async (itemId: string, checked: boolean) => {
     setMutationError(null)
     const previousItems = items
+    if (inlineAddAfterItemId === itemId) {
+      setInlineAddAfterItemId(null)
+    }
 
     if (list?.type === 'delete' && checked) {
       setItemsWithPreview((prev) => prev.filter((item) => item.id !== itemId))
@@ -243,6 +300,9 @@ export function ReminderDetailView({
     } catch (e) {
       console.error('[ReminderDetailView] checkReminderItem failed:', e)
       setItemsWithPreview(previousItems)
+      if (inlineAddAfterItemId === itemId) {
+        setInlineAddAfterItemId(itemId)
+      }
       setMutationError(
         list?.type === 'delete' && checked
           ? '아이템을 삭제하지 못했어요'
@@ -254,6 +314,9 @@ export function ReminderDetailView({
   const handleDelete = async (itemId: string) => {
     setMutationError(null)
     const previousItems = items
+    if (inlineAddAfterItemId === itemId) {
+      setInlineAddAfterItemId(null)
+    }
     setItemsWithPreview((prev) => prev.filter((item) => item.id !== itemId))
 
     try {
@@ -262,6 +325,9 @@ export function ReminderDetailView({
     } catch (e) {
       console.error('[ReminderDetailView] deleteReminderItem failed:', e)
       setItemsWithPreview(previousItems)
+      if (inlineAddAfterItemId === itemId) {
+        setInlineAddAfterItemId(itemId)
+      }
       setMutationError('아이템을 삭제하지 못했어요')
     }
   }
@@ -356,11 +422,16 @@ export function ReminderDetailView({
     setEditingItemId((currentItemId) => {
       if (currentItemId !== itemId) return currentItemId
 
+      setInlineAddAfterItemId(itemId)
       requestAnimationFrame(() => {
-        addInputRef.current?.focus()
+        inlineAddInputRef.current?.focus()
       })
       return null
     })
+  }, [])
+  const handleEditStart = useCallback((itemId: string) => {
+    setInlineAddAfterItemId(null)
+    setEditingItemId(itemId)
   }, [])
   const handleEditEnd = useCallback((itemId: string) => {
     setEditingItemId((currentItemId) => (currentItemId === itemId ? null : currentItemId))
@@ -470,19 +541,29 @@ export function ReminderDetailView({
                 strategy={verticalListSortingStrategy}
               >
                 {uncheckedItems.map((item) => (
-                  <ReminderItem
-                    key={item.id}
-                    item={item}
-                    listType={list?.type === 'delete' ? 'delete' : 'strikethrough'}
-                    onCheck={handleCheck}
-                    onDelete={handleDelete}
-                    onRename={handleRename}
-                    isEditing={editingItemId === item.id}
-                    onEditStart={setEditingItemId}
-                    onEditEnd={handleEditEnd}
-                    onAdvanceEdit={handleAdvanceEdit}
-                    draggable
-                  />
+                  <div key={item.id}>
+                    <ReminderItem
+                      item={item}
+                      listType={list?.type === 'delete' ? 'delete' : 'strikethrough'}
+                      onCheck={handleCheck}
+                      onDelete={handleDelete}
+                      onRename={handleRename}
+                      isEditing={editingItemId === item.id}
+                      onEditStart={handleEditStart}
+                      onEditEnd={handleEditEnd}
+                      onAdvanceEdit={handleAdvanceEdit}
+                      draggable
+                    />
+                    {inlineAddAfterItemId === item.id && (
+                      <AddItemInput
+                        ref={inlineAddInputRef}
+                        onAdd={handleInlineAdd(item.id)}
+                        onCancelEmpty={() => setInlineAddAfterItemId(null)}
+                        inline
+                        testId="inline-add-item-input"
+                      />
+                    )}
+                  </div>
                 ))}
               </SortableContext>
             </DndContext>
@@ -495,18 +576,28 @@ export function ReminderDetailView({
                   </p>
                 </div>
                 {checkedItems.map((item) => (
-                  <ReminderItem
-                    key={item.id}
-                    item={item}
-                    listType="strikethrough"
-                    onCheck={handleCheck}
-                    onDelete={handleDelete}
-                    onRename={handleRename}
-                    isEditing={editingItemId === item.id}
-                    onEditStart={setEditingItemId}
-                    onEditEnd={handleEditEnd}
-                    onAdvanceEdit={handleAdvanceEdit}
-                  />
+                  <div key={item.id}>
+                    <ReminderItem
+                      item={item}
+                      listType="strikethrough"
+                      onCheck={handleCheck}
+                      onDelete={handleDelete}
+                      onRename={handleRename}
+                      isEditing={editingItemId === item.id}
+                      onEditStart={handleEditStart}
+                      onEditEnd={handleEditEnd}
+                      onAdvanceEdit={handleAdvanceEdit}
+                    />
+                    {inlineAddAfterItemId === item.id && (
+                      <AddItemInput
+                        ref={inlineAddInputRef}
+                        onAdd={handleInlineAdd(item.id)}
+                        onCancelEmpty={() => setInlineAddAfterItemId(null)}
+                        inline
+                        testId="inline-add-item-input"
+                      />
+                    )}
+                  </div>
                 ))}
               </>
             )}
@@ -516,7 +607,7 @@ export function ReminderDetailView({
             data-testid="reminder-detail-footer"
             className="shrink-0 border-t border-stone-100 dark:border-stone-800 bg-white dark:bg-stone-950 pb-safe"
           >
-            <AddItemInput ref={addInputRef} onAdd={handleAdd} />
+            <AddItemInput ref={addInputRef} onAdd={handleFooterAdd} />
           </div>
         </div>
       )}

--- a/src/lib/reminder-lists.ts
+++ b/src/lib/reminder-lists.ts
@@ -225,13 +225,15 @@ export async function getReminderItems(listId: string): Promise<ReminderItem[]> 
 export async function addReminderItem(
   listId: string,
   userId: string,
-  name: string
+  name: string,
+  afterItemId: string | null = null
 ): Promise<ReminderItem> {
-  const { data, error } = await supabase
-    .from('shopping_items')
-    .insert({ list_id: listId, created_by: userId, name })
-    .select()
-    .single()
+  const { data, error } = await supabase.rpc('add_shopping_item_authorized', {
+    p_actor_user_id: userId,
+    p_list_id: listId,
+    p_name: name,
+    p_after_item_id: afterItemId,
+  })
 
   if (error) throw error
   return data

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -773,6 +773,15 @@ export type Database = {
         }
         Returns: Database["public"]["Tables"]["shopping_lists"]["Row"]
       }
+      add_shopping_item_authorized: {
+        Args: {
+          p_actor_user_id: string
+          p_list_id: string
+          p_name: string
+          p_after_item_id?: string | null
+        }
+        Returns: Database["public"]["Tables"]["shopping_items"]["Row"]
+      }
       get_my_calendar_ids: {
         Args: Record<PropertyKey, never>
         Returns: string[]

--- a/supabase/migrations/20260513000000_add_shopping_item_authorized.sql
+++ b/supabase/migrations/20260513000000_add_shopping_item_authorized.sql
@@ -1,0 +1,118 @@
+-- ================================================================
+-- Authorized shopping item creation
+--
+-- 인라인 추가는 "anchor 아래 삽입 + 뒤쪽 sort_order 이동 + 새 row 생성"이
+-- 한 트랜잭션이어야 하므로 명시 RPC에서 처리한다.
+-- ================================================================
+
+create or replace function add_shopping_item_authorized(
+  p_actor_user_id uuid,
+  p_list_id uuid,
+  p_name text,
+  p_after_item_id uuid default null
+)
+returns shopping_items
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_actor_id uuid := auth.uid();
+  v_list shopping_lists;
+  v_after_item shopping_items;
+  v_insert_sort_order integer;
+  v_item shopping_items;
+begin
+  if v_actor_id is null or v_actor_id <> p_actor_user_id then
+    raise exception 'forbidden' using errcode = '42501';
+  end if;
+
+  if p_name is null or btrim(p_name) = '' then
+    raise exception 'invalid_name' using errcode = '22023';
+  end if;
+
+  select *
+  into v_list
+  from shopping_lists
+  where id = p_list_id;
+
+  if not found then
+    raise exception 'not_found' using errcode = 'P0002';
+  end if;
+
+  if not exists (
+    select 1
+    from family_members fm
+    where fm.family_id = v_list.family_id
+      and fm.user_id = v_actor_id
+  ) then
+    raise exception 'forbidden' using errcode = '42501';
+  end if;
+
+  if v_list.reminder_group_id is not null and not exists (
+    select 1
+    from reminder_groups rg
+    where rg.id = v_list.reminder_group_id
+      and rg.family_id = v_list.family_id
+      and (
+        rg.created_by = v_actor_id
+        or exists (
+          select 1
+          from reminder_group_members rgm
+          where rgm.reminder_group_id = rg.id
+            and rgm.user_id = v_actor_id
+        )
+      )
+  ) then
+    raise exception 'forbidden' using errcode = '42501';
+  end if;
+
+  if p_after_item_id is null then
+    select coalesce(max(sort_order) + 1, 0)
+    into v_insert_sort_order
+    from shopping_items
+    where list_id = p_list_id;
+  else
+    select *
+    into v_after_item
+    from shopping_items
+    where id = p_after_item_id
+      and list_id = p_list_id;
+
+    if not found then
+      raise exception 'invalid_anchor' using errcode = '22023';
+    end if;
+
+    v_insert_sort_order := v_after_item.sort_order + 1;
+
+    update shopping_items
+    set sort_order = sort_order + 1
+    where list_id = p_list_id
+      and sort_order >= v_insert_sort_order;
+  end if;
+
+  insert into shopping_items (
+    list_id,
+    created_by,
+    name,
+    sort_order
+  )
+  values (
+    p_list_id,
+    v_actor_id,
+    btrim(p_name),
+    v_insert_sort_order
+  )
+  returning * into v_item;
+
+  return v_item;
+end;
+$$;
+
+revoke execute on function add_shopping_item_authorized(
+  uuid, uuid, text, uuid
+) from public, anon;
+
+grant execute on function add_shopping_item_authorized(
+  uuid, uuid, text, uuid
+) to authenticated;


### PR DESCRIPTION
## Summary
- 리마인더 아이템 수정 후 Enter를 누르면 하단 입력창 대신 수정한 아이템 바로 아래에 새 아이템 입력행을 열도록 변경했습니다.
- inline 추가 입력행은 미리알림처럼 원형 체크 자리와 입력 필드만 표시합니다.
- inline 입력행에서 추가한 아이템이 실제로 편집한 아이템 바로 아래에 저장되도록 DB RPC에서 삽입과 sort_order 이동을 한 번에 처리합니다.
- inline 입력 기준 아이템이 삭제되거나 완료 처리되면 inline 입력행을 닫고, 빈 inline 입력행이 포커스를 잃어도 닫히도록 했습니다.
- 기존 지연 저장 race 가드는 유지하고, 테스트 기대값을 inline 입력행 기준으로 갱신했습니다.

## Testing
- npm run test -- --runTestsByPath src/__tests__/reminders/ReminderDetailView.test.tsx src/__tests__/reminders/ReminderItem.test.tsx src/__tests__/reminders/AddItemInput.test.tsx src/__tests__/lib/reminder-lists.test.ts src/__tests__/lib/reminder-groups-sql.test.ts
- npm run lint
- npx tsc --noEmit

## Manual Testing
- [ ] 리마인더 상세에서 첫 번째 아이템을 수정한 뒤 Enter를 눌렀을 때, 해당 아이템 바로 아래에 inline 입력행이 열리는지 확인합니다.
- [ ] inline 입력행에 새 아이템을 입력하고 Enter를 눌렀을 때, 새 아이템이 목록 끝이 아니라 수정했던 아이템 바로 아래에 저장되는지 확인합니다.
- [ ] inline 입력행에서 연속으로 아이템을 추가했을 때, 방금 추가한 아이템 아래로 다음 inline 입력행이 이어지는지 확인합니다.
- [ ] inline 입력행이 열린 상태에서 기준 아이템을 삭제했을 때, inline 입력행이 남지 않는지 확인합니다.
- [ ] inline 입력행이 열린 상태에서 기준 아이템을 완료 처리했을 때, 완료 영역에 빈 입력행이 남지 않는지 확인합니다.
- [ ] 빈 inline 입력행이 열린 상태에서 화면의 다른 곳을 터치했을 때, inline 입력행이 닫히는지 확인합니다.
- [ ] 하단의 일반 추가 입력창으로 아이템을 추가했을 때, 기존처럼 목록 마지막에 추가되는지 확인합니다.