### PR TITLE
fix: backfill supabase data api grants

### DIFF
--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -36,6 +36,10 @@ DB migration -> src/types/database.ts -> src/lib/* -> src/hooks/* -> src/app/* -
 - 인증이 필요한 API route는 `src/lib/api-auth.ts`의 helper를 사용해 사용자 식별을 처리한다.
 - 클라이언트에서 API route를 호출할 때는 `src/lib/api-client.ts`의 auth helper로 bearer token을 붙인다.
 - 권한 검증, 원자 저장, cross-table mutation, push fan-out이 필요한 로직은 API route + admin client + DB RPC 조합을 우선한다.
+- `public` schema에 새 테이블을 만들 때는 Data API 접근 role에 대한 table-level `GRANT`를 migration에 명시한다.
+- RLS policy만으로는 Supabase Data API 접근이 열리지 않는다. Data API로 접근할 테이블은 `GRANT`와 `alter table ... enable row level security`, policy가 모두 필요하다.
+- 로그인 사용자용 앱 테이블은 보통 `authenticated`에 필요한 권한을 grant한다. `anon` grant는 익명 접근이 의도된 경우에만 추가한다.
+- `service_role`은 RLS를 우회하지만 PostgREST/Data API 권한 계약을 명확히 하기 위해 필요한 table 권한을 명시한다.
 
 ## 4. Auth And Onboarding Flow
 

--- a/src/__tests__/lib/supabase-data-api-grants-sql.test.ts
+++ b/src/__tests__/lib/supabase-data-api-grants-sql.test.ts
@@ -1,0 +1,39 @@
+import fs from 'fs'
+import path from 'path'
+
+const migrationPath = path.join(
+  process.cwd(),
+  'supabase/migrations/20260514000000_backfill_data_api_grants.sql'
+)
+
+const sql = () => fs.readFileSync(migrationPath, 'utf8')
+
+describe('supabase data api grants migration', () => {
+  it('backfills authenticated grants for direct client tables', () => {
+    const migration = sql()
+
+    expect(migration).toContain("to_regclass('public.user_preferences')")
+    expect(migration).toContain('grant select, insert, update on public.user_preferences to authenticated')
+    expect(migration).toContain('grant select, update, delete on public.shopping_items to authenticated')
+    expect(migration).toContain('grant select, insert, update, delete on public.calendars to authenticated')
+    expect(migration).toContain('grant select on public.recurrence_rules to authenticated')
+  })
+
+  it('keeps service-only tables off authenticated and grants them to service_role', () => {
+    const migration = sql()
+
+    expect(migration).toContain("to_regclass('public.allowed_emails')")
+    expect(migration).toContain('grant select, insert, update, delete on public.allowed_emails to service_role')
+    expect(migration).toContain('grant select, insert, update, delete on public.app_invites to service_role')
+    expect(migration).toContain('grant select, insert, update, delete on public.daily_digest_log to service_role')
+    expect(migration).not.toContain('grant select, insert, update, delete on public.allowed_emails to authenticated')
+  })
+
+  it('uses table existence guards so bootstrap does not fail on absent legacy tables', () => {
+    const migration = sql()
+
+    expect(migration).toContain("if to_regclass('public.calendars') is not null then")
+    expect(migration).toContain("if to_regclass('public.push_subscriptions') is not null then")
+    expect(migration).toContain("if to_regclass('public.daily_digest_log') is not null then")
+  })
+})

--- a/supabase/migrations/20260514000000_backfill_data_api_grants.sql
+++ b/supabase/migrations/20260514000000_backfill_data_api_grants.sql
@@ -1,0 +1,103 @@
+-- ================================================================
+-- Backfill Data API table grants for public schema
+--
+-- Supabase no longer auto-exposes new public tables to the Data API.
+-- Existing migrations in this repository predate that change, so a fresh
+-- project bootstrap needs explicit table-level GRANTs in addition to RLS.
+-- ================================================================
+
+do $$
+begin
+  if to_regclass('public.families') is not null then
+    execute 'grant select, insert on public.families to authenticated';
+    execute 'grant select, insert, update, delete on public.families to service_role';
+  end if;
+
+  if to_regclass('public.family_members') is not null then
+    execute 'grant select, insert, update on public.family_members to authenticated';
+    execute 'grant select, insert, update, delete on public.family_members to service_role';
+  end if;
+
+  if to_regclass('public.calendars') is not null then
+    execute 'grant select, insert, update, delete on public.calendars to authenticated';
+    execute 'grant select, insert, update, delete on public.calendars to service_role';
+  end if;
+
+  if to_regclass('public.calendar_members') is not null then
+    execute 'grant select, insert, update, delete on public.calendar_members to authenticated';
+    execute 'grant select, insert, update, delete on public.calendar_members to service_role';
+  end if;
+
+  if to_regclass('public.events') is not null then
+    execute 'grant select on public.events to authenticated';
+    execute 'grant select, insert, update, delete on public.events to service_role';
+  end if;
+
+  if to_regclass('public.event_reminders') is not null then
+    execute 'grant select on public.event_reminders to authenticated';
+    execute 'grant select, insert, update, delete on public.event_reminders to service_role';
+  end if;
+
+  if to_regclass('public.event_votes') is not null then
+    execute 'grant select, insert, update, delete on public.event_votes to authenticated';
+    execute 'grant select, insert, update, delete on public.event_votes to service_role';
+  end if;
+
+  if to_regclass('public.recurrence_rules') is not null then
+    execute 'grant select on public.recurrence_rules to authenticated';
+    execute 'grant select, insert, update, delete on public.recurrence_rules to service_role';
+  end if;
+
+  if to_regclass('public.recurrence_series') is not null then
+    execute 'grant select on public.recurrence_series to authenticated';
+    execute 'grant select, insert, update, delete on public.recurrence_series to service_role';
+  end if;
+
+  if to_regclass('public.shopping_lists') is not null then
+    execute 'grant select, update, delete on public.shopping_lists to authenticated';
+    execute 'grant select, insert, update, delete on public.shopping_lists to service_role';
+  end if;
+
+  if to_regclass('public.shopping_items') is not null then
+    execute 'grant select, update, delete on public.shopping_items to authenticated';
+    execute 'grant select, insert, update, delete on public.shopping_items to service_role';
+  end if;
+
+  if to_regclass('public.reminder_groups') is not null then
+    execute 'grant select, insert, update, delete on public.reminder_groups to authenticated';
+    execute 'grant select, insert, update, delete on public.reminder_groups to service_role';
+  end if;
+
+  if to_regclass('public.reminder_group_members') is not null then
+    execute 'grant select, insert, update, delete on public.reminder_group_members to authenticated';
+    execute 'grant select, insert, update, delete on public.reminder_group_members to service_role';
+  end if;
+
+  if to_regclass('public.user_preferences') is not null then
+    execute 'grant select, insert, update on public.user_preferences to authenticated';
+    execute 'grant select, insert, update, delete on public.user_preferences to service_role';
+  end if;
+
+  if to_regclass('public.push_subscriptions') is not null then
+    execute 'grant select, insert, update, delete on public.push_subscriptions to authenticated';
+    execute 'grant select, insert, update, delete on public.push_subscriptions to service_role';
+  end if;
+
+  if to_regclass('public.memos') is not null then
+    execute 'grant select, insert, update, delete on public.memos to authenticated';
+    execute 'grant select, insert, update, delete on public.memos to service_role';
+  end if;
+
+  if to_regclass('public.allowed_emails') is not null then
+    execute 'grant select, insert, update, delete on public.allowed_emails to service_role';
+  end if;
+
+  if to_regclass('public.app_invites') is not null then
+    execute 'grant select, insert, update, delete on public.app_invites to service_role';
+  end if;
+
+  if to_regclass('public.daily_digest_log') is not null then
+    execute 'grant select, insert, update, delete on public.daily_digest_log to service_role';
+  end if;
+end
+$$;


### PR DESCRIPTION
## Summary
- Supabase Data API 기본 권한 변경을 문서화해, 이후 `public` 테이블 생성 시 explicit `GRANT + RLS + policy`를 함께 추가하도록 `docs/PATTERNS.md`에 규칙을 남겼습니다.
- 새 Supabase 프로젝트에서 historical migration replay가 깨지지 않도록, 현재 Data API가 접근하는 `public` 테이블들에 대한 table-level GRANT backfill migration을 추가했습니다.
- `allowed_emails`, `app_invites`, `daily_digest_log` 같은 서버 전용 테이블은 `service_role`만 열고, 클라이언트가 직접 접근하는 테이블만 `authenticated` grant를 부여하도록 보수적으로 나눴습니다.
- absent legacy table에서도 bootstrap이 실패하지 않도록 `to_regclass(...)` guard를 사용하는 SQL 테스트를 추가했습니다.

## Testing
- `npm run test -- --runTestsByPath src/__tests__/lib/supabase-data-api-grants-sql.test.ts`
- `npx tsc --noEmit`
- `npm run lint`
