### PR TITLE
polish: add floating reminder item button

### DIFF
--- a/src/__tests__/reminders/ReminderDetailView.test.tsx
+++ b/src/__tests__/reminders/ReminderDetailView.test.tsx
@@ -146,7 +146,8 @@ describe('ReminderDetailView', () => {
     )
 
     expect(await screen.findByText('이마트')).toBeInTheDocument()
-    expect(screen.getByText('아래 입력창에 추가해보세요')).toBeInTheDocument()
+    expect(screen.getByText('오른쪽 아래에서 추가해보세요')).toBeInTheDocument()
+    expect(screen.getByTestId('floating-add-item-button')).toBeInTheDocument()
   })
 
   it('목록이 없으면 not found 상태를 보여준다', async () => {
@@ -556,6 +557,173 @@ describe('ReminderDetailView', () => {
     })
   })
 
+  it('floating 추가 버튼으로 목록 맨 아래에 입력창을 연다', async () => {
+    const user = userEvent.setup()
+    mockGetReminderItems.mockResolvedValueOnce([
+      {
+        id: 'item-1',
+        list_id: 'list-1',
+        created_by: 'user-1',
+        name: '우유',
+        is_checked: false,
+        checked_by: null,
+        checked_at: null,
+        sort_order: 0,
+        created_at: '2026-01-01T00:00:00Z',
+      },
+    ] as never)
+
+    render(
+      <ReminderDetailView
+        listId="list-1"
+        user={mockUser}
+        onClose={onClose}
+        onPreviewItemsChange={onPreviewItemsChange}
+      />
+    )
+
+    await user.click(await screen.findByTestId('floating-add-item-button'))
+
+    const bottomAddInput = await screen.findByTestId('bottom-add-item-input')
+    expect(screen.queryByTestId('floating-add-item-button')).not.toBeInTheDocument()
+    await waitFor(() => {
+      expect(within(bottomAddInput).getByPlaceholderText('아이템 추가...')).toHaveFocus()
+    })
+  })
+
+  it('floating 추가 입력창에서 저장하면 목록 마지막에 추가하고 입력창을 유지한다', async () => {
+    const user = userEvent.setup()
+    mockGetReminderItems.mockResolvedValueOnce([
+      {
+        id: 'item-1',
+        list_id: 'list-1',
+        created_by: 'user-1',
+        name: '우유',
+        is_checked: false,
+        checked_by: null,
+        checked_at: null,
+        sort_order: 0,
+        created_at: '2026-01-01T00:00:00Z',
+      },
+    ] as never)
+    mockAddReminderItem.mockResolvedValueOnce({
+      id: 'item-new',
+      list_id: 'list-1',
+      created_by: 'user-1',
+      name: '버터',
+      is_checked: false,
+      checked_by: null,
+      checked_at: null,
+      sort_order: 1,
+      created_at: '2026-01-01T00:00:01Z',
+    } as never)
+
+    render(
+      <ReminderDetailView
+        listId="list-1"
+        user={mockUser}
+        onClose={onClose}
+        onPreviewItemsChange={onPreviewItemsChange}
+      />
+    )
+
+    await user.click(await screen.findByTestId('floating-add-item-button'))
+    const bottomAddInput = await screen.findByTestId('bottom-add-item-input')
+    await user.type(within(bottomAddInput).getByPlaceholderText('아이템 추가...'), '버터')
+    await user.keyboard('{Enter}')
+
+    expect(mockAddReminderItem).toHaveBeenCalledWith('list-1', 'user-1', '버터', null)
+    await waitFor(() => {
+      expect(screen.getByTestId('bottom-add-item-input')).toBeInTheDocument()
+    })
+    expect(screen.queryByTestId('floating-add-item-button')).not.toBeInTheDocument()
+    expect(onPreviewItemsChange).toHaveBeenLastCalledWith(
+      'list-1',
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'item-1', sort_order: 0 }),
+        expect.objectContaining({ id: 'item-new', name: '버터', sort_order: 1 }),
+      ])
+    )
+  })
+
+  it('완료 아이템이 있어도 floating 추가 입력창은 완료 섹션 위에 열린다', async () => {
+    const user = userEvent.setup()
+    mockGetReminderItems.mockResolvedValueOnce([
+      {
+        id: 'item-1',
+        list_id: 'list-1',
+        created_by: 'user-1',
+        name: '우유',
+        is_checked: false,
+        checked_by: null,
+        checked_at: null,
+        sort_order: 0,
+        created_at: '2026-01-01T00:00:00Z',
+      },
+      {
+        id: 'item-2',
+        list_id: 'list-1',
+        created_by: 'user-1',
+        name: '완료된 항목',
+        is_checked: true,
+        checked_by: 'user-1',
+        checked_at: '2026-01-01T00:00:00Z',
+        sort_order: 1,
+        created_at: '2026-01-01T00:00:00Z',
+      },
+    ] as never)
+
+    render(
+      <ReminderDetailView
+        listId="list-1"
+        user={mockUser}
+        onClose={onClose}
+        onPreviewItemsChange={onPreviewItemsChange}
+      />
+    )
+
+    await user.click(await screen.findByTestId('floating-add-item-button'))
+
+    const scroll = screen.getByTestId('reminder-detail-scroll')
+    const bottomAddInput = await screen.findByTestId('bottom-add-item-input')
+    const completedHeading = screen.getByText('완료 (1)')
+
+    expect(
+      Array.from(scroll.children).indexOf(bottomAddInput)
+    ).toBeLessThan(Array.from(scroll.children).indexOf(completedHeading.parentElement!))
+  })
+
+  it('수정 중에는 floating 추가 버튼을 숨긴다', async () => {
+    const user = userEvent.setup()
+    mockGetReminderItems.mockResolvedValueOnce([
+      {
+        id: 'item-1',
+        list_id: 'list-1',
+        created_by: 'user-1',
+        name: '우유',
+        is_checked: false,
+        checked_by: null,
+        checked_at: null,
+        sort_order: 0,
+        created_at: '2026-01-01T00:00:00Z',
+      },
+    ] as never)
+
+    render(
+      <ReminderDetailView
+        listId="list-1"
+        user={mockUser}
+        onClose={onClose}
+        onPreviewItemsChange={onPreviewItemsChange}
+      />
+    )
+
+    expect(await screen.findByTestId('floating-add-item-button')).toBeInTheDocument()
+    await user.click(screen.getByText('우유'))
+
+    expect(screen.queryByTestId('floating-add-item-button')).not.toBeInTheDocument()
+  })
+
   it('이전 아이템 blur 저장이 늦게 완료되어도 새 편집 세션을 닫지 않는다', async () => {
     const user = userEvent.setup()
     let resolveRename: () => void = () => {}
@@ -791,7 +959,7 @@ describe('ReminderDetailView', () => {
     expect(onPreviewItemsChange).toHaveBeenLastCalledWith('list-1', [])
   })
 
-  it('아이템이 많아도 목록만 스크롤되고 추가 입력란은 화면 안에 유지된다', async () => {
+  it('아이템이 많아도 목록만 스크롤되고 floating 추가 버튼은 화면 안에 유지된다', async () => {
     mockGetReminderItems.mockResolvedValueOnce(
       Array.from({ length: 40 }, (_, index) => ({
         id: `item-${index + 1}`,
@@ -818,10 +986,11 @@ describe('ReminderDetailView', () => {
     expect(await screen.findByText('아이템 40')).toBeInTheDocument()
     expect(screen.getByTestId('reminder-detail-overlay')).toHaveClass('overflow-hidden')
     expect(screen.getByTestId('reminder-detail-shell')).toHaveClass('h-full', 'min-h-0', 'flex', 'flex-col')
-    expect(screen.getByTestId('reminder-detail-scroll')).toHaveClass('flex-1', 'min-h-0', 'overflow-y-auto')
+    const scroll = screen.getByTestId('reminder-detail-scroll')
+    expect(scroll).toHaveClass('flex-1', 'min-h-0', 'overflow-y-auto', 'pt-2')
+    expect(scroll).toHaveStyle({ paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + 6rem)' })
 
-    const footer = screen.getByTestId('reminder-detail-footer')
-    expect(footer).toHaveClass('shrink-0')
-    expect(within(footer).getByPlaceholderText('아이템 추가...')).toBeInTheDocument()
+    expect(screen.queryByTestId('reminder-detail-footer')).not.toBeInTheDocument()
+    expect(screen.getByTestId('floating-add-item-button')).toHaveClass('absolute')
   })
 })

--- a/src/components/reminders/ReminderDetailView.tsx
+++ b/src/components/reminders/ReminderDetailView.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { ArrowLeft, ListChecks } from 'lucide-react'
+import { ArrowLeft, ListChecks, Plus } from 'lucide-react'
 import {
   DndContext,
   PointerSensor,
@@ -76,7 +76,8 @@ export function ReminderDetailView({
   const [groupSaving, setGroupSaving] = useState(false)
   const [editingItemId, setEditingItemId] = useState<string | null>(null)
   const [inlineAddAfterItemId, setInlineAddAfterItemId] = useState<string | null>(null)
-  const addInputRef = useRef<HTMLInputElement>(null)
+  const [showBottomAddInput, setShowBottomAddInput] = useState(false)
+  const bottomAddInputRef = useRef<HTMLInputElement>(null)
   const inlineAddInputRef = useRef<HTMLInputElement>(null)
 
   const sensors = useSensors(
@@ -243,9 +244,14 @@ export function ReminderDetailView({
     }
   }, [broadcast, items, listId, setItemsWithPreview, user.id])
 
-  const handleFooterAdd = useCallback(
+  const handleBottomAdd = useCallback(
     async (name: string): Promise<boolean> => {
       const createdItem = await handleAddItem(name)
+      if (createdItem) {
+        requestAnimationFrame(() => {
+          bottomAddInputRef.current?.focus()
+        })
+      }
       return createdItem !== null
     },
     [handleAddItem]
@@ -422,6 +428,7 @@ export function ReminderDetailView({
     setEditingItemId((currentItemId) => {
       if (currentItemId !== itemId) return currentItemId
 
+      setShowBottomAddInput(false)
       setInlineAddAfterItemId(itemId)
       requestAnimationFrame(() => {
         inlineAddInputRef.current?.focus()
@@ -431,11 +438,22 @@ export function ReminderDetailView({
   }, [])
   const handleEditStart = useCallback((itemId: string) => {
     setInlineAddAfterItemId(null)
+    setShowBottomAddInput(false)
     setEditingItemId(itemId)
   }, [])
   const handleEditEnd = useCallback((itemId: string) => {
     setEditingItemId((currentItemId) => (currentItemId === itemId ? null : currentItemId))
   }, [])
+  const handleOpenBottomAdd = useCallback(() => {
+    setInlineAddAfterItemId(null)
+    setShowBottomAddInput(true)
+    requestAnimationFrame(() => {
+      bottomAddInputRef.current?.focus()
+    })
+  }, [])
+
+  const showFloatingAddButton =
+    editingItemId === null && inlineAddAfterItemId === null && !showBottomAddInput
 
   return (
     <div
@@ -465,7 +483,7 @@ export function ReminderDetailView({
       ) : (
         <div
           data-testid="reminder-detail-shell"
-          className="max-w-lg mx-auto h-full min-h-0 flex flex-col bg-white dark:bg-stone-950"
+          className="relative max-w-lg mx-auto h-full min-h-0 flex flex-col bg-white dark:bg-stone-950"
         >
           <div className="flex items-center gap-3 px-4 py-5 border-b border-stone-100 dark:border-stone-800">
             <button
@@ -518,7 +536,11 @@ export function ReminderDetailView({
             </div>
           )}
 
-          <div data-testid="reminder-detail-scroll" className="flex-1 min-h-0 overflow-y-auto py-2">
+          <div
+            data-testid="reminder-detail-scroll"
+            className="flex-1 min-h-0 overflow-y-auto pt-2"
+            style={{ paddingBottom: 'calc(env(safe-area-inset-bottom, 0px) + 6rem)' }}
+          >
             {mutationError && (
               <div className="px-4 pt-2">
                 <div className="rounded-xl border border-red-100 bg-red-50 px-4 py-3 text-sm text-red-500 dark:border-red-900/40 dark:bg-red-950/30 dark:text-red-400">
@@ -527,11 +549,11 @@ export function ReminderDetailView({
               </div>
             )}
 
-            {uncheckedItems.length === 0 && checkedItems.length === 0 && (
+            {uncheckedItems.length === 0 && checkedItems.length === 0 && !showBottomAddInput && (
               <div className="flex flex-col items-center justify-center py-24 text-center">
                 <div className="text-5xl mb-4">📝</div>
                 <p className="text-stone-500 dark:text-stone-400 font-medium">아직 아이템이 없어요</p>
-                <p className="text-sm text-stone-400 dark:text-stone-500 mt-1">아래 입력창에 추가해보세요</p>
+                <p className="text-sm text-stone-400 dark:text-stone-500 mt-1">오른쪽 아래에서 추가해보세요</p>
               </div>
             )}
 
@@ -568,6 +590,16 @@ export function ReminderDetailView({
               </SortableContext>
             </DndContext>
 
+            {showBottomAddInput && (
+              <AddItemInput
+                ref={bottomAddInputRef}
+                onAdd={handleBottomAdd}
+                onCancelEmpty={() => setShowBottomAddInput(false)}
+                inline
+                testId="bottom-add-item-input"
+              />
+            )}
+
             {list?.type === 'strikethrough' && checkedItems.length > 0 && (
               <>
                 <div className="px-4 py-2 mt-2">
@@ -603,12 +635,17 @@ export function ReminderDetailView({
             )}
           </div>
 
-          <div
-            data-testid="reminder-detail-footer"
-            className="shrink-0 border-t border-stone-100 dark:border-stone-800 bg-white dark:bg-stone-950 pb-safe"
-          >
-            <AddItemInput ref={addInputRef} onAdd={handleFooterAdd} />
-          </div>
+          {showFloatingAddButton && (
+            <button
+              type="button"
+              onClick={handleOpenBottomAdd}
+              className="absolute right-4 bottom-4 z-30 flex h-11 w-11 items-center justify-center rounded-full bg-accent-400 text-white shadow-lg transition-colors hover:bg-accent-500 focus:outline-none focus:ring-2 focus:ring-accent-300"
+              aria-label="아이템 추가"
+              data-testid="floating-add-item-button"
+            >
+              <Plus size={18} />
+            </button>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- 리마인더 상세의 하단 고정 입력박스와 + 버튼을 제거하고, 오른쪽 하단 floating + 버튼으로 새 아이템 추가를 시작하도록 변경했습니다.
- floating + 버튼을 누르면 미완료 목록 맨 아래에 inline 입력행이 열리고 포커스됩니다.
- 아이템 수정 중이거나 inline 입력행이 열린 동안에는 floating + 버튼을 숨기도록 했습니다.
- floating + 버튼 크기, 위치, 아이콘 크기를 캘린더 FAB와 통일했습니다.
- 스크롤 목록 마지막 콘텐츠가 floating + 버튼 뒤에 가려지지 않도록 safe-area를 포함한 하단 여백을 추가했습니다.
- 기존 아이템 수정 후 Enter로 해당 아이템 아래 inline 입력행을 여는 흐름은 유지했습니다.

## Testing
- npm run test -- --runTestsByPath src/__tests__/reminders/ReminderDetailView.test.tsx src/__tests__/reminders/AddItemInput.test.tsx src/__tests__/reminders/ReminderItem.test.tsx
- npm run lint
- npx tsc --noEmit

## Manual Testing
- [x] 리마인더 상세 기본 상태에서 오른쪽 하단 floating + 버튼이 보이는지 확인합니다.
- [x] floating + 버튼이 캘린더의 일정 추가 버튼과 비슷한 크기와 위치로 보이는지 확인합니다.
- [x] 긴 리마인더 목록의 마지막 아이템이나 완료 섹션이 floating + 버튼에 가려지지 않는지 확인합니다.
- [x] floating + 버튼을 누르면 목록 맨 아래에 inline 입력행이 열리고 + 버튼이 숨겨지는지 확인합니다.
- [x] floating 입력행에서 새 아이템을 저장하면 목록 마지막에 추가되고 다음 inline 입력행이 유지되는지 확인합니다.
- [x] 기존 아이템 수정 중에는 floating + 버튼이 보이지 않는지 확인합니다.
- [x] 기존 아이템 수정 후 Enter를 누르면 기존처럼 해당 아이템 바로 아래에 inline 입력행이 열리는지 확인합니다.