### PR TITLE
fix: prioritize holidays above multi-day events

### DIFF
--- a/src/__tests__/components/CalendarGrid.test.tsx
+++ b/src/__tests__/components/CalendarGrid.test.tsx
@@ -6,11 +6,9 @@ import {
   isEventOnDate,
   computeSegments,
   computeLaneHeightsByColumn,
-  computeReservedLaneHeightsByColumn,
   getSingleEventDisplayBudget,
   getHolidayBlockHeight,
   getHolidayOverlayOffset,
-  splitSegmentsByHolidayOffsets,
 } from '@/components/calendar/CalendarGrid'
 import type { Calendar, CalendarEvent } from '@/lib/calendar'
 import type { Holiday } from '@/hooks/useHolidays'
@@ -330,50 +328,7 @@ describe('holiday overlay helpers', () => {
     expect(getHolidayOverlayOffset(2)).toBe(38)
   })
 
-  it('같은 lane의 멀티데이 이벤트도 공휴일 높이가 바뀌는 지점에서 분할된다', () => {
-    const row = makeRow(2025, 5, 15)
-    const segments = computeSegments(row, [
-      makeEvent({
-        id: 'trip',
-        is_all_day: true,
-        start_at: '2025-06-15T00:00:00Z',
-        end_at: '2025-06-18T00:00:00Z',
-      }),
-    ])
-    const displaySegments = splitSegmentsByHolidayOffsets(segments, [0, 0, 1, 1, 0, 0, 0])
-
-    expect(displaySegments).toHaveLength(2)
-    expect(displaySegments.map((seg) => ({
-      colStart: seg.colStart,
-      colSpan: seg.colSpan,
-      holidayOffset: seg.holidayOffset,
-      isStart: seg.isStart,
-      isEnd: seg.isEnd,
-      showLeadingContinuation: seg.showLeadingContinuation,
-      showTrailingContinuation: seg.showTrailingContinuation,
-    }))).toEqual([
-      {
-        colStart: 0,
-        colSpan: 2,
-        holidayOffset: 0,
-        isStart: true,
-        isEnd: false,
-        showLeadingContinuation: false,
-        showTrailingContinuation: false,
-      },
-      {
-        colStart: 2,
-        colSpan: 2,
-        holidayOffset: 19,
-        isStart: false,
-        isEnd: true,
-        showLeadingContinuation: false,
-        showTrailingContinuation: false,
-      },
-    ])
-  })
-
-  it('공휴일이 있는 열과 없는 열의 spacer 높이를 다르게 예약한다', () => {
+  it('같은 주에서는 최대 공휴일 높이만큼 멀티데이 lane을 일괄 오프셋한다', () => {
     const row = makeRow(2025, 5, 15)
     const segments = computeSegments(row, [
       makeEvent({
@@ -383,9 +338,8 @@ describe('holiday overlay helpers', () => {
         end_at: '2025-06-16T00:00:00Z',
       }),
     ])
-    const displaySegments = splitSegmentsByHolidayOffsets(segments, [1, 0, 0, 0, 0, 0, 0])
 
-    expect(computeReservedLaneHeightsByColumn(displaySegments, [1, 0, 0, 0, 0, 0, 0])).toEqual([20, 18, 0, 0, 0, 0, 0])
+    expect(computeLaneHeightsByColumn(segments, getHolidayOverlayOffset(1))).toEqual([37, 37, 0, 0, 0, 0, 0])
   })
 })
 
@@ -813,13 +767,12 @@ describe('공휴일-이벤트 칩 간격', () => {
 
     render(<CalendarGrid {...defaultProps} events={[event]} holidays={holidays} />)
 
-    expect(screen.getByTestId('lane-spacer-2025-06-15')).toHaveStyle({ height: '20px' })
-    expect(screen.getByTestId('lane-spacer-2025-06-16')).toHaveStyle({ height: '18px' })
-    expect(screen.getByTestId('multi-segment-row-priority-row2-piece0')).toHaveStyle({ top: '19px' })
-    expect(screen.getByTestId('multi-segment-row-priority-row2-piece1')).toHaveStyle({ top: '0px' })
+    expect(screen.getByTestId('lane-spacer-2025-06-15')).toHaveStyle({ height: '37px' })
+    expect(screen.getByTestId('lane-spacer-2025-06-16')).toHaveStyle({ height: '37px' })
+    expect(screen.getByTestId('multi-segment-row-priority-row2')).toHaveStyle({ top: '19px' })
   })
 
-  it('같은 주 내부 holiday split으로 생긴 조각에는 가짜 continuation 화살표가 보이지 않는다', () => {
+  it('같은 주 내부 공휴일 변화로 멀티데이 bar가 분절되지 않는다', () => {
     const holidays: Holiday[] = [
       { date: '2025-06-17', localName: '테스트공휴일', countryCode: 'KR' },
       { date: '2025-06-18', localName: '테스트공휴일2', countryCode: 'KR' },
@@ -835,9 +788,8 @@ describe('공휴일-이벤트 칩 간격', () => {
     render(<CalendarGrid {...defaultProps} events={[event]} holidays={holidays} />)
 
     const bars = screen.getAllByTitle('연속휴가')
-    expect(bars).toHaveLength(2)
+    expect(bars).toHaveLength(1)
     expect(bars[0].textContent).not.toMatch(/[‹›]/)
-    expect(bars[1].textContent).not.toMatch(/[‹›]/)
   })
 })
 

--- a/src/__tests__/components/CalendarGrid.test.tsx
+++ b/src/__tests__/components/CalendarGrid.test.tsx
@@ -349,9 +349,27 @@ describe('holiday overlay helpers', () => {
       holidayOffset: seg.holidayOffset,
       isStart: seg.isStart,
       isEnd: seg.isEnd,
+      showLeadingContinuation: seg.showLeadingContinuation,
+      showTrailingContinuation: seg.showTrailingContinuation,
     }))).toEqual([
-      { colStart: 0, colSpan: 2, holidayOffset: 0, isStart: true, isEnd: false },
-      { colStart: 2, colSpan: 2, holidayOffset: 19, isStart: false, isEnd: true },
+      {
+        colStart: 0,
+        colSpan: 2,
+        holidayOffset: 0,
+        isStart: true,
+        isEnd: false,
+        showLeadingContinuation: false,
+        showTrailingContinuation: false,
+      },
+      {
+        colStart: 2,
+        colSpan: 2,
+        holidayOffset: 19,
+        isStart: false,
+        isEnd: true,
+        showLeadingContinuation: false,
+        showTrailingContinuation: false,
+      },
     ])
   })
 
@@ -799,6 +817,27 @@ describe('공휴일-이벤트 칩 간격', () => {
     expect(screen.getByTestId('lane-spacer-2025-06-16')).toHaveStyle({ height: '18px' })
     expect(screen.getByTestId('multi-segment-row-priority-row2-piece0')).toHaveStyle({ top: '19px' })
     expect(screen.getByTestId('multi-segment-row-priority-row2-piece1')).toHaveStyle({ top: '0px' })
+  })
+
+  it('같은 주 내부 holiday split으로 생긴 조각에는 가짜 continuation 화살표가 보이지 않는다', () => {
+    const holidays: Holiday[] = [
+      { date: '2025-06-17', localName: '테스트공휴일', countryCode: 'KR' },
+      { date: '2025-06-18', localName: '테스트공휴일2', countryCode: 'KR' },
+    ]
+    const event = makeEvent({
+      id: 'holiday-split',
+      title: '연속휴가',
+      is_all_day: true,
+      start_at: '2025-06-15T00:00:00Z',
+      end_at: '2025-06-18T00:00:00Z',
+    })
+
+    render(<CalendarGrid {...defaultProps} events={[event]} holidays={holidays} />)
+
+    const bars = screen.getAllByTitle('연속휴가')
+    expect(bars).toHaveLength(2)
+    expect(bars[0].textContent).not.toMatch(/[‹›]/)
+    expect(bars[1].textContent).not.toMatch(/[‹›]/)
   })
 })
 

--- a/src/__tests__/components/CalendarGrid.test.tsx
+++ b/src/__tests__/components/CalendarGrid.test.tsx
@@ -10,7 +10,7 @@ import {
   getSingleEventDisplayBudget,
   getHolidayBlockHeight,
   getHolidayOverlayOffset,
-  getRowHolidayOverlayOffset,
+  splitSegmentsByHolidayOffsets,
 } from '@/components/calendar/CalendarGrid'
 import type { Calendar, CalendarEvent } from '@/lib/calendar'
 import type { Holiday } from '@/hooks/useHolidays'
@@ -330,8 +330,29 @@ describe('holiday overlay helpers', () => {
     expect(getHolidayOverlayOffset(2)).toBe(38)
   })
 
-  it('같은 주에서는 가장 높은 공휴일 스택 아래로 멀티데이 레인을 일괄 내린다', () => {
-    expect(getRowHolidayOverlayOffset([0, 1, 0, 2, 0, 0, 0])).toBe(38)
+  it('같은 lane의 멀티데이 이벤트도 공휴일 높이가 바뀌는 지점에서 분할된다', () => {
+    const row = makeRow(2025, 5, 15)
+    const segments = computeSegments(row, [
+      makeEvent({
+        id: 'trip',
+        is_all_day: true,
+        start_at: '2025-06-15T00:00:00Z',
+        end_at: '2025-06-18T00:00:00Z',
+      }),
+    ])
+    const displaySegments = splitSegmentsByHolidayOffsets(segments, [0, 0, 1, 1, 0, 0, 0])
+
+    expect(displaySegments).toHaveLength(2)
+    expect(displaySegments.map((seg) => ({
+      colStart: seg.colStart,
+      colSpan: seg.colSpan,
+      holidayOffset: seg.holidayOffset,
+      isStart: seg.isStart,
+      isEnd: seg.isEnd,
+    }))).toEqual([
+      { colStart: 0, colSpan: 2, holidayOffset: 0, isStart: true, isEnd: false },
+      { colStart: 2, colSpan: 2, holidayOffset: 19, isStart: false, isEnd: true },
+    ])
   })
 
   it('공휴일이 있는 열과 없는 열의 spacer 높이를 다르게 예약한다', () => {
@@ -344,8 +365,9 @@ describe('holiday overlay helpers', () => {
         end_at: '2025-06-16T00:00:00Z',
       }),
     ])
+    const displaySegments = splitSegmentsByHolidayOffsets(segments, [1, 0, 0, 0, 0, 0, 0])
 
-    expect(computeReservedLaneHeightsByColumn(segments, 19, [1, 0, 0, 0, 0, 0, 0])).toEqual([20, 37, 0, 0, 0, 0, 0])
+    expect(computeReservedLaneHeightsByColumn(displaySegments, [1, 0, 0, 0, 0, 0, 0])).toEqual([20, 18, 0, 0, 0, 0, 0])
   })
 })
 
@@ -774,8 +796,9 @@ describe('공휴일-이벤트 칩 간격', () => {
     render(<CalendarGrid {...defaultProps} events={[event]} holidays={holidays} />)
 
     expect(screen.getByTestId('lane-spacer-2025-06-15')).toHaveStyle({ height: '20px' })
-    expect(screen.getByTestId('lane-spacer-2025-06-16')).toHaveStyle({ height: '37px' })
-    expect(screen.getByTestId('multi-segment-row-priority-row2')).toHaveStyle({ top: '0px' })
+    expect(screen.getByTestId('lane-spacer-2025-06-16')).toHaveStyle({ height: '18px' })
+    expect(screen.getByTestId('multi-segment-row-priority-row2-piece0')).toHaveStyle({ top: '19px' })
+    expect(screen.getByTestId('multi-segment-row-priority-row2-piece1')).toHaveStyle({ top: '0px' })
   })
 })
 

--- a/src/__tests__/components/CalendarGrid.test.tsx
+++ b/src/__tests__/components/CalendarGrid.test.tsx
@@ -6,7 +6,11 @@ import {
   isEventOnDate,
   computeSegments,
   computeLaneHeightsByColumn,
+  computeReservedLaneHeightsByColumn,
   getSingleEventDisplayBudget,
+  getHolidayBlockHeight,
+  getHolidayOverlayOffset,
+  getRowHolidayOverlayOffset,
 } from '@/components/calendar/CalendarGrid'
 import type { Calendar, CalendarEvent } from '@/lib/calendar'
 import type { Holiday } from '@/hooks/useHolidays'
@@ -313,6 +317,35 @@ describe('computeLaneHeightsByColumn', () => {
     ])
 
     expect(computeLaneHeightsByColumn(segs)).toEqual([0, 18, 36, 36, 18, 0, 0])
+  })
+})
+
+describe('holiday overlay helpers', () => {
+  it('공휴일 block 높이와 overlay offset을 올바르게 계산한다', () => {
+    expect(getHolidayBlockHeight(0)).toBe(0)
+    expect(getHolidayBlockHeight(1)).toBe(17)
+    expect(getHolidayBlockHeight(2)).toBe(36)
+    expect(getHolidayOverlayOffset(0)).toBe(0)
+    expect(getHolidayOverlayOffset(1)).toBe(19)
+    expect(getHolidayOverlayOffset(2)).toBe(38)
+  })
+
+  it('같은 주에서는 가장 높은 공휴일 스택 아래로 멀티데이 레인을 일괄 내린다', () => {
+    expect(getRowHolidayOverlayOffset([0, 1, 0, 2, 0, 0, 0])).toBe(38)
+  })
+
+  it('공휴일이 있는 열과 없는 열의 spacer 높이를 다르게 예약한다', () => {
+    const row = makeRow(2025, 5, 15)
+    const segments = computeSegments(row, [
+      makeEvent({
+        id: 'trip',
+        is_all_day: true,
+        start_at: '2025-06-15T00:00:00Z',
+        end_at: '2025-06-16T00:00:00Z',
+      }),
+    ])
+
+    expect(computeReservedLaneHeightsByColumn(segments, 19, [1, 0, 0, 0, 0, 0, 0])).toEqual([20, 37, 0, 0, 0, 0, 0])
   })
 })
 
@@ -726,6 +759,23 @@ describe('공휴일-이벤트 칩 간격', () => {
     // 이벤트(생일파티)는 6/15, 공휴일은 6/6 → 6/15 이벤트 블록에 mt-0.5 없어야 함
     const chip = screen.getByText('생일파티')
     expect(chip.parentElement).not.toHaveClass('mt-0.5')
+  })
+
+  it('같은 주에 공휴일과 멀티데이 종일 일정이 겹치면 멀티데이 bar가 공휴일 아래에서 시작한다', () => {
+    const holidays: Holiday[] = [{ date: '2025-06-15', localName: '테스트공휴일', countryCode: 'KR' }]
+    const event = makeEvent({
+      id: 'row-priority',
+      title: '연속휴가',
+      is_all_day: true,
+      start_at: '2025-06-15T00:00:00Z',
+      end_at: '2025-06-16T00:00:00Z',
+    })
+
+    render(<CalendarGrid {...defaultProps} events={[event]} holidays={holidays} />)
+
+    expect(screen.getByTestId('lane-spacer-2025-06-15')).toHaveStyle({ height: '20px' })
+    expect(screen.getByTestId('lane-spacer-2025-06-16')).toHaveStyle({ height: '37px' })
+    expect(screen.getByTestId('multi-segment-row-priority-row2')).toHaveStyle({ top: '0px' })
   })
 })
 

--- a/src/components/calendar/CalendarGrid.tsx
+++ b/src/components/calendar/CalendarGrid.tsx
@@ -87,6 +87,8 @@ export function getHolidayOverlayOffset(holidayCount: number): number {
 
 interface DisplaySegment extends EventSegment {
   holidayOffset: number
+  showLeadingContinuation: boolean
+  showTrailingContinuation: boolean
 }
 
 export function splitSegmentsByHolidayOffsets(
@@ -111,6 +113,8 @@ export function splitSegmentsByHolidayOffsets(
         isStart: seg.isStart && pieceStart === seg.colStart,
         isEnd: seg.isEnd && col === segmentEnd,
         holidayOffset: getHolidayOverlayOffset(currentHolidayCount),
+        showLeadingContinuation: !seg.isStart && pieceStart === seg.colStart,
+        showTrailingContinuation: !seg.isEnd && col === segmentEnd,
       })
 
       pieceStart = col
@@ -578,9 +582,9 @@ export function CalendarGrid({
                           }}
                           onClick={() => onSelectDate(dateOnly(new Date(seg.event.start_at)))}
                         >
-                          {!seg.isStart && <span className="shrink-0 opacity-70">‹</span>}
+                          {seg.showLeadingContinuation && <span className="shrink-0 opacity-70">‹</span>}
                           <span className="overflow-hidden min-w-0">{seg.event.title}</span>
-                          {!seg.isEnd && <span className="shrink-0 opacity-70">›</span>}
+                          {seg.showTrailingContinuation && <span className="shrink-0 opacity-70">›</span>}
                         </button>
                       </div>
                     )

--- a/src/components/calendar/CalendarGrid.tsx
+++ b/src/components/calendar/CalendarGrid.tsx
@@ -85,46 +85,6 @@ export function getHolidayOverlayOffset(holidayCount: number): number {
   return getHolidayBlockHeight(holidayCount) + HOLIDAY_EVENT_GAP
 }
 
-interface DisplaySegment extends EventSegment {
-  holidayOffset: number
-  showLeadingContinuation: boolean
-  showTrailingContinuation: boolean
-}
-
-export function splitSegmentsByHolidayOffsets(
-  segments: EventSegment[],
-  holidayCountsByColumn: number[]
-): DisplaySegment[] {
-  const displaySegments: DisplaySegment[] = []
-
-  for (const seg of segments) {
-    const segmentEnd = seg.colStart + seg.colSpan
-    let pieceStart = seg.colStart
-    let currentHolidayCount = holidayCountsByColumn[pieceStart] ?? 0
-
-    for (let col = seg.colStart + 1; col <= segmentEnd; col += 1) {
-      const nextHolidayCount = col < segmentEnd ? (holidayCountsByColumn[col] ?? 0) : null
-      if (nextHolidayCount === currentHolidayCount) continue
-
-      displaySegments.push({
-        ...seg,
-        colStart: pieceStart,
-        colSpan: col - pieceStart,
-        isStart: seg.isStart && pieceStart === seg.colStart,
-        isEnd: seg.isEnd && col === segmentEnd,
-        holidayOffset: getHolidayOverlayOffset(currentHolidayCount),
-        showLeadingContinuation: !seg.isStart && pieceStart === seg.colStart,
-        showTrailingContinuation: !seg.isEnd && col === segmentEnd,
-      })
-
-      pieceStart = col
-      currentHolidayCount = nextHolidayCount ?? 0
-    }
-  }
-
-  return displaySegments
-}
-
 export function getSingleEventDisplayBudget({
   rowHeight,
   dateHeaderHeight,
@@ -234,32 +194,14 @@ export function computeSegments(row: DayCell[], multiDayEvents: CalendarEvent[])
   return segments
 }
 
-export function computeLaneHeightsByColumn(segments: EventSegment[]): number[] {
+export function computeLaneHeightsByColumn(segments: EventSegment[], baseOffset = 0): number[] {
   const heights = Array.from({ length: 7 }, () => 0)
 
   for (const seg of segments) {
-    const laneHeight = (seg.lane + 1) * LANE_HEIGHT
+    const laneHeight = baseOffset + (seg.lane + 1) * LANE_HEIGHT
     const endCol = seg.colStart + seg.colSpan
     for (let col = seg.colStart; col < endCol; col += 1) {
       if (laneHeight > heights[col]) heights[col] = laneHeight
-    }
-  }
-
-  return heights
-}
-
-export function computeReservedLaneHeightsByColumn(
-  segments: DisplaySegment[],
-  holidayCountsByColumn: number[]
-): number[] {
-  const heights = Array.from({ length: 7 }, () => 0)
-
-  for (const seg of segments) {
-    const segmentBottom = seg.holidayOffset + (seg.lane + 1) * LANE_HEIGHT
-    const endCol = seg.colStart + seg.colSpan
-    for (let col = seg.colStart; col < endCol; col += 1) {
-      const reservedHeight = Math.max(0, segmentBottom - getHolidayBlockHeight(holidayCountsByColumn[col] ?? 0))
-      if (reservedHeight > heights[col]) heights[col] = reservedHeight
     }
   }
 
@@ -419,11 +361,8 @@ export function CalendarGrid({
           const ymd = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
           return holidaysByDate.get(ymd)?.length ?? 0
         })
-        const displaySegments = splitSegmentsByHolidayOffsets(segments, holidayCountsByColumn)
-        const laneHeightsByColumn = computeReservedLaneHeightsByColumn(
-          displaySegments,
-          holidayCountsByColumn
-        )
+        const rowHolidayOffset = getHolidayOverlayOffset(Math.max(0, ...holidayCountsByColumn))
+        const laneHeightsByColumn = computeLaneHeightsByColumn(segments, rowHolidayOffset)
 
         return (
             <div key={rowIdx} className="relative min-h-0">
@@ -546,13 +485,13 @@ export function CalendarGrid({
               </div>
 
               {/* 멀티데이 이벤트 overlay */}
-              {displaySegments.length > 0 && (
+              {segments.length > 0 && (
                 <div
                   aria-hidden="true"
                   className="absolute inset-x-0 pointer-events-none"
                   style={{ top: effectiveDateHeaderHeight }}
                 >
-                  {displaySegments.map((seg, segIdx) => {
+                  {segments.map((seg) => {
                     const color = getEventColor(seg.event)
                     const s = seg.isStart ? '4px' : '0'
                     const e = seg.isEnd ? '4px' : '0'
@@ -560,13 +499,13 @@ export function CalendarGrid({
 
                     return (
                       <div
-                        key={`${seg.event.id}-row${rowIdx}-piece${segIdx}`}
-                        data-testid={`multi-segment-${seg.event.id}-row${rowIdx}-piece${segIdx}`}
+                        key={`${seg.event.id}-row${rowIdx}`}
+                        data-testid={`multi-segment-${seg.event.id}-row${rowIdx}`}
                         className="absolute px-0.5 pointer-events-none"
                         style={{
                           left: `${(seg.colStart / 7) * 100}%`,
                           width: `${(seg.colSpan / 7) * 100}%`,
-                          top: seg.holidayOffset + seg.lane * LANE_HEIGHT,
+                          top: rowHolidayOffset + seg.lane * LANE_HEIGHT,
                           height: 16,
                         }}
                       >
@@ -582,9 +521,9 @@ export function CalendarGrid({
                           }}
                           onClick={() => onSelectDate(dateOnly(new Date(seg.event.start_at)))}
                         >
-                          {seg.showLeadingContinuation && <span className="shrink-0 opacity-70">‹</span>}
+                          {!seg.isStart && <span className="shrink-0 opacity-70">‹</span>}
                           <span className="overflow-hidden min-w-0">{seg.event.title}</span>
-                          {seg.showTrailingContinuation && <span className="shrink-0 opacity-70">›</span>}
+                          {!seg.isEnd && <span className="shrink-0 opacity-70">›</span>}
                         </button>
                       </div>
                     )

--- a/src/components/calendar/CalendarGrid.tsx
+++ b/src/components/calendar/CalendarGrid.tsx
@@ -85,11 +85,40 @@ export function getHolidayOverlayOffset(holidayCount: number): number {
   return getHolidayBlockHeight(holidayCount) + HOLIDAY_EVENT_GAP
 }
 
-export function getRowHolidayOverlayOffset(holidayCountsByColumn: number[]): number {
-  return holidayCountsByColumn.reduce(
-    (maxOffset, count) => Math.max(maxOffset, getHolidayOverlayOffset(count)),
-    0
-  )
+interface DisplaySegment extends EventSegment {
+  holidayOffset: number
+}
+
+export function splitSegmentsByHolidayOffsets(
+  segments: EventSegment[],
+  holidayCountsByColumn: number[]
+): DisplaySegment[] {
+  const displaySegments: DisplaySegment[] = []
+
+  for (const seg of segments) {
+    const segmentEnd = seg.colStart + seg.colSpan
+    let pieceStart = seg.colStart
+    let currentHolidayCount = holidayCountsByColumn[pieceStart] ?? 0
+
+    for (let col = seg.colStart + 1; col <= segmentEnd; col += 1) {
+      const nextHolidayCount = col < segmentEnd ? (holidayCountsByColumn[col] ?? 0) : null
+      if (nextHolidayCount === currentHolidayCount) continue
+
+      displaySegments.push({
+        ...seg,
+        colStart: pieceStart,
+        colSpan: col - pieceStart,
+        isStart: seg.isStart && pieceStart === seg.colStart,
+        isEnd: seg.isEnd && col === segmentEnd,
+        holidayOffset: getHolidayOverlayOffset(currentHolidayCount),
+      })
+
+      pieceStart = col
+      currentHolidayCount = nextHolidayCount ?? 0
+    }
+  }
+
+  return displaySegments
 }
 
 export function getSingleEventDisplayBudget({
@@ -216,14 +245,13 @@ export function computeLaneHeightsByColumn(segments: EventSegment[]): number[] {
 }
 
 export function computeReservedLaneHeightsByColumn(
-  segments: EventSegment[],
-  rowHolidayOffset: number,
+  segments: DisplaySegment[],
   holidayCountsByColumn: number[]
 ): number[] {
   const heights = Array.from({ length: 7 }, () => 0)
 
   for (const seg of segments) {
-    const segmentBottom = rowHolidayOffset + (seg.lane + 1) * LANE_HEIGHT
+    const segmentBottom = seg.holidayOffset + (seg.lane + 1) * LANE_HEIGHT
     const endCol = seg.colStart + seg.colSpan
     for (let col = seg.colStart; col < endCol; col += 1) {
       const reservedHeight = Math.max(0, segmentBottom - getHolidayBlockHeight(holidayCountsByColumn[col] ?? 0))
@@ -387,10 +415,9 @@ export function CalendarGrid({
           const ymd = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
           return holidaysByDate.get(ymd)?.length ?? 0
         })
-        const rowHolidayOffset = getRowHolidayOverlayOffset(holidayCountsByColumn)
+        const displaySegments = splitSegmentsByHolidayOffsets(segments, holidayCountsByColumn)
         const laneHeightsByColumn = computeReservedLaneHeightsByColumn(
-          segments,
-          rowHolidayOffset,
+          displaySegments,
           holidayCountsByColumn
         )
 
@@ -515,13 +542,13 @@ export function CalendarGrid({
               </div>
 
               {/* 멀티데이 이벤트 overlay */}
-              {segments.length > 0 && (
+              {displaySegments.length > 0 && (
                 <div
                   aria-hidden="true"
                   className="absolute inset-x-0 pointer-events-none"
-                  style={{ top: effectiveDateHeaderHeight + rowHolidayOffset }}
+                  style={{ top: effectiveDateHeaderHeight }}
                 >
-                  {segments.map((seg) => {
+                  {displaySegments.map((seg, segIdx) => {
                     const color = getEventColor(seg.event)
                     const s = seg.isStart ? '4px' : '0'
                     const e = seg.isEnd ? '4px' : '0'
@@ -529,13 +556,13 @@ export function CalendarGrid({
 
                     return (
                       <div
-                        key={`${seg.event.id}-row${rowIdx}`}
-                        data-testid={`multi-segment-${seg.event.id}-row${rowIdx}`}
+                        key={`${seg.event.id}-row${rowIdx}-piece${segIdx}`}
+                        data-testid={`multi-segment-${seg.event.id}-row${rowIdx}-piece${segIdx}`}
                         className="absolute px-0.5 pointer-events-none"
                         style={{
                           left: `${(seg.colStart / 7) * 100}%`,
                           width: `${(seg.colSpan / 7) * 100}%`,
-                          top: seg.lane * LANE_HEIGHT,
+                          top: seg.holidayOffset + seg.lane * LANE_HEIGHT,
                           height: 16,
                         }}
                       >

--- a/src/components/calendar/CalendarGrid.tsx
+++ b/src/components/calendar/CalendarGrid.tsx
@@ -75,6 +75,23 @@ function getChipStyle(isAllDay: boolean, color: string): CSSProperties {
   return { backgroundColor: color + '26', color }
 }
 
+export function getHolidayBlockHeight(holidayCount: number): number {
+  if (holidayCount <= 0) return 0
+  return holidayCount * CHIP_HEIGHT + Math.max(0, holidayCount - 1) * CHIP_GAP
+}
+
+export function getHolidayOverlayOffset(holidayCount: number): number {
+  if (holidayCount <= 0) return 0
+  return getHolidayBlockHeight(holidayCount) + HOLIDAY_EVENT_GAP
+}
+
+export function getRowHolidayOverlayOffset(holidayCountsByColumn: number[]): number {
+  return holidayCountsByColumn.reduce(
+    (maxOffset, count) => Math.max(maxOffset, getHolidayOverlayOffset(count)),
+    0
+  )
+}
+
 export function getSingleEventDisplayBudget({
   rowHeight,
   dateHeaderHeight,
@@ -192,6 +209,25 @@ export function computeLaneHeightsByColumn(segments: EventSegment[]): number[] {
     const endCol = seg.colStart + seg.colSpan
     for (let col = seg.colStart; col < endCol; col += 1) {
       if (laneHeight > heights[col]) heights[col] = laneHeight
+    }
+  }
+
+  return heights
+}
+
+export function computeReservedLaneHeightsByColumn(
+  segments: EventSegment[],
+  rowHolidayOffset: number,
+  holidayCountsByColumn: number[]
+): number[] {
+  const heights = Array.from({ length: 7 }, () => 0)
+
+  for (const seg of segments) {
+    const segmentBottom = rowHolidayOffset + (seg.lane + 1) * LANE_HEIGHT
+    const endCol = seg.colStart + seg.colSpan
+    for (let col = seg.colStart; col < endCol; col += 1) {
+      const reservedHeight = Math.max(0, segmentBottom - getHolidayBlockHeight(holidayCountsByColumn[col] ?? 0))
+      if (reservedHeight > heights[col]) heights[col] = reservedHeight
     }
   }
 
@@ -346,7 +382,17 @@ export function CalendarGrid({
       {/* 주 단위 행 — minmax(0,1fr) 트랙 */}
       {rows.map((row, rowIdx) => {
         const segments = computeSegments(row, multiDayEvents)
-        const laneHeightsByColumn = computeLaneHeightsByColumn(segments)
+        const holidayCountsByColumn = row.map((cell) => {
+          const d = cell.date
+          const ymd = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+          return holidaysByDate.get(ymd)?.length ?? 0
+        })
+        const rowHolidayOffset = getRowHolidayOverlayOffset(holidayCountsByColumn)
+        const laneHeightsByColumn = computeReservedLaneHeightsByColumn(
+          segments,
+          rowHolidayOffset,
+          holidayCountsByColumn
+        )
 
         return (
             <div key={rowIdx} className="relative min-h-0">
@@ -424,13 +470,6 @@ export function CalendarGrid({
                         )}
                       </div>
 
-                      {/* 멀티데이 lane 공간 확보용 spacer */}
-                      <div
-                        aria-hidden="true"
-                        data-testid={`lane-spacer-${ymd}`}
-                        style={{ height: laneAreaHeight }}
-                      />
-
                       {/* 공휴일 chips */}
                       <div className="w-full space-y-0.5">
                         {dayHolidays.map((h) => (
@@ -442,6 +481,13 @@ export function CalendarGrid({
                           </div>
                         ))}
                       </div>
+
+                      {/* 멀티데이 lane 공간 확보용 spacer */}
+                      <div
+                        aria-hidden="true"
+                        data-testid={`lane-spacer-${ymd}`}
+                        style={{ height: laneAreaHeight }}
+                      />
 
                       {/* 단일 일정 pills */}
                       <div className={`w-full space-y-0.5${hasHolidaysAndEvents ? ' mt-0.5' : ''}`}>
@@ -473,7 +519,7 @@ export function CalendarGrid({
                 <div
                   aria-hidden="true"
                   className="absolute inset-x-0 pointer-events-none"
-                  style={{ top: effectiveDateHeaderHeight }}
+                  style={{ top: effectiveDateHeaderHeight + rowHolidayOffset }}
                 >
                   {segments.map((seg) => {
                     const color = getEventColor(seg.event)
@@ -484,6 +530,7 @@ export function CalendarGrid({
                     return (
                       <div
                         key={`${seg.event.id}-row${rowIdx}`}
+                        data-testid={`multi-segment-${seg.event.id}-row${rowIdx}`}
                         className="absolute px-0.5 pointer-events-none"
                         style={{
                           left: `${(seg.colStart / 7) * 100}%`,


### PR DESCRIPTION
## Summary
- 월간 `CalendarGrid`에서 공휴일 칩을 멀티데이 종일 일정 overlay보다 먼저 렌더링하도록 셀 내부 순서를 조정했습니다.
- 같은 주 안에서는 공휴일 개수 차이로 멀티데이 종일 일정 bar를 분절하지 않고, 주 단위 최대 공휴일 높이만큼 lane을 일괄 오프셋하도록 변경했습니다.
- 주 내부에서는 멀티데이 종일 일정의 연속성을 유지하고, continuation 화살표는 주 경계에서만 표시되도록 정리했습니다.
- `CalendarGrid` 테스트를 새 배치 규칙에 맞게 갱신해 공휴일 높이 계산, 주 단위 lane 오프셋, 공휴일 주간에서의 연속 bar 렌더를 검증했습니다.

## Testing
- `npm run test -- --runTestsByPath src/__tests__/components/CalendarGrid.test.tsx`
- `npx tsc --noEmit`

## Manual Testing
- [x] 모바일 월간 보기에서 여러 날짜에 걸친 종일 일정과 공휴일이 같은 주에 있을 때 공휴일이 항상 최상단에 보이는지 확인
- [x] 같은 주 안에서 공휴일이 일부 날짜에만 있어도 멀티데이 종일 일정 bar가 중간에서 끊기지 않고 한 줄로 이어지는지 확인
- [x] 같은 주에 공휴일 개수가 다른 날짜가 섞여 있어도 멀티데이 종일 일정 바가 서로 겹치지 않는지 확인
