### PR TITLE
perf: idle preload secondary tabs

### DIFF
--- a/src/__tests__/TabsShell.test.tsx
+++ b/src/__tests__/TabsShell.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { TabsShell } from '@/components/TabsShell'
 import { registerPushSubscription } from '@/lib/push'
@@ -86,6 +86,7 @@ describe('TabsShell', () => {
     mockFamilyError = null
     mockCalendarsError = null
     mockAuthUser = { id: 'user-1' }
+    jest.useRealTimers()
   })
 
   it('인증 로딩 중에는 AppSplash를 표시한다', () => {
@@ -120,13 +121,13 @@ describe('TabsShell', () => {
   it('?tab 파라미터가 없으면 캘린더 탭이 표시된다', () => {
     render(<TabsShell />)
     expect(screen.getByTestId('calendar-tab').parentElement).not.toHaveClass('hidden')
-    expect(screen.getByTestId('reminder-tab').parentElement).toHaveClass('hidden')
+    expect(screen.queryByTestId('reminder-tab')).not.toBeInTheDocument()
   })
 
-  it('?tab=reminders 파라미터가 있으면 리마인더 탭이 활성화된다', () => {
+  it('?tab=reminders 파라미터가 있으면 리마인더 탭이 활성화된다', async () => {
     mockTabParam = 'reminders'
     render(<TabsShell />)
-    expect(screen.getByTestId('reminder-tab').parentElement).not.toHaveClass('hidden')
+    expect((await screen.findByTestId('reminder-tab')).parentElement).not.toHaveClass('hidden')
     expect(screen.getByTestId('calendar-tab').parentElement).toHaveClass('hidden')
   })
 
@@ -134,7 +135,26 @@ describe('TabsShell', () => {
     mockTabParam = 'invalid'
     render(<TabsShell />)
     expect(screen.getByTestId('calendar-tab').parentElement).not.toHaveClass('hidden')
+    expect(screen.queryByTestId('reminder-tab')).not.toBeInTheDocument()
+  })
+
+  it('캘린더 진입 후 idle 시점에 리마인더와 설정 탭을 hidden 상태로 예열한다', async () => {
+    jest.useFakeTimers()
+
+    render(<TabsShell />)
+
+    expect(screen.getByTestId('calendar-tab').parentElement).not.toHaveClass('hidden')
+    expect(screen.queryByTestId('reminder-tab')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('settings-tab')).not.toBeInTheDocument()
+
+    await act(async () => {
+      jest.advanceTimersByTime(1200)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
     expect(screen.getByTestId('reminder-tab').parentElement).toHaveClass('hidden')
+    expect(screen.getByTestId('settings-tab').parentElement).toHaveClass('hidden')
   })
 
   it('초기 진입 시 자동으로 푸시 구독을 요청하지 않는다', () => {

--- a/src/components/TabsShell.tsx
+++ b/src/components/TabsShell.tsx
@@ -1,10 +1,9 @@
 'use client'
 
-import { useEffect } from 'react'
+import dynamic from 'next/dynamic'
+import { useEffect, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { CalendarTab } from '@/components/tabs/CalendarTab'
-import { ReminderTab } from '@/components/tabs/ReminderTab'
-import { SettingsTab } from '@/components/tabs/SettingsTab'
 import { BottomNav } from '@/components/BottomNav'
 import { useAuth } from '@/hooks/useAuth'
 import { useFamily } from '@/hooks/useFamily'
@@ -12,6 +11,46 @@ import { useCalendars } from '@/hooks/useCalendars'
 import { useUserPreferences } from '@/hooks/useUserPreferences'
 import { type Tab, TABS } from '@/types/tabs'
 import { AppSplash } from '@/components/AppSplash'
+
+const IDLE_PRELOAD_TABS: Tab[] = ['reminders', 'settings']
+
+type RequestIdleCallback = (callback: () => void, options?: { timeout?: number }) => number
+type CancelIdleCallback = (handle: number) => void
+
+const ReminderTab = dynamic(
+  () => import('@/components/tabs/ReminderTab').then((mod) => mod.ReminderTab),
+  { loading: () => <TabChunkFallback /> }
+)
+
+const SettingsTab = dynamic(
+  () => import('@/components/tabs/SettingsTab').then((mod) => mod.SettingsTab),
+  { loading: () => <TabChunkFallback /> }
+)
+
+function TabChunkFallback() {
+  return (
+    <div className="flex items-center justify-center min-h-[calc(100vh-5rem)]">
+      <div className="w-8 h-8 rounded-full border-2 border-accent-300 border-t-accent-500 animate-spin" />
+    </div>
+  )
+}
+
+function scheduleIdlePreload(callback: () => void) {
+  if (typeof window === 'undefined') return () => {}
+
+  const idleWindow = window as Window & {
+    requestIdleCallback?: RequestIdleCallback
+    cancelIdleCallback?: CancelIdleCallback
+  }
+
+  if (idleWindow.requestIdleCallback && idleWindow.cancelIdleCallback) {
+    const handle = idleWindow.requestIdleCallback(callback, { timeout: 2000 })
+    return () => idleWindow.cancelIdleCallback?.(handle)
+  }
+
+  const handle = window.setTimeout(callback, 1200)
+  return () => window.clearTimeout(handle)
+}
 
 export function TabsShell() {
   const searchParams = useSearchParams()
@@ -36,6 +75,7 @@ export function TabsShell() {
 
   const tabParam = searchParams.get('tab')
   const activeTab: Tab = tabParam && TABS.includes(tabParam as Tab) ? (tabParam as Tab) : 'calendar'
+  const [mountedTabs, setMountedTabs] = useState<Set<Tab>>(() => new Set(['calendar', activeTab]))
 
   useEffect(() => {
     if (!authLoading && !user) router.replace('/login')
@@ -52,6 +92,37 @@ export function TabsShell() {
       document.documentElement.setAttribute('data-theme', preferences.app_theme)
     }
   }, [preferences?.app_theme])
+
+  useEffect(() => {
+    let cancelled = false
+
+    queueMicrotask(() => {
+      if (cancelled) return
+      setMountedTabs((prev) => {
+        if (prev.has(activeTab)) return prev
+        const next = new Set(prev)
+        next.add(activeTab)
+        return next
+      })
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [activeTab])
+
+  useEffect(() => {
+    if (isInitializing || startupError || !user || needsFamilyOnboarding) return
+
+    return scheduleIdlePreload(() => {
+      setMountedTabs((prev) => {
+        if (IDLE_PRELOAD_TABS.every((tab) => prev.has(tab))) return prev
+        const next = new Set(prev)
+        IDLE_PRELOAD_TABS.forEach((tab) => next.add(tab))
+        return next
+      })
+    })
+  }, [isInitializing, needsFamilyOnboarding, startupError, user])
 
   const handleStartupRetry = async () => {
     await Promise.allSettled([reloadFamily(), reloadCalendars()])
@@ -120,25 +191,29 @@ export function TabsShell() {
             reloadCalendars={reloadCalendars}
           />
         </div>
-        <div className={`absolute inset-0 overflow-y-auto${activeTab !== 'reminders' ? ' hidden' : ''}`}>
-          <ReminderTab
-            key={familyId ?? 'no-family'}
-            user={user}
-            familyId={familyId}
-            isInitializing={isInitializing}
-          />
-        </div>
-        <div className={`absolute inset-0 overflow-y-auto${activeTab !== 'settings' ? ' hidden' : ''}`}>
-          <SettingsTab
-            onNavigateToTab={handleTabChange}
-            preferences={preferences}
-            updatePreferences={updatePreferences}
-            user={user}
-            familyId={familyId}
-            appRole={appRole}
-            isInitializing={isInitializing}
-          />
-        </div>
+        {mountedTabs.has('reminders') && (
+          <div className={`absolute inset-0 overflow-y-auto${activeTab !== 'reminders' ? ' hidden' : ''}`}>
+            <ReminderTab
+              key={familyId ?? 'no-family'}
+              user={user}
+              familyId={familyId}
+              isInitializing={isInitializing}
+            />
+          </div>
+        )}
+        {mountedTabs.has('settings') && (
+          <div className={`absolute inset-0 overflow-y-auto${activeTab !== 'settings' ? ' hidden' : ''}`}>
+            <SettingsTab
+              onNavigateToTab={handleTabChange}
+              preferences={preferences}
+              updatePreferences={updatePreferences}
+              user={user}
+              familyId={familyId}
+              appRole={appRole}
+              isInitializing={isInitializing}
+            />
+          </div>
+        )}
       </div>
       <BottomNav activeTab={activeTab} onTabChange={handleTabChange} />
     </div>

--- a/src/components/TabsShell.tsx
+++ b/src/components/TabsShell.tsx
@@ -96,6 +96,7 @@ export function TabsShell() {
   useEffect(() => {
     let cancelled = false
 
+    // Mount URL-selected tabs on the next tick to avoid cascading effect updates.
     queueMicrotask(() => {
       if (cancelled) return
       setMountedTabs((prev) => {
@@ -114,6 +115,7 @@ export function TabsShell() {
   useEffect(() => {
     if (isInitializing || startupError || !user || needsFamilyOnboarding) return
 
+    // Let the calendar paint first, then hidden-mount secondary tabs to warm their data.
     return scheduleIdlePreload(() => {
       setMountedTabs((prev) => {
         if (IDLE_PRELOAD_TABS.every((tab) => prev.has(tab))) return prev


### PR DESCRIPTION
## Summary
- 초기 캘린더 셸 경로에서 리마인더/설정 탭 청크를 분리해 동적 로드하도록 변경했습니다.
- 앱 시작 시 캘린더 탭을 먼저 렌더링하고, 초기화가 끝난 뒤 idle 시점에 리마인더/설정 탭을 hidden 상태로 마운트해 백그라운드에서 데이터를 예열하도록 했습니다.
- 단계적 탭 마운트 동작에 맞춰 TabsShell 테스트를 업데이트했습니다.

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm run test -- --testPathPatterns=src/__tests__/TabsShell.test.tsx --runInBand`
- `npm run test -- --runInBand`
- `npm run build`: 컴파일과 TypeScript 단계는 완료됐고, 이후 page data collection 단계에서 로컬 Supabase 서버 환경변수 누락으로 `supabaseUrl is required`가 발생했습니다.