### PR TITLE
fix: improve calendar memo display

### DIFF
--- a/src/__tests__/components/EventDetailSheet.test.tsx
+++ b/src/__tests__/components/EventDetailSheet.test.tsx
@@ -86,4 +86,21 @@ describe('EventDetailSheet', () => {
     expect(screen.getByText('매주 수요일')).toBeInTheDocument()
     expect(screen.getByText('종료일 미설정 · 시작일 기준 1년 생성')).toBeInTheDocument()
   })
+
+  it('메모 상세는 개행을 보존해서 표시한다', () => {
+    const { container } = render(
+      <EventDetailSheet
+        {...defaultProps}
+        event={{
+          ...defaultProps.event,
+          description: '첫 줄\n둘째 줄',
+        }}
+      />
+    )
+
+    const note = container.querySelector('.whitespace-pre-wrap') as HTMLElement
+    expect(note.firstChild?.nodeValue).toBe('첫 줄\n둘째 줄')
+    expect(note).toHaveClass('whitespace-pre-wrap')
+    expect(note).toHaveClass('break-words')
+  })
 })

--- a/src/__tests__/components/EventFormModal.test.tsx
+++ b/src/__tests__/components/EventFormModal.test.tsx
@@ -338,6 +338,25 @@ describe('EventFormModal', () => {
     expect(screen.getByPlaceholderText('메모 (선택)')).not.toHaveClass('text-sm')
   })
 
+  it('메모 입력창은 내용이 길어지면 높이를 자동으로 늘린다', () => {
+    Object.defineProperty(HTMLTextAreaElement.prototype, 'scrollHeight', {
+      configurable: true,
+      get() {
+        return 160
+      },
+    })
+
+    render(<EventFormModal {...defaultProps} initialDate={new Date('2026-03-31')} />)
+
+    const textarea = screen.getByPlaceholderText('메모 (선택)') as HTMLTextAreaElement
+    fireEvent.change(textarea, { target: { value: '첫 줄\n둘째 줄\n셋째 줄\n넷째 줄' } })
+
+    expect(textarea.style.height).toBe('160px')
+    expect(textarea.style.overflowY).toBe('hidden')
+
+    delete (HTMLTextAreaElement.prototype as { scrollHeight?: number }).scrollHeight
+  })
+
   it('showPicker()가 없는 브라우저에서는 native 날짜 input 기본 동작을 막지 않는다', () => {
     render(<EventFormModal {...defaultProps} initialDate={new Date('2026-03-31')} />)
     const dateInputs = document.querySelectorAll('input[type="date"]')

--- a/src/components/calendar/EventDetailSheet.tsx
+++ b/src/components/calendar/EventDetailSheet.tsx
@@ -140,7 +140,7 @@ export function EventDetailSheet({ event, calendars, onClose, onEdit, onDelete }
 
           {/* 메모 */}
           {event.description && (
-            <div className="text-sm text-stone-600 dark:text-stone-300 bg-stone-50 dark:bg-stone-800 rounded-xl px-3 py-2">
+            <div className="whitespace-pre-wrap break-words text-sm text-stone-600 dark:text-stone-300 bg-stone-50 dark:bg-stone-800 rounded-xl px-3 py-2">
               {event.description}
             </div>
           )}

--- a/src/components/calendar/EventFormModal.tsx
+++ b/src/components/calendar/EventFormModal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useRef, useEffect, type MouseEvent } from 'react'
+import { useState, useRef, useEffect, useLayoutEffect, type MouseEvent } from 'react'
 import { X, Bell, RefreshCw, Check, Tag, CalendarDays, Clock3, ChevronRight, AlignLeft } from 'lucide-react'
 import { REMINDER_OPTIONS, LABEL_COLORS, LABEL_COLOR_NAMES, type Calendar, type CalendarEvent } from '@/lib/calendar'
 import { toDisplayColor } from '@/lib/label-colors'
@@ -151,6 +151,7 @@ export function EventFormModal({
   const titleInputRef = useRef<HTMLInputElement>(null)
   const startDateInputRef = useRef<HTMLInputElement>(null)
   const endDateInputRef = useRef<HTMLInputElement>(null)
+  const descriptionTextareaRef = useRef<HTMLTextAreaElement>(null)
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -158,6 +159,16 @@ export function EventFormModal({
     }, 300)
     return () => clearTimeout(timer)
   }, [])
+
+  useLayoutEffect(() => {
+    const textarea = descriptionTextareaRef.current
+    if (!textarea) return
+
+    const maxHeight = 224
+    textarea.style.height = 'auto'
+    textarea.style.height = `${Math.min(textarea.scrollHeight, maxHeight)}px`
+    textarea.style.overflowY = textarea.scrollHeight > maxHeight ? 'auto' : 'hidden'
+  }, [description])
 
   const triggerShake = () => {
     setEndShake(false)
@@ -611,6 +622,7 @@ export function EventFormModal({
             </div>
             <div className="py-3 pr-4 sm:py-5 sm:pr-5">
               <textarea
+                ref={descriptionTextareaRef}
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
                 placeholder="메모 (선택)"


### PR DESCRIPTION
## Summary
- auto-grow the memo field in the calendar event editor so longer notes show more lines before scrolling
- preserve line breaks in the calendar event detail sheet while keeping the day events summary compact
- add component tests for memo auto-resize and newline-preserving detail rendering

## Testing
- npm run test -- --runInBand src/__tests__/components/EventFormModal.test.tsx src/__tests__/components/EventDetailSheet.test.tsx
- npx tsc --noEmit
