### PR TITLE
fix: keep wheel picker text visible

### DIFF
--- a/src/__tests__/components/TimeWheelPicker.test.tsx
+++ b/src/__tests__/components/TimeWheelPicker.test.tsx
@@ -19,4 +19,14 @@ describe('TimeWheelPicker', () => {
     expect(screen.getAllByText('30').length).toBeGreaterThanOrEqual(1)
     expect(screen.getAllByText('59').length).toBeGreaterThanOrEqual(1)
   })
+
+  it('선택 영역 배경이 선택된 시간 텍스트를 덮지 않도록 레이어를 분리한다', () => {
+    render(<TimeWheelPicker hours={9} minutes={30} onChange={jest.fn()} />)
+
+    const [selectedHour] = screen.getAllByRole('option', { selected: true })
+    const highlight = selectedHour.parentElement?.previousElementSibling
+
+    expect(highlight).toHaveClass('z-0')
+    expect(selectedHour).toHaveClass('relative', 'z-10')
+  })
 })

--- a/src/__tests__/components/YearMonthPickerSheet.test.tsx
+++ b/src/__tests__/components/YearMonthPickerSheet.test.tsx
@@ -200,4 +200,5 @@ describe('WheelPickerColumn — 키보드 방향키 탐색', () => {
     expect(options[0]).toHaveAttribute('aria-selected', 'false')
     expect(options[2]).toHaveAttribute('aria-selected', 'false')
   })
+
 })

--- a/src/components/calendar/WheelPickerColumn.tsx
+++ b/src/components/calendar/WheelPickerColumn.tsx
@@ -64,7 +64,7 @@ export function WheelPickerColumn({ values, selected, onSelect, label }: Props) 
     <div className="relative flex-1">
       <div
         aria-hidden="true"
-        className="pointer-events-none absolute inset-x-0 bg-accent-50 dark:bg-accent-950/30 rounded-xl z-10"
+        className="pointer-events-none absolute inset-x-0 z-0 rounded-xl bg-accent-50 dark:bg-accent-950/30"
         style={{ top: WHEEL_ITEM_H * 2, height: WHEEL_ITEM_H }}
       />
       <div
@@ -90,7 +90,7 @@ export function WheelPickerColumn({ values, selected, onSelect, label }: Props) 
             role="option"
             aria-selected={i === selected}
             style={{ height: WHEEL_ITEM_H, scrollSnapAlign: 'center' }}
-            className="flex items-center justify-center text-lg font-semibold text-stone-800 dark:text-stone-100"
+            className="relative z-10 flex items-center justify-center text-lg font-semibold text-stone-800 dark:text-stone-100"
           >
             {v}
           </div>


### PR DESCRIPTION
## Summary
- 라이트 모드에서 시간 wheel picker의 선택 영역 배경이 선택된 시간 텍스트를 덮지 않도록 레이어 순서를 조정했습니다.
- 공통 WheelPickerColumn의 선택 배경은 뒤로 보내고 옵션 텍스트는 위에 렌더링되도록 했습니다.
- wheel picker 선택 영역이 텍스트를 덮지 않는지 테스트를 추가했습니다.

## Testing
- npm run test -- --runTestsByPath src/__tests__/components/TimeWheelPicker.test.tsx src/__tests__/components/YearMonthPickerSheet.test.tsx src/__tests__/components/EventFormModal.test.tsx
- npm run lint
- npx tsc --noEmit

## Manual Testing
- [x] 라이트 모드에서 일정 생성/수정 화면의 시작 시간 wheel picker를 열었을 때 선택된 시/분 글자가 보이는지 확인합니다.
- [x] 라이트 모드에서 종료 시간 wheel picker도 선택된 시/분 글자가 보이는지 확인합니다.
- [x] 다크 모드에서도 시간 wheel picker 선택 영역과 글자 대비가 유지되는지 확인합니다.