### PR TITLE
feat: auto adjust event end time

### DIFF
--- a/src/__tests__/components/EventFormModal.test.tsx
+++ b/src/__tests__/components/EventFormModal.test.tsx
@@ -290,6 +290,83 @@ describe('EventFormModal', () => {
     expect(screen.getByText('17:30')).toBeInTheDocument()
   })
 
+  it('end_at 없는 기존 일정도 사용자가 바꾼 현재 일정 길이를 유지한다', () => {
+    const initial: import('@/lib/calendar').CalendarEvent = {
+      id: 'evt-1',
+      family_id: 'fam-1',
+      calendar_id: 'cal-1',
+      created_by: 'user-1',
+      title: '종료 없음',
+      description: null,
+      start_at: new Date('2026-03-31T09:00').toISOString(),
+      end_at: null,
+      is_all_day: false,
+      is_cancelled: false,
+      label_color: null,
+      series_id: null,
+      series_occurrence_date: null,
+      created_at: '',
+      updated_at: '',
+    }
+    render(<EventFormModal {...defaultProps} initial={initial} />)
+
+    fireEvent.click(screen.getByText('10:00'))
+    let hoursInput = screen.getByTestId('wheel-hours') as HTMLInputElement
+    let minutesInput = screen.getByTestId('wheel-minutes') as HTMLInputElement
+    fireEvent.change(hoursInput, { target: { value: '12' } })
+    fireEvent.change(minutesInput, { target: { value: '30' } })
+    expect(screen.getByText('12:30')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('09:00'))
+    hoursInput = screen.getByTestId('wheel-hours') as HTMLInputElement
+    minutesInput = screen.getByTestId('wheel-minutes') as HTMLInputElement
+    fireEvent.change(hoursInput, { target: { value: '11' } })
+    fireEvent.change(minutesInput, { target: { value: '0' } })
+
+    expect(screen.getByText('11:00')).toBeInTheDocument()
+    expect(screen.getByText('14:30')).toBeInTheDocument()
+  })
+
+  it('end_at 없는 기존 일정의 종료 날짜를 다음날로 바꾼 뒤에도 현재 일정 길이를 유지한다', () => {
+    const initial: import('@/lib/calendar').CalendarEvent = {
+      id: 'evt-1',
+      family_id: 'fam-1',
+      calendar_id: 'cal-1',
+      created_by: 'user-1',
+      title: '다음날 종료',
+      description: null,
+      start_at: new Date('2026-03-31T09:00').toISOString(),
+      end_at: null,
+      is_all_day: false,
+      is_cancelled: false,
+      label_color: null,
+      series_id: null,
+      series_occurrence_date: null,
+      created_at: '',
+      updated_at: '',
+    }
+    render(<EventFormModal {...defaultProps} initial={initial} />)
+
+    const dateInputs = document.querySelectorAll('input[type="date"]')
+    fireEvent.change(dateInputs[1] as HTMLInputElement, { target: { value: '2026-04-01' } })
+    fireEvent.click(screen.getByText('10:00'))
+    let hoursInput = screen.getByTestId('wheel-hours') as HTMLInputElement
+    let minutesInput = screen.getByTestId('wheel-minutes') as HTMLInputElement
+    fireEvent.change(hoursInput, { target: { value: '0' } })
+    fireEvent.change(minutesInput, { target: { value: '30' } })
+    expect(screen.getByText('00:30')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('09:00'))
+    hoursInput = screen.getByTestId('wheel-hours') as HTMLInputElement
+    minutesInput = screen.getByTestId('wheel-minutes') as HTMLInputElement
+    fireEvent.change(hoursInput, { target: { value: '10' } })
+    fireEvent.change(minutesInput, { target: { value: '0' } })
+
+    expect((dateInputs[1] as HTMLInputElement).value).toBe('2026-04-01')
+    expect(screen.getByText('10:00')).toBeInTheDocument()
+    expect(screen.getByText('01:30')).toBeInTheDocument()
+  })
+
   it('시작 시간 변경으로 종료 시간이 자정을 넘으면 종료 날짜를 다음날로 이동한다', () => {
     render(<EventFormModal {...defaultProps} initialDate={new Date('2026-03-31')} />)
 

--- a/src/__tests__/components/EventFormModal.test.tsx
+++ b/src/__tests__/components/EventFormModal.test.tsx
@@ -215,7 +215,7 @@ describe('EventFormModal', () => {
     expect(hoursInput.value).toBe('9')
   })
 
-  it('시작 시간이 종료 시간보다 뒤로 바뀌면 종료 시간을 시작 시간으로 보정한다', async () => {
+  it('새 일정의 시작 시간이 바뀌면 종료 시간을 한 시간 뒤로 이동한다', async () => {
     render(<EventFormModal {...defaultProps} initialDate={new Date('2026-03-31')} />)
 
     fireEvent.click(screen.getByRole('button', { name: '종일' }))
@@ -224,7 +224,8 @@ describe('EventFormModal', () => {
     const hoursInput = screen.getByTestId('wheel-hours') as HTMLInputElement
     fireEvent.change(hoursInput, { target: { value: '11' } })
 
-    expect(screen.getAllByText('11:00')).toHaveLength(2)
+    expect(screen.getByText('11:00')).toBeInTheDocument()
+    expect(screen.getByText('12:00')).toBeInTheDocument()
 
     fireEvent.change(screen.getByPlaceholderText('제목'), { target: { value: '시간 일정' } })
     await act(async () => {
@@ -238,7 +239,73 @@ describe('EventFormModal', () => {
       })
     )
     const savedParams = defaultProps.onSave.mock.calls[0][0]
-    expect(savedParams.endAt).toBe(savedParams.startAt)
+    expect(new Date(savedParams.endAt).getTime() - new Date(savedParams.startAt).getTime()).toBe(60 * 60 * 1000)
+  })
+
+  it('종료 시간을 직접 바꾼 뒤 시작 시간을 바꾸면 현재 일정 길이를 유지한다', () => {
+    render(<EventFormModal {...defaultProps} initialDate={new Date('2026-03-31')} />)
+
+    fireEvent.click(screen.getByRole('button', { name: '종일' }))
+    fireEvent.click(screen.getByText('10:00'))
+
+    const minutesInput = screen.getByTestId('wheel-minutes') as HTMLInputElement
+    fireEvent.change(minutesInput, { target: { value: '30' } })
+    expect(screen.getByText('10:30')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('09:00'))
+    const hoursInput = screen.getByTestId('wheel-hours') as HTMLInputElement
+    fireEvent.change(hoursInput, { target: { value: '11' } })
+
+    expect(screen.getByText('11:00')).toBeInTheDocument()
+    expect(screen.getByText('12:30')).toBeInTheDocument()
+  })
+
+  it('기존 일정의 시작 시간이 바뀌면 기존 일정 길이만큼 종료 시간을 이동한다', () => {
+    const initial: import('@/lib/calendar').CalendarEvent = {
+      id: 'evt-1',
+      family_id: 'fam-1',
+      calendar_id: 'cal-1',
+      created_by: 'user-1',
+      title: '기존 일정',
+      description: null,
+      start_at: new Date('2026-03-31T13:30').toISOString(),
+      end_at: new Date('2026-03-31T15:00').toISOString(),
+      is_all_day: false,
+      is_cancelled: false,
+      label_color: null,
+      series_id: null,
+      series_occurrence_date: null,
+      created_at: '',
+      updated_at: '',
+    }
+    render(<EventFormModal {...defaultProps} initial={initial} />)
+
+    fireEvent.click(screen.getByText('13:30'))
+    const hoursInput = screen.getByTestId('wheel-hours') as HTMLInputElement
+    const minutesInput = screen.getByTestId('wheel-minutes') as HTMLInputElement
+    fireEvent.change(hoursInput, { target: { value: '16' } })
+    fireEvent.change(minutesInput, { target: { value: '0' } })
+
+    expect(screen.getByText('16:00')).toBeInTheDocument()
+    expect(screen.getByText('17:30')).toBeInTheDocument()
+  })
+
+  it('시작 시간 변경으로 종료 시간이 자정을 넘으면 종료 날짜를 다음날로 이동한다', () => {
+    render(<EventFormModal {...defaultProps} initialDate={new Date('2026-03-31')} />)
+
+    fireEvent.click(screen.getByRole('button', { name: '종일' }))
+    fireEvent.click(screen.getByText('09:00'))
+
+    const hoursInput = screen.getByTestId('wheel-hours') as HTMLInputElement
+    const minutesInput = screen.getByTestId('wheel-minutes') as HTMLInputElement
+    fireEvent.change(hoursInput, { target: { value: '23' } })
+    fireEvent.change(minutesInput, { target: { value: '30' } })
+
+    const dateInputs = document.querySelectorAll('input[type="date"]')
+    expect((dateInputs[0] as HTMLInputElement).value).toBe('2026-03-31')
+    expect((dateInputs[1] as HTMLInputElement).value).toBe('2026-04-01')
+    expect(screen.getByText('23:30')).toBeInTheDocument()
+    expect(screen.getByText('00:30')).toBeInTheDocument()
   })
 
   it('X 버튼 클릭 시 애니메이션 후 onClose가 호출된다', () => {

--- a/src/components/calendar/EventFormModal.tsx
+++ b/src/components/calendar/EventFormModal.tsx
@@ -21,16 +21,28 @@ function buildTime(h: number, m: number): string {
   return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`
 }
 
+function formatLocalDate(date: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`
+}
+
+function formatLocalTime(date: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return `${pad(date.getHours())}:${pad(date.getMinutes())}`
+}
+
+function buildLocalDateTime(date: string, time: string): Date {
+  return new Date(`${date}T${time}`)
+}
+
 function parseDate(isoString: string): string {
   const d = new Date(isoString)
-  const pad = (n: number) => String(n).padStart(2, '0')
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
+  return formatLocalDate(d)
 }
 
 function parseTime(isoString: string): string {
   const d = new Date(isoString)
-  const pad = (n: number) => String(n).padStart(2, '0')
-  return `${pad(d.getHours())}:${pad(d.getMinutes())}`
+  return formatLocalTime(d)
 }
 
 function buildISO(date: string, time: string): string {
@@ -255,8 +267,17 @@ export function EventFormModal({
 
   const handleStartTimeChange = (h: number, m: number) => {
     const newStartTime = buildTime(h, m)
+    const currentStart = buildLocalDateTime(startDate, startTime)
+    const currentEnd = initial && !initial.end_at
+      ? new Date(currentStart.getTime() + 60 * 60 * 1000)
+      : buildLocalDateTime(endDate, endTime)
+    const durationMs = Math.max(0, currentEnd.getTime() - currentStart.getTime())
+    const newStart = buildLocalDateTime(startDate, newStartTime)
+    const newEnd = new Date(newStart.getTime() + durationMs)
+
     setStartTime(newStartTime)
-    keepEndAtOrAfterStart(startDate, newStartTime)
+    setEndDate(formatLocalDate(newEnd))
+    setEndTime(formatLocalTime(newEnd))
   }
 
   const handleEndTimeChange = (h: number, m: number) => {

--- a/src/components/calendar/EventFormModal.tsx
+++ b/src/components/calendar/EventFormModal.tsx
@@ -123,10 +123,16 @@ export function EventFormModal({
   })
   const [endDate, setEndDate] = useState<string>(() => {
     if (initial?.end_at) return parseDate(initial.end_at)
+    if (initial && !initial.is_all_day) {
+      return formatLocalDate(new Date(new Date(initial.start_at).getTime() + 60 * 60 * 1000))
+    }
     return defaultDateStr
   })
   const [endTime, setEndTime] = useState<string>(() => {
     if (initial?.end_at && !initial.is_all_day) return parseTime(initial.end_at)
+    if (initial && !initial.is_all_day) {
+      return formatLocalTime(new Date(new Date(initial.start_at).getTime() + 60 * 60 * 1000))
+    }
     return '10:00'
   })
 
@@ -268,9 +274,7 @@ export function EventFormModal({
   const handleStartTimeChange = (h: number, m: number) => {
     const newStartTime = buildTime(h, m)
     const currentStart = buildLocalDateTime(startDate, startTime)
-    const currentEnd = initial && !initial.end_at
-      ? new Date(currentStart.getTime() + 60 * 60 * 1000)
-      : buildLocalDateTime(endDate, endTime)
+    const currentEnd = buildLocalDateTime(endDate, endTime)
     const durationMs = Math.max(0, currentEnd.getTime() - currentStart.getTime())
     const newStart = buildLocalDateTime(startDate, newStartTime)
     const newEnd = new Date(newStart.getTime() + durationMs)


### PR DESCRIPTION
## Summary
- 일정 작성/수정 화면에서 시작 시간을 변경하면 종료 날짜/시간이 현재 화면의 일정 길이를 유지하도록 자동 이동합니다.
- 새 timed 일정은 기본 1시간 길이로 종료 시간을 설정합니다.
- 기존 timed 일정은 기존 종료 시간이 있으면 그 길이를 유지하고, 종료 시간이 없는 기존 일정은 초기 진입 시에만 1시간 fallback을 적용합니다.
- 사용자가 종료 시간을 직접 바꾼 뒤 시작 시간을 다시 바꾸면, 변경된 현재 일정 길이를 유지합니다.
- 종료 시간이 자정을 넘으면 종료 날짜를 다음날로 자동 이동합니다.
- 관련 EventFormModal 테스트를 추가/갱신했습니다.

## Testing
- npm run test -- --testPathPatterns=src/__tests__/components/EventFormModal.test.tsx
- npx tsc --noEmit
- GitHub Actions: Lint & Test 통과
- Vercel Preview 통과

수동 확인 항목:
- [x] 캘린더 일정 작성 화면에서 timed 새 일정을 만들고, 시작 시간을 바꾸면 종료 시간이 1시간 뒤로 이동하는지 확인합니다.
- [x] 기존 timed 일정을 수정하면서 시작 시간을 바꾸면 기존 일정 길이가 유지되는지 확인합니다.
- [x] 종료 시간을 먼저 직접 변경한 뒤 시작 시간을 바꿨을 때, 변경된 현재 일정 길이가 유지되는지 확인합니다.
- [x] 23:30처럼 늦은 시작 시간으로 바꿨을 때 종료 날짜가 다음날로 넘어가고 종료 시간이 기대값으로 표시되는지 확인합니다.