### PR TITLE
fix: lift reminder item delete dialog

### DIFF
--- a/src/__tests__/reminders/ReminderDetailView.test.tsx
+++ b/src/__tests__/reminders/ReminderDetailView.test.tsx
@@ -473,6 +473,42 @@ describe('ReminderDetailView', () => {
     })
   })
 
+  it('완료 아이템 삭제 확인 다이얼로그를 상세 화면 최상위 레이어에 렌더링한다', async () => {
+    const user = userEvent.setup()
+    mockGetReminderItems.mockResolvedValueOnce([
+      {
+        id: 'item-1',
+        list_id: 'list-1',
+        created_by: 'user-1',
+        name: '완료된 항목',
+        is_checked: true,
+        checked_by: 'user-1',
+        checked_at: '2026-01-01T00:00:00Z',
+        sort_order: 0,
+        created_at: '2026-01-01T00:00:00Z',
+      },
+    ] as never)
+
+    render(
+      <ReminderDetailView
+        listId="list-1"
+        user={mockUser}
+        onClose={onClose}
+        onPreviewItemsChange={onPreviewItemsChange}
+      />
+    )
+
+    await user.click(await screen.findByLabelText('삭제'))
+
+    const dialog = screen.getByRole('dialog', { name: '아이템 삭제' })
+    expect(dialog).toHaveClass('fixed', 'z-[60]')
+    expect(screen.getByTestId('reminder-detail-shell')).toContainElement(dialog)
+    expect(screen.getByText(/완료된 항목.*삭제할까요/)).toBeInTheDocument()
+
+    await user.click(screen.getByLabelText('삭제 확인'))
+    expect(mockDeleteReminderItem).toHaveBeenCalledWith('item-1')
+  })
+
   it('인라인 입력 기준 아이템을 완료 처리하면 인라인 입력창을 닫는다', async () => {
     const user = userEvent.setup()
     mockGetReminderItems.mockResolvedValueOnce([

--- a/src/__tests__/reminders/ReminderItem.test.tsx
+++ b/src/__tests__/reminders/ReminderItem.test.tsx
@@ -48,28 +48,15 @@ describe('ReminderItem', () => {
     expect(screen.getByText('우유')).toHaveClass('line-through')
   })
 
-  it('삭제 버튼 클릭 시 확인 다이얼로그가 나타난다', () => {
-    render(<ReminderItem item={mockItem} listType="strikethrough" onCheck={jest.fn()} onDelete={jest.fn()} onRename={jest.fn()} />)
-    fireEvent.click(screen.getByLabelText('삭제'))
-    expect(screen.getByText('아이템 삭제')).toBeInTheDocument()
-    expect(screen.getByLabelText('삭제 확인')).toBeInTheDocument()
-    expect(screen.getByLabelText('취소')).toBeInTheDocument()
-  })
-
-  it('다이얼로그에서 삭제 확인 시 onDelete가 호출된다', () => {
+  it('삭제 버튼 클릭 시 onDelete가 호출된다', () => {
     const onDelete = jest.fn()
     render(<ReminderItem item={mockItem} listType="strikethrough" onCheck={jest.fn()} onDelete={onDelete} onRename={jest.fn()} />)
     fireEvent.click(screen.getByLabelText('삭제'))
-    fireEvent.click(screen.getByLabelText('삭제 확인'))
     expect(onDelete).toHaveBeenCalledWith('item-1')
   })
 
-  it('다이얼로그에서 취소 시 onDelete가 호출되지 않는다', () => {
-    const onDelete = jest.fn()
-    render(<ReminderItem item={mockItem} listType="strikethrough" onCheck={jest.fn()} onDelete={onDelete} onRename={jest.fn()} />)
-    fireEvent.click(screen.getByLabelText('삭제'))
-    fireEvent.click(screen.getByLabelText('취소'))
-    expect(onDelete).not.toHaveBeenCalled()
+  it('아이템 내부에서 삭제 확인 다이얼로그를 직접 렌더링하지 않는다', () => {
+    render(<ReminderItem item={mockItem} listType="strikethrough" onCheck={jest.fn()} onDelete={jest.fn()} onRename={jest.fn()} />)
     expect(screen.queryByText('아이템 삭제')).not.toBeInTheDocument()
   })
 

--- a/src/components/reminders/ReminderDetailView.tsx
+++ b/src/components/reminders/ReminderDetailView.tsx
@@ -77,6 +77,7 @@ export function ReminderDetailView({
   const [editingItemId, setEditingItemId] = useState<string | null>(null)
   const [inlineAddAfterItemId, setInlineAddAfterItemId] = useState<string | null>(null)
   const [showBottomAddInput, setShowBottomAddInput] = useState(false)
+  const [deleteConfirmItem, setDeleteConfirmItem] = useState<ReminderItemType | null>(null)
   const bottomAddInputRef = useRef<HTMLInputElement>(null)
   const inlineAddInputRef = useRef<HTMLInputElement>(null)
 
@@ -319,6 +320,7 @@ export function ReminderDetailView({
 
   const handleDelete = async (itemId: string) => {
     setMutationError(null)
+    setDeleteConfirmItem(null)
     const previousItems = items
     if (inlineAddAfterItemId === itemId) {
       setInlineAddAfterItemId(null)
@@ -454,6 +456,11 @@ export function ReminderDetailView({
 
   const showFloatingAddButton =
     editingItemId === null && inlineAddAfterItemId === null && !showBottomAddInput
+  const handleCancelDelete = () => setDeleteConfirmItem(null)
+  const handleConfirmDelete = () => {
+    if (!deleteConfirmItem) return
+    void handleDelete(deleteConfirmItem.id)
+  }
 
   return (
     <div
@@ -568,7 +575,7 @@ export function ReminderDetailView({
                       item={item}
                       listType={list?.type === 'delete' ? 'delete' : 'strikethrough'}
                       onCheck={handleCheck}
-                      onDelete={handleDelete}
+                      onDelete={() => setDeleteConfirmItem(item)}
                       onRename={handleRename}
                       isEditing={editingItemId === item.id}
                       onEditStart={handleEditStart}
@@ -613,7 +620,7 @@ export function ReminderDetailView({
                       item={item}
                       listType="strikethrough"
                       onCheck={handleCheck}
-                      onDelete={handleDelete}
+                      onDelete={() => setDeleteConfirmItem(item)}
                       onRename={handleRename}
                       isEditing={editingItemId === item.id}
                       onEditStart={handleEditStart}
@@ -645,6 +652,41 @@ export function ReminderDetailView({
             >
               <Plus size={18} />
             </button>
+          )}
+
+          {deleteConfirmItem && (
+            <div
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby="reminder-item-delete-title"
+              className="fixed inset-0 z-[60] flex items-end justify-center p-4 sm:items-center"
+            >
+              <div className="absolute inset-0 bg-black/40" onClick={handleCancelDelete} />
+              <div className="relative w-full rounded-2xl bg-stone-50 p-6 shadow-xl dark:bg-stone-900 sm:max-w-xs">
+                <p id="reminder-item-delete-title" className="mb-1 font-semibold text-stone-800 dark:text-stone-100">
+                  아이템 삭제
+                </p>
+                <p className="mb-6 text-sm text-stone-500 dark:text-stone-400">
+                  &ldquo;{deleteConfirmItem.name}&rdquo;을(를) 삭제할까요?
+                </p>
+                <div className="flex gap-3">
+                  <button
+                    onClick={handleCancelDelete}
+                    className="flex-1 rounded-xl bg-stone-100 py-2.5 text-sm font-semibold text-stone-700 transition-colors hover:bg-stone-200 dark:bg-stone-800 dark:text-stone-300 dark:hover:bg-stone-700"
+                    aria-label="취소"
+                  >
+                    취소
+                  </button>
+                  <button
+                    onClick={handleConfirmDelete}
+                    className="flex-1 rounded-xl bg-red-500 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-red-600"
+                    aria-label="삭제 확인"
+                  >
+                    삭제
+                  </button>
+                </div>
+              </div>
+            </div>
           )}
         </div>
       )}

--- a/src/components/reminders/ReminderItem.tsx
+++ b/src/components/reminders/ReminderItem.tsx
@@ -33,7 +33,6 @@ export function ReminderItem({
 }: Props) {
   const [internalEditing, setInternalEditing] = useState(false)
   const [editValue, setEditValue] = useState(item.name)
-  const [confirming, setConfirming] = useState(false)
   const committingRef = useRef(false)
   const wasEditingRef = useRef(false)
   const editing = isEditing ?? internalEditing
@@ -195,40 +194,12 @@ export function ReminderItem({
       )}
 
       <button
-        onClick={() => setConfirming(true)}
+        onClick={() => onDelete(item.id)}
         className="opacity-100 sm:opacity-0 sm:group-hover:opacity-100 p-1.5 rounded-lg text-stone-300 hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-950/40 transition-all"
         aria-label="삭제"
       >
         <Trash2 size={14} />
       </button>
-
-      {confirming && (
-        <div className="fixed inset-0 z-[60] flex items-end sm:items-center justify-center p-4">
-          <div className="absolute inset-0 bg-black/40" onClick={() => setConfirming(false)} />
-          <div className="relative bg-stone-50 dark:bg-stone-900 rounded-2xl w-full sm:max-w-xs p-6 shadow-xl">
-            <p className="font-semibold text-stone-800 dark:text-stone-100 mb-1">아이템 삭제</p>
-            <p className="text-sm text-stone-500 dark:text-stone-400 mb-6">
-              &ldquo;{item.name}&rdquo;을(를) 삭제할까요?
-            </p>
-            <div className="flex gap-3">
-              <button
-                onClick={() => setConfirming(false)}
-                className="flex-1 py-2.5 rounded-xl bg-stone-100 dark:bg-stone-800 text-stone-700 dark:text-stone-300 font-semibold text-sm transition-colors hover:bg-stone-200 dark:hover:bg-stone-700"
-                aria-label="취소"
-              >
-                취소
-              </button>
-              <button
-                onClick={() => { setConfirming(false); onDelete(item.id) }}
-                className="flex-1 py-2.5 rounded-xl bg-red-500 hover:bg-red-600 text-white font-semibold text-sm transition-colors"
-                aria-label="삭제 확인"
-              >
-                삭제
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- 리마인더 아이템 삭제 확인 다이얼로그를 개별 ReminderItem 내부에서 ReminderDetailView 최상위 레이어로 이동했습니다.
- 완료 아이템의 opacity/drag stacking context 안에 fixed 다이얼로그가 갇혀 투명하게 보이고 클릭이 어려워지던 문제를 방지했습니다.
- 아이템 삭제 확인 다이얼로그에 role=dialog, aria-modal, aria-labelledby를 추가해 목록 삭제 다이얼로그와 접근성 구조를 맞췄습니다.
- 완료 아이템 삭제 다이얼로그가 상세 화면 최상위 z-[60] 레이어로 렌더되는 회귀 테스트를 추가했습니다.

## Testing
- npm run test -- --testPathPatterns=src/__tests__/reminders/ReminderItem.test.tsx src/__tests__/reminders/ReminderDetailView.test.tsx
- npx tsc --noEmit

수동 확인 항목:
- [x] 리마인더 상세 화면에서 완료된 아이템의 휴지통을 눌렀을 때 삭제 확인 모달이 불투명하게 최상단에 표시되는지 확인합니다.
- [x] 삭제 확인 모달의 취소/배경 클릭이 정상적으로 모달을 닫는지 확인합니다.
- [x] 삭제 버튼을 눌렀을 때 해당 아이템이 실제로 삭제되고 플로팅 추가 버튼보다 모달이 위에 표시되는지 확인합니다.