### PR TITLE
fix: keep holiday-free segments aligned

### DIFF
--- a/src/__tests__/components/CalendarGrid.test.tsx
+++ b/src/__tests__/components/CalendarGrid.test.tsx
@@ -6,9 +6,11 @@ import {
   isEventOnDate,
   computeSegments,
   computeLaneHeightsByColumn,
+  computeReservedLaneHeightsByColumn,
   getSingleEventDisplayBudget,
   getHolidayBlockHeight,
   getHolidayOverlayOffset,
+  splitSegmentsByHolidayOffsets,
 } from '@/components/calendar/CalendarGrid'
 import type { Calendar, CalendarEvent } from '@/lib/calendar'
 import type { Holiday } from '@/hooks/useHolidays'
@@ -328,7 +330,56 @@ describe('holiday overlay helpers', () => {
     expect(getHolidayOverlayOffset(2)).toBe(38)
   })
 
-  it('같은 주에서는 최대 공휴일 높이만큼 멀티데이 lane을 일괄 오프셋한다', () => {
+  it('같은 lane의 멀티데이 이벤트도 공휴일 높이가 바뀌는 지점에서 분할된다', () => {
+    const row = makeRow(2025, 5, 15)
+    const segments = computeSegments(row, [
+      makeEvent({
+        id: 'trip',
+        is_all_day: true,
+        start_at: '2025-06-15T00:00:00Z',
+        end_at: '2025-06-18T00:00:00Z',
+      }),
+    ])
+    const displaySegments = splitSegmentsByHolidayOffsets(segments, [0, 0, 1, 1, 0, 0, 0])
+
+    expect(displaySegments).toHaveLength(2)
+    expect(displaySegments.map((seg) => ({
+      colStart: seg.colStart,
+      colSpan: seg.colSpan,
+      holidayOffset: seg.holidayOffset,
+      isStart: seg.isStart,
+      isEnd: seg.isEnd,
+      showLeadingContinuation: seg.showLeadingContinuation,
+      showTrailingContinuation: seg.showTrailingContinuation,
+      insetLeft: seg.insetLeft,
+      insetRight: seg.insetRight,
+    }))).toEqual([
+      {
+        colStart: 0,
+        colSpan: 2,
+        holidayOffset: 0,
+        isStart: true,
+        isEnd: false,
+        showLeadingContinuation: false,
+        showTrailingContinuation: false,
+        insetLeft: true,
+        insetRight: false,
+      },
+      {
+        colStart: 2,
+        colSpan: 2,
+        holidayOffset: 19,
+        isStart: false,
+        isEnd: true,
+        showLeadingContinuation: false,
+        showTrailingContinuation: false,
+        insetLeft: false,
+        insetRight: true,
+      },
+    ])
+  })
+
+  it('공휴일이 있는 열과 없는 열의 spacer 높이를 다르게 예약한다', () => {
     const row = makeRow(2025, 5, 15)
     const segments = computeSegments(row, [
       makeEvent({
@@ -338,8 +389,9 @@ describe('holiday overlay helpers', () => {
         end_at: '2025-06-16T00:00:00Z',
       }),
     ])
+    const displaySegments = splitSegmentsByHolidayOffsets(segments, [1, 0, 0, 0, 0, 0, 0])
 
-    expect(computeLaneHeightsByColumn(segments, getHolidayOverlayOffset(1))).toEqual([37, 37, 0, 0, 0, 0, 0])
+    expect(computeReservedLaneHeightsByColumn(displaySegments, [1, 0, 0, 0, 0, 0, 0])).toEqual([20, 18, 0, 0, 0, 0, 0])
   })
 })
 
@@ -767,12 +819,13 @@ describe('공휴일-이벤트 칩 간격', () => {
 
     render(<CalendarGrid {...defaultProps} events={[event]} holidays={holidays} />)
 
-    expect(screen.getByTestId('lane-spacer-2025-06-15')).toHaveStyle({ height: '37px' })
-    expect(screen.getByTestId('lane-spacer-2025-06-16')).toHaveStyle({ height: '37px' })
-    expect(screen.getByTestId('multi-segment-row-priority-row2')).toHaveStyle({ top: '19px' })
+    expect(screen.getByTestId('lane-spacer-2025-06-15')).toHaveStyle({ height: '20px' })
+    expect(screen.getByTestId('lane-spacer-2025-06-16')).toHaveStyle({ height: '18px' })
+    expect(screen.getByTestId('multi-segment-row-priority-row2-piece0')).toHaveStyle({ top: '19px' })
+    expect(screen.getByTestId('multi-segment-row-priority-row2-piece1')).toHaveStyle({ top: '0px' })
   })
 
-  it('같은 주 내부 공휴일 변화로 멀티데이 bar가 분절되지 않는다', () => {
+  it('같은 주 내부 holiday split으로 생긴 조각에는 가짜 continuation 화살표가 보이지 않는다', () => {
     const holidays: Holiday[] = [
       { date: '2025-06-17', localName: '테스트공휴일', countryCode: 'KR' },
       { date: '2025-06-18', localName: '테스트공휴일2', countryCode: 'KR' },
@@ -788,8 +841,28 @@ describe('공휴일-이벤트 칩 간격', () => {
     render(<CalendarGrid {...defaultProps} events={[event]} holidays={holidays} />)
 
     const bars = screen.getAllByTitle('연속휴가')
-    expect(bars).toHaveLength(1)
+    expect(bars).toHaveLength(2)
     expect(bars[0].textContent).not.toMatch(/[‹›]/)
+    expect(bars[1].textContent).not.toMatch(/[‹›]/)
+  })
+
+  it('공휴일이 없는 구간은 같은 주 안에서도 불필요하게 아래로 처지지 않는다', () => {
+    const holidays: Holiday[] = [
+      { date: '2026-05-24', localName: '부처님오신날', countryCode: 'KR' },
+      { date: '2026-05-25', localName: '대체공휴일', countryCode: 'KR' },
+    ]
+    const event = makeEvent({
+      id: 'geunchang-japan',
+      title: '근짱 일본',
+      is_all_day: true,
+      start_at: '2026-05-28T00:00:00Z',
+      end_at: '2026-06-02T00:00:00Z',
+    })
+
+    render(<CalendarGrid {...defaultProps} year={2026} month={4} events={[event]} holidays={holidays} />)
+
+    expect(screen.getByTestId('multi-segment-geunchang-japan-row4-piece0')).toHaveStyle({ top: '0px' })
+    expect(screen.getByTestId('multi-segment-geunchang-japan-row5-piece0')).toHaveStyle({ top: '0px' })
   })
 })
 

--- a/src/__tests__/components/CalendarGrid.test.tsx
+++ b/src/__tests__/components/CalendarGrid.test.tsx
@@ -11,6 +11,7 @@ import {
   getHolidayBlockHeight,
   getHolidayOverlayOffset,
   splitSegmentsByHolidayOffsets,
+  shouldRenderMultiDayAboveHolidays,
 } from '@/components/calendar/CalendarGrid'
 import type { Calendar, CalendarEvent } from '@/lib/calendar'
 import type { Holiday } from '@/hooks/useHolidays'
@@ -393,6 +394,34 @@ describe('holiday overlay helpers', () => {
 
     expect(computeReservedLaneHeightsByColumn(displaySegments, [1, 0, 0, 0, 0, 0, 0])).toEqual([20, 18, 0, 0, 0, 0, 0])
   })
+
+  it('연속 공휴일 구간을 멀티데이 일정이 가로지르면 멀티데이를 공휴일 위에 둔다', () => {
+    const row = makeRow(2026, 8, 20)
+    const segments = computeSegments(row, [
+      makeEvent({
+        id: 'holiday-bridge',
+        is_all_day: true,
+        start_at: '2026-09-20T00:00:00Z',
+        end_at: '2026-09-26T00:00:00Z',
+      }),
+    ])
+
+    expect(shouldRenderMultiDayAboveHolidays(segments, [0, 1, 1, 1, 1, 1, 1])).toBe(true)
+  })
+
+  it('연속 공휴일을 가로지르지 않으면 기존 holiday-aware split을 유지한다', () => {
+    const row = makeRow(2026, 4, 24)
+    const segments = computeSegments(row, [
+      makeEvent({
+        id: 'geunchang-japan',
+        is_all_day: true,
+        start_at: '2026-05-28T00:00:00Z',
+        end_at: '2026-06-02T00:00:00Z',
+      }),
+    ])
+
+    expect(shouldRenderMultiDayAboveHolidays(segments, [1, 1, 0, 0, 0, 0, 0])).toBe(false)
+  })
 })
 
 // ── 동적 단일 일정 표시 개수 ─────────────────────────────────
@@ -615,8 +644,8 @@ describe('CalendarGrid', () => {
 
     render(<CalendarGrid {...defaultProps} year={2026} month={4} events={events} />)
 
-    expect(screen.getByTestId('lane-spacer-2026-05-24')).toHaveStyle({ height: '0px' })
-    expect(screen.getByTestId('lane-spacer-2026-05-25')).toHaveStyle({ height: '0px' })
+    expect(screen.queryByTestId('lane-spacer-2026-05-24')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('lane-spacer-2026-05-25')).not.toBeInTheDocument()
     expect(screen.getByTestId('lane-spacer-2026-05-28')).toHaveStyle({ height: '18px' })
     expect(screen.getByTestId('lane-spacer-2026-05-29')).toHaveStyle({ height: '18px' })
     expect(screen.getByTestId('lane-spacer-2026-05-30')).toHaveStyle({ height: '18px' })
@@ -828,7 +857,6 @@ describe('공휴일-이벤트 칩 간격', () => {
   it('같은 주 내부 holiday split으로 생긴 조각에는 가짜 continuation 화살표가 보이지 않는다', () => {
     const holidays: Holiday[] = [
       { date: '2025-06-17', localName: '테스트공휴일', countryCode: 'KR' },
-      { date: '2025-06-18', localName: '테스트공휴일2', countryCode: 'KR' },
     ]
     const event = makeEvent({
       id: 'holiday-split',
@@ -841,9 +869,10 @@ describe('공휴일-이벤트 칩 간격', () => {
     render(<CalendarGrid {...defaultProps} events={[event]} holidays={holidays} />)
 
     const bars = screen.getAllByTitle('연속휴가')
-    expect(bars).toHaveLength(2)
+    expect(bars).toHaveLength(3)
     expect(bars[0].textContent).not.toMatch(/[‹›]/)
     expect(bars[1].textContent).not.toMatch(/[‹›]/)
+    expect(bars[2].textContent).not.toMatch(/[‹›]/)
   })
 
   it('공휴일이 없는 구간은 같은 주 안에서도 불필요하게 아래로 처지지 않는다', () => {
@@ -863,6 +892,30 @@ describe('공휴일-이벤트 칩 간격', () => {
 
     expect(screen.getByTestId('multi-segment-geunchang-japan-row4-piece0')).toHaveStyle({ top: '0px' })
     expect(screen.getByTestId('multi-segment-geunchang-japan-row5-piece0')).toHaveStyle({ top: '0px' })
+  })
+
+  it('연속 공휴일 구간을 가로지르는 멀티데이 일정은 공휴일보다 위에 유지된다', () => {
+    const holidays: Holiday[] = [
+      { date: '2026-09-21', localName: '敬老の日', countryCode: 'JP' },
+      { date: '2026-09-22', localName: '国民の休日', countryCode: 'JP' },
+      { date: '2026-09-23', localName: '秋分の日', countryCode: 'JP' },
+      { date: '2026-09-24', localName: '추석', countryCode: 'KR' },
+      { date: '2026-09-25', localName: '추석', countryCode: 'KR' },
+      { date: '2026-09-26', localName: '추석', countryCode: 'KR' },
+    ]
+    const event = makeEvent({
+      id: 'jeonju-japan',
+      title: '전주in日本',
+      is_all_day: true,
+      start_at: '2026-09-20T00:00:00Z',
+      end_at: '2026-09-26T00:00:00Z',
+    })
+
+    render(<CalendarGrid {...defaultProps} year={2026} month={8} events={[event]} holidays={holidays} />)
+
+    expect(screen.getByTestId('lane-spacer-2026-09-21')).toHaveStyle({ height: '18px' })
+    expect(screen.getByTestId('lane-spacer-2026-09-26')).toHaveStyle({ height: '18px' })
+    expect(screen.getByTestId('multi-segment-jeonju-japan-row3-piece0')).toHaveStyle({ top: '0px' })
   })
 })
 

--- a/src/components/calendar/CalendarGrid.tsx
+++ b/src/components/calendar/CalendarGrid.tsx
@@ -85,6 +85,52 @@ export function getHolidayOverlayOffset(holidayCount: number): number {
   return getHolidayBlockHeight(holidayCount) + HOLIDAY_EVENT_GAP
 }
 
+interface DisplaySegment extends EventSegment {
+  holidayOffset: number
+  showLeadingContinuation: boolean
+  showTrailingContinuation: boolean
+  insetLeft: boolean
+  insetRight: boolean
+}
+
+export function splitSegmentsByHolidayOffsets(
+  segments: EventSegment[],
+  holidayCountsByColumn: number[]
+): DisplaySegment[] {
+  const displaySegments: DisplaySegment[] = []
+
+  for (const seg of segments) {
+    const segmentEnd = seg.colStart + seg.colSpan
+    let pieceStart = seg.colStart
+    let currentHolidayCount = holidayCountsByColumn[pieceStart] ?? 0
+
+    for (let col = seg.colStart + 1; col <= segmentEnd; col += 1) {
+      const nextHolidayCount = col < segmentEnd ? (holidayCountsByColumn[col] ?? 0) : null
+      if (nextHolidayCount === currentHolidayCount) continue
+
+      const isPieceStart = pieceStart === seg.colStart
+      const isPieceEnd = col === segmentEnd
+      displaySegments.push({
+        ...seg,
+        colStart: pieceStart,
+        colSpan: col - pieceStart,
+        isStart: seg.isStart && isPieceStart,
+        isEnd: seg.isEnd && isPieceEnd,
+        holidayOffset: getHolidayOverlayOffset(currentHolidayCount),
+        showLeadingContinuation: !seg.isStart && isPieceStart,
+        showTrailingContinuation: !seg.isEnd && isPieceEnd,
+        insetLeft: isPieceStart,
+        insetRight: isPieceEnd,
+      })
+
+      pieceStart = col
+      currentHolidayCount = nextHolidayCount ?? 0
+    }
+  }
+
+  return displaySegments
+}
+
 export function getSingleEventDisplayBudget({
   rowHeight,
   dateHeaderHeight,
@@ -202,6 +248,24 @@ export function computeLaneHeightsByColumn(segments: EventSegment[], baseOffset 
     const endCol = seg.colStart + seg.colSpan
     for (let col = seg.colStart; col < endCol; col += 1) {
       if (laneHeight > heights[col]) heights[col] = laneHeight
+    }
+  }
+
+  return heights
+}
+
+export function computeReservedLaneHeightsByColumn(
+  segments: DisplaySegment[],
+  holidayCountsByColumn: number[]
+): number[] {
+  const heights = Array.from({ length: 7 }, () => 0)
+
+  for (const seg of segments) {
+    const segmentBottom = seg.holidayOffset + (seg.lane + 1) * LANE_HEIGHT
+    const endCol = seg.colStart + seg.colSpan
+    for (let col = seg.colStart; col < endCol; col += 1) {
+      const reservedHeight = Math.max(0, segmentBottom - getHolidayBlockHeight(holidayCountsByColumn[col] ?? 0))
+      if (reservedHeight > heights[col]) heights[col] = reservedHeight
     }
   }
 
@@ -361,8 +425,11 @@ export function CalendarGrid({
           const ymd = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
           return holidaysByDate.get(ymd)?.length ?? 0
         })
-        const rowHolidayOffset = getHolidayOverlayOffset(Math.max(0, ...holidayCountsByColumn))
-        const laneHeightsByColumn = computeLaneHeightsByColumn(segments, rowHolidayOffset)
+        const displaySegments = splitSegmentsByHolidayOffsets(segments, holidayCountsByColumn)
+        const laneHeightsByColumn = computeReservedLaneHeightsByColumn(
+          displaySegments,
+          holidayCountsByColumn
+        )
 
         return (
             <div key={rowIdx} className="relative min-h-0">
@@ -485,13 +552,13 @@ export function CalendarGrid({
               </div>
 
               {/* 멀티데이 이벤트 overlay */}
-              {segments.length > 0 && (
+              {displaySegments.length > 0 && (
                 <div
                   aria-hidden="true"
                   className="absolute inset-x-0 pointer-events-none"
                   style={{ top: effectiveDateHeaderHeight }}
                 >
-                  {segments.map((seg) => {
+                  {displaySegments.map((seg, segIdx) => {
                     const color = getEventColor(seg.event)
                     const s = seg.isStart ? '4px' : '0'
                     const e = seg.isEnd ? '4px' : '0'
@@ -499,14 +566,16 @@ export function CalendarGrid({
 
                     return (
                       <div
-                        key={`${seg.event.id}-row${rowIdx}`}
-                        data-testid={`multi-segment-${seg.event.id}-row${rowIdx}`}
-                        className="absolute px-0.5 pointer-events-none"
+                        key={`${seg.event.id}-row${rowIdx}-piece${segIdx}`}
+                        data-testid={`multi-segment-${seg.event.id}-row${rowIdx}-piece${segIdx}`}
+                        className="absolute pointer-events-none"
                         style={{
                           left: `${(seg.colStart / 7) * 100}%`,
                           width: `${(seg.colSpan / 7) * 100}%`,
-                          top: rowHolidayOffset + seg.lane * LANE_HEIGHT,
+                          top: seg.holidayOffset + seg.lane * LANE_HEIGHT,
                           height: 16,
+                          paddingLeft: seg.insetLeft ? 2 : 0,
+                          paddingRight: seg.insetRight ? 2 : 0,
                         }}
                       >
                         <button
@@ -521,9 +590,9 @@ export function CalendarGrid({
                           }}
                           onClick={() => onSelectDate(dateOnly(new Date(seg.event.start_at)))}
                         >
-                          {!seg.isStart && <span className="shrink-0 opacity-70">‹</span>}
+                          {seg.showLeadingContinuation && <span className="shrink-0 opacity-70">‹</span>}
                           <span className="overflow-hidden min-w-0">{seg.event.title}</span>
-                          {!seg.isEnd && <span className="shrink-0 opacity-70">›</span>}
+                          {seg.showTrailingContinuation && <span className="shrink-0 opacity-70">›</span>}
                         </button>
                       </div>
                     )

--- a/src/components/calendar/CalendarGrid.tsx
+++ b/src/components/calendar/CalendarGrid.tsx
@@ -97,6 +97,8 @@ export function shouldRenderMultiDayAboveHolidays(
   segments: EventSegment[],
   holidayCountsByColumn: number[]
 ): boolean {
+  // Default policy keeps holiday-aware splits so holiday-free days do not drop.
+  // Long holiday streaks are the exception: keep one continuous multi-day bar above them.
   let streakStart = -1
 
   for (let col = 0; col <= holidayCountsByColumn.length; col += 1) {

--- a/src/components/calendar/CalendarGrid.tsx
+++ b/src/components/calendar/CalendarGrid.tsx
@@ -93,6 +93,39 @@ interface DisplaySegment extends EventSegment {
   insetRight: boolean
 }
 
+export function shouldRenderMultiDayAboveHolidays(
+  segments: EventSegment[],
+  holidayCountsByColumn: number[]
+): boolean {
+  let streakStart = -1
+
+  for (let col = 0; col <= holidayCountsByColumn.length; col += 1) {
+    const hasHoliday = col < holidayCountsByColumn.length && (holidayCountsByColumn[col] ?? 0) > 0
+
+    if (hasHoliday) {
+      if (streakStart === -1) streakStart = col
+      continue
+    }
+
+    if (streakStart === -1) continue
+
+    const streakEnd = col
+    const streakLength = streakEnd - streakStart
+    if (streakLength >= 2) {
+      const crossesHolidayStreak = segments.some((seg) => (
+        seg.colStart < streakStart &&
+        seg.colStart + seg.colSpan > streakStart &&
+        seg.colStart + seg.colSpan >= streakEnd
+      ))
+      if (crossesHolidayStreak) return true
+    }
+
+    streakStart = -1
+  }
+
+  return false
+}
+
 export function splitSegmentsByHolidayOffsets(
   segments: EventSegment[],
   holidayCountsByColumn: number[]
@@ -425,11 +458,20 @@ export function CalendarGrid({
           const ymd = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
           return holidaysByDate.get(ymd)?.length ?? 0
         })
-        const displaySegments = splitSegmentsByHolidayOffsets(segments, holidayCountsByColumn)
-        const laneHeightsByColumn = computeReservedLaneHeightsByColumn(
-          displaySegments,
-          holidayCountsByColumn
-        )
+        const renderMultiDayAboveHolidays = shouldRenderMultiDayAboveHolidays(segments, holidayCountsByColumn)
+        const displaySegments = renderMultiDayAboveHolidays
+          ? segments.map((seg) => ({
+              ...seg,
+              holidayOffset: 0,
+              showLeadingContinuation: !seg.isStart,
+              showTrailingContinuation: !seg.isEnd,
+              insetLeft: true,
+              insetRight: true,
+            }))
+          : splitSegmentsByHolidayOffsets(segments, holidayCountsByColumn)
+        const laneHeightsByColumn = renderMultiDayAboveHolidays
+          ? computeLaneHeightsByColumn(segments)
+          : computeReservedLaneHeightsByColumn(displaySegments, holidayCountsByColumn)
 
         return (
             <div key={rowIdx} className="relative min-h-0">
@@ -447,6 +489,8 @@ export function CalendarGrid({
                   const isSat = dow === 6
                   const hasHolidaysAndEvents = dayHolidays.length > 0 && daySingleEvents.length > 0
                   const laneAreaHeight = laneHeightsByColumn[colIdx] ?? 0
+                  const holidaySpacerBefore = renderMultiDayAboveHolidays ? laneAreaHeight : 0
+                  const holidaySpacerAfter = renderMultiDayAboveHolidays ? 0 : laneAreaHeight
                   const singleEventDisplay = getSingleEventDisplayBudget({
                     rowHeight,
                     dateHeaderHeight: effectiveDateHeaderHeight,
@@ -507,6 +551,15 @@ export function CalendarGrid({
                         )}
                       </div>
 
+                      {/* 멀티데이 lane 공간 확보용 spacer - 공휴일 위 모드 */}
+                      {holidaySpacerBefore > 0 && (
+                        <div
+                          aria-hidden="true"
+                          data-testid={`lane-spacer-${ymd}`}
+                          style={{ height: holidaySpacerBefore }}
+                        />
+                      )}
+
                       {/* 공휴일 chips */}
                       <div className="w-full space-y-0.5">
                         {dayHolidays.map((h) => (
@@ -519,12 +572,14 @@ export function CalendarGrid({
                         ))}
                       </div>
 
-                      {/* 멀티데이 lane 공간 확보용 spacer */}
-                      <div
-                        aria-hidden="true"
-                        data-testid={`lane-spacer-${ymd}`}
-                        style={{ height: laneAreaHeight }}
-                      />
+                      {/* 멀티데이 lane 공간 확보용 spacer - 공휴일 아래 모드 */}
+                      {holidaySpacerAfter > 0 && (
+                        <div
+                          aria-hidden="true"
+                          data-testid={`lane-spacer-${ymd}`}
+                          style={{ height: holidaySpacerAfter }}
+                        />
+                      )}
 
                       {/* 단일 일정 pills */}
                       <div className={`w-full space-y-0.5${hasHolidaysAndEvents ? ' mt-0.5' : ''}`}>


### PR DESCRIPTION
## Summary
- 월간 `CalendarGrid`의 기본 멀티데이 배치는 `holiday-aware split`를 유지해, 같은 주 안에서도 공휴일이 없는 구간은 불필요하게 아래로 내려가지 않도록 했습니다.
- 연속 공휴일 구간을 가로지르는 멀티데이 종일 일정은 예외적으로 공휴일보다 위에 렌더링하도록 규칙을 추가해, 긴 공휴일 블록 위에서도 줄바꿈 없이 연속 bar를 유지하도록 했습니다.
- split된 내부 조각은 좌우 inset과 continuation 표시 규칙을 분리해, 실제 렌더에서는 하나의 연속 bar처럼 보이도록 정리했습니다.
- `CalendarGrid` 테스트를 보강해 split helper, spacer 예약, 내부 split 화살표 억제, `근짱 일본` 회귀 케이스, 연속 공휴일 교차 우선순위를 검증했습니다.

## Testing
- `npm run test -- --runInBand src/__tests__/components/CalendarGrid.test.tsx`
- `npx tsc --noEmit`

## Manual Testing
- [x] 같은 주 안에서 공휴일이 없는 날짜 구간은 멀티데이 종일 일정이 불필요하게 아래로 처지지 않는지 확인
- [x] 연속 공휴일 구간을 가로지르는 멀티데이 일정은 공휴일보다 위에 유지되어 줄바꿈 없이 이어지는지 확인
- [x] 주 경계 continuation 화살표는 유지되고, 주 내부 holiday split 조각에는 가짜 화살표가 보이지 않는지 확인
