### PR TITLE
perf: preload calendar overlays and members

### DIFF
--- a/src/__tests__/components/CalendarTab.picker.integration.test.tsx
+++ b/src/__tests__/components/CalendarTab.picker.integration.test.tsx
@@ -3,7 +3,7 @@
  * YearMonthPickerSheet를 실제 컴포넌트로 렌더해서
  * "헤더 클릭 → 실제 dialog 렌더 → Escape → dialog 사라짐" 흐름을 검증한다.
  */
-import { render, act, fireEvent, screen } from '@testing-library/react'
+import { render, act, fireEvent, screen, waitFor } from '@testing-library/react'
 import type { User } from '@supabase/supabase-js'
 import { CalendarTab } from '@/components/tabs/CalendarTab'
 
@@ -83,7 +83,7 @@ describe('CalendarTab + YearMonthPickerSheet 통합', () => {
     const today = new Date()
     fireEvent.click(screen.getByRole('button', { name: new RegExp(`${today.getFullYear()}년`) }))
 
-    expect(screen.getByRole('dialog', { name: '연월 선택' })).toBeInTheDocument()
+    expect(await screen.findByRole('dialog', { name: '연월 선택' })).toBeInTheDocument()
   })
 
   it('dialog가 열린 상태에서 Escape 키 입력 시 dialog가 닫힌다', async () => {
@@ -92,11 +92,13 @@ describe('CalendarTab + YearMonthPickerSheet 통합', () => {
 
     const today = new Date()
     fireEvent.click(screen.getByRole('button', { name: new RegExp(`${today.getFullYear()}년`) }))
-    expect(screen.getByRole('dialog', { name: '연월 선택' })).toBeInTheDocument()
+    expect(await screen.findByRole('dialog', { name: '연월 선택' })).toBeInTheDocument()
 
     fireEvent.keyDown(document, { key: 'Escape' })
 
-    expect(screen.queryByRole('dialog', { name: '연월 선택' })).not.toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: '연월 선택' })).not.toBeInTheDocument()
+    })
   })
 
   it('dialog 내 취소 버튼 클릭 시 dialog가 닫힌다', async () => {

--- a/src/__tests__/components/CalendarTab.test.tsx
+++ b/src/__tests__/components/CalendarTab.test.tsx
@@ -186,13 +186,15 @@ jest.mock('@/components/calendar/CalendarFormModal', () => ({
 }))
 jest.mock('@/components/calendar/CalendarListSheet', () => ({
   CalendarListSheet: ({
+    familyMembers,
     onSave,
     onDelete,
   }: {
+    familyMembers: { user_id: string }[]
     onSave: (calendarId: string, name: string, color: string, memberIds: string[] | null) => Promise<{ status: string }>
     onDelete: (calendarId: string) => Promise<void>
   }) => (
-    <div data-testid="calendar-list-sheet">
+    <div data-testid="calendar-list-sheet" data-member-count={familyMembers.length}>
       <button data-testid="list-save-null-members" onClick={() => onSave('cal-1', '가족', '#f97316', null)} />
       <button data-testid="list-save-with-members" onClick={() => onSave('cal-1', '가족', '#f97316', ['user-2'])} />
       <button data-testid="list-delete" onClick={() => onDelete('cal-1')} />
@@ -268,6 +270,10 @@ describe('CalendarTab — touch-action 스크롤 차단', () => {
 
   afterAll(() => {
     consoleErrorSpy.mockRestore()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
   })
 
   beforeEach(() => {
@@ -394,6 +400,107 @@ describe('CalendarTab — touch-action 스크롤 차단', () => {
     expect(screen.queryByText('이번 달 등록된 일정이 없어요.')).not.toBeInTheDocument()
   })
 
+  it('초기 렌더에서는 가족 멤버를 즉시 불러오지 않는다', async () => {
+    render(<CalendarTab {...defaultProps} />)
+    await act(async () => {})
+
+    expect(mockGetFamilyMembers).not.toHaveBeenCalled()
+  })
+
+  it('캘린더 리스트를 열 때 가족 멤버를 준비한 뒤 시트를 표시한다', async () => {
+    mockGetFamilyMembers.mockResolvedValueOnce([
+      {
+        user_id: 'user-2',
+        display_name: '보호자',
+      } as Awaited<ReturnType<typeof getFamilyMembers>>[number],
+    ])
+
+    render(<CalendarTab {...defaultProps} />)
+    await act(async () => {})
+
+    fireEvent.click(screen.getByRole('button', { name: '캘린더 리스트' }))
+
+    const sheet = await screen.findByTestId('calendar-list-sheet')
+    expect(sheet).toHaveAttribute('data-member-count', '1')
+    expect(mockGetFamilyMembers).toHaveBeenCalledTimes(1)
+  })
+
+  it('가족 멤버 로드 실패 시 캘린더 리스트를 열지 않고 에러 배너를 표시한다', async () => {
+    mockGetFamilyMembers.mockRejectedValueOnce(new Error('family members failed'))
+
+    render(<CalendarTab {...defaultProps} />)
+    await act(async () => {})
+
+    fireEvent.click(screen.getByRole('button', { name: '캘린더 리스트' }))
+
+    expect(await screen.findByText('가족 멤버를 불러오지 못했어요')).toBeInTheDocument()
+    expect(screen.queryByTestId('calendar-list-sheet')).not.toBeInTheDocument()
+  })
+
+  it('가족 멤버 로드 중 가족이 바뀌면 이전 요청 완료로 캘린더 리스트를 열지 않는다', async () => {
+    let resolveMembers: ((members: Awaited<ReturnType<typeof getFamilyMembers>>) => void) | null = null
+    const membersPromise = new Promise<Awaited<ReturnType<typeof getFamilyMembers>>>((resolve) => {
+      resolveMembers = resolve
+    })
+    mockGetFamilyMembers.mockReturnValueOnce(membersPromise)
+
+    const { rerender } = render(<CalendarTab {...defaultProps} />)
+    await act(async () => {})
+
+    fireEvent.click(screen.getByRole('button', { name: '캘린더 리스트' }))
+
+    rerender(<CalendarTab {...defaultProps} familyId="fam-2" calendars={[{
+      id: 'cal-2',
+      family_id: 'fam-2',
+      created_by: 'user-1',
+      name: '다른 가족',
+      color: '#3b82f6',
+      created_at: '',
+      updated_at: '',
+    }]} />)
+    await act(async () => {})
+
+    await act(async () => {
+      resolveMembers?.([
+        {
+          user_id: 'user-2',
+          display_name: '이전 가족',
+        } as Awaited<ReturnType<typeof getFamilyMembers>>[number],
+      ])
+      await membersPromise
+    })
+
+    expect(screen.queryByTestId('calendar-list-sheet')).not.toBeInTheDocument()
+    expect(screen.queryByText('가족 멤버를 불러오지 못했어요')).not.toBeInTheDocument()
+  })
+
+  it('silent preload 실패를 사용자 열기가 재사용해도 에러 배너를 표시하고 리스트를 닫는다', async () => {
+    jest.useFakeTimers()
+    let rejectMembers: ((error: Error) => void) | null = null
+    const membersPromise = new Promise<Awaited<ReturnType<typeof getFamilyMembers>>>((_, reject) => {
+      rejectMembers = reject
+    })
+    mockGetFamilyMembers.mockReturnValueOnce(membersPromise)
+
+    render(<CalendarTab {...defaultProps} />)
+    await act(async () => {})
+
+    act(() => {
+      jest.advanceTimersByTime(700)
+    })
+    expect(mockGetFamilyMembers).toHaveBeenCalledTimes(1)
+
+    fireEvent.click(screen.getByRole('button', { name: '캘린더 리스트' }))
+
+    await act(async () => {
+      rejectMembers?.(new Error('preload failed'))
+      await membersPromise.catch(() => {})
+    })
+
+    expect(await screen.findByText('가족 멤버를 불러오지 못했어요')).toBeInTheDocument()
+    expect(screen.queryByTestId('calendar-list-sheet')).not.toBeInTheDocument()
+  })
+
   it('재시도 버튼 클릭 시 캘린더 데이터를 다시 불러온다', async () => {
     mockGetEventsByMonth
       .mockRejectedValueOnce(new Error('load failed'))
@@ -427,7 +534,7 @@ describe('CalendarTab — touch-action 스크롤 차단', () => {
     const headerButton = screen.getByRole('button', { name: new RegExp(`${today.getFullYear()}년`) })
     fireEvent.click(headerButton)
 
-    expect(screen.getByTestId('year-month-picker')).toBeInTheDocument()
+    expect(await screen.findByTestId('year-month-picker')).toBeInTheDocument()
   })
 
   it('피커 취소 시 연월이 변경되지 않고 피커가 닫힌다', async () => {
@@ -436,9 +543,9 @@ describe('CalendarTab — touch-action 스크롤 차단', () => {
     await act(async () => {})
 
     fireEvent.click(screen.getByRole('button', { name: new RegExp(`${today.getFullYear()}년`) }))
-    expect(screen.getByTestId('year-month-picker')).toBeInTheDocument()
+    expect(await screen.findByTestId('year-month-picker')).toBeInTheDocument()
 
-    fireEvent.click(screen.getByTestId('picker-cancel'))
+    fireEvent.click(await screen.findByTestId('picker-cancel'))
 
     expect(screen.queryByTestId('year-month-picker')).not.toBeInTheDocument()
     expect(screen.getByText(`${today.getFullYear()}년 ${today.getMonth() + 1}월`)).toBeInTheDocument()
@@ -450,7 +557,7 @@ describe('CalendarTab — touch-action 스크롤 차단', () => {
     await act(async () => {})
 
     fireEvent.click(screen.getByRole('button', { name: new RegExp(`${today.getFullYear()}년`) }))
-    fireEvent.click(screen.getByTestId('picker-confirm'))
+    fireEvent.click(await screen.findByTestId('picker-confirm'))
 
     await waitFor(() => {
       expect(screen.queryByTestId('year-month-picker')).not.toBeInTheDocument()
@@ -508,8 +615,8 @@ describe('CalendarTab — touch-action 스크롤 차단', () => {
     await act(async () => {})
 
     fireEvent.click(screen.getByTestId('select-date'))
-    fireEvent.click(screen.getByTestId('select-recurring-event'))
-    fireEvent.click(screen.getByTestId('detail-delete'))
+    fireEvent.click(await screen.findByTestId('select-recurring-event'))
+    fireEvent.click(await screen.findByTestId('detail-delete'))
     fireEvent.click(await screen.findByTestId('scope-all'))
 
     await waitFor(() => {
@@ -524,8 +631,8 @@ describe('CalendarTab — touch-action 스크롤 차단', () => {
     await act(async () => {})
 
     fireEvent.click(screen.getByTestId('select-date'))
-    fireEvent.click(screen.getByTestId('select-recurring-event'))
-    fireEvent.click(screen.getByTestId('detail-edit'))
+    fireEvent.click(await screen.findByTestId('select-recurring-event'))
+    fireEvent.click(await screen.findByTestId('detail-edit'))
     fireEvent.click(await screen.findByTestId('scope-following'))
     fireEvent.click(await screen.findByTestId('event-form-save-following-date'))
 
@@ -549,8 +656,8 @@ describe('CalendarTab — touch-action 스크롤 차단', () => {
     await act(async () => {})
 
     fireEvent.click(screen.getByTestId('select-date'))
-    fireEvent.click(screen.getByTestId('select-recurring-event'))
-    fireEvent.click(screen.getByTestId('detail-edit'))
+    fireEvent.click(await screen.findByTestId('select-recurring-event'))
+    fireEvent.click(await screen.findByTestId('detail-edit'))
     fireEvent.click(await screen.findByTestId('scope-following'))
 
     const saveButton = await screen.findByTestId('event-form-save-following-recurrence')

--- a/src/components/tabs/CalendarTab.tsx
+++ b/src/components/tabs/CalendarTab.tsx
@@ -1,9 +1,9 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import dynamic from 'next/dynamic'
 import { useSwipe } from '@/hooks/useSwipe'
 import { ChevronDown, ChevronLeft, ChevronRight, Plus } from 'lucide-react'
-import { useAsyncData } from '@/hooks/useAsyncData'
 import { useHolidays } from '@/hooks/useHolidays'
 import type { UserPreferences } from '@/lib/preferences'
 import type { AuthState } from '@/types/tabs'
@@ -23,13 +23,6 @@ import {
 } from '@/lib/calendar'
 import { CalendarFilter } from '@/components/calendar/CalendarFilter'
 import { CalendarGrid } from '@/components/calendar/CalendarGrid'
-import { CalendarListSheet } from '@/components/calendar/CalendarListSheet'
-import { DayEventsSheet } from '@/components/calendar/DayEventsSheet'
-import { EventDetailSheet } from '@/components/calendar/EventDetailSheet'
-import { EventFormModal } from '@/components/calendar/EventFormModal'
-import { CalendarFormModal } from '@/components/calendar/CalendarFormModal'
-import { YearMonthPickerSheet } from '@/components/calendar/YearMonthPickerSheet'
-import { RecurrenceScopeSheet } from '@/components/calendar/RecurrenceScopeSheet'
 import type { RecurrenceRule, RecurrenceScope } from '@/types/recurrence'
 import { useRealtimeSync } from '@/hooks/useRealtimeSync'
 import { postJsonWithAuth, patchJsonWithAuth, deleteWithAuth } from '@/lib/api-client'
@@ -44,6 +37,79 @@ interface Props extends AuthState {
 }
 
 const MAX_MONTH_EVENT_CACHE = 12
+
+type FamilyMembersStatus = 'idle' | 'loading' | 'ready' | 'error'
+
+interface FamilyMembersState {
+  familyId: string | null
+  members: FamilyMember[]
+  status: FamilyMembersStatus
+}
+
+// Keep dynamic render loaders and idle preload loaders identical so first-open chunks are actually warmed.
+const loadCalendarListSheet = () =>
+  import('@/components/calendar/CalendarListSheet').then((mod) => mod.CalendarListSheet)
+const loadDayEventsSheet = () =>
+  import('@/components/calendar/DayEventsSheet').then((mod) => mod.DayEventsSheet)
+const loadEventDetailSheet = () =>
+  import('@/components/calendar/EventDetailSheet').then((mod) => mod.EventDetailSheet)
+const loadEventFormModal = () =>
+  import('@/components/calendar/EventFormModal').then((mod) => mod.EventFormModal)
+const loadCalendarFormModal = () =>
+  import('@/components/calendar/CalendarFormModal').then((mod) => mod.CalendarFormModal)
+const loadYearMonthPickerSheet = () =>
+  import('@/components/calendar/YearMonthPickerSheet').then((mod) => mod.YearMonthPickerSheet)
+const loadRecurrenceScopeSheet = () =>
+  import('@/components/calendar/RecurrenceScopeSheet').then((mod) => mod.RecurrenceScopeSheet)
+
+function CalendarOverlayFallback() {
+  return (
+    <div
+      className="fixed inset-0 z-[70] flex items-center justify-center bg-black/20 backdrop-blur-[1px]"
+      role="status"
+      aria-live="polite"
+    >
+      <div className="h-8 w-8 rounded-full border-2 border-white/80 border-t-accent-400 animate-spin" />
+      <span className="sr-only">화면을 준비 중이에요</span>
+    </div>
+  )
+}
+
+const CalendarListSheet = dynamic(loadCalendarListSheet, { loading: CalendarOverlayFallback })
+const DayEventsSheet = dynamic(loadDayEventsSheet, { loading: CalendarOverlayFallback })
+const EventDetailSheet = dynamic(loadEventDetailSheet, { loading: CalendarOverlayFallback })
+const EventFormModal = dynamic(loadEventFormModal, { loading: CalendarOverlayFallback })
+const CalendarFormModal = dynamic(loadCalendarFormModal, { loading: CalendarOverlayFallback })
+const YearMonthPickerSheet = dynamic(loadYearMonthPickerSheet, { loading: CalendarOverlayFallback })
+const RecurrenceScopeSheet = dynamic(loadRecurrenceScopeSheet, { loading: CalendarOverlayFallback })
+
+const calendarOverlayLoaders = [
+  loadCalendarListSheet,
+  loadDayEventsSheet,
+  loadEventDetailSheet,
+  loadEventFormModal,
+  loadCalendarFormModal,
+  loadYearMonthPickerSheet,
+  loadRecurrenceScopeSheet,
+]
+
+type WindowWithIdleCallback = Window & typeof globalThis & {
+  requestIdleCallback?: (callback: () => void, options?: { timeout: number }) => number
+  cancelIdleCallback?: (handle: number) => void
+}
+
+function scheduleIdleWork(callback: () => void) {
+  if (typeof window === 'undefined') return () => {}
+
+  const idleWindow = window as WindowWithIdleCallback
+  if (idleWindow.requestIdleCallback) {
+    const handle = idleWindow.requestIdleCallback(callback, { timeout: 2500 })
+    return () => idleWindow.cancelIdleCallback?.(handle)
+  }
+
+  const timeoutId = window.setTimeout(callback, 700)
+  return () => window.clearTimeout(timeoutId)
+}
 
 function getMonthEventsKey(familyId: string, year: number, month: number) {
   return `${familyId}:${year}:${month}`
@@ -122,19 +188,24 @@ export function CalendarTab({
 
   const [slideKey, setSlideKey] = useState(0)
   const [slideDir, setSlideDir] = useState<'left' | 'right' | null>(null)
+  const [preparingCalendarForm, setPreparingCalendarForm] = useState(false)
 
-  const isModalOpen = selectedDate !== null || selectedEvent !== null || editingEvent !== null || calendarForm !== null || showYearMonthPicker
+  const isModalOpen = selectedDate !== null ||
+    selectedEvent !== null ||
+    editingEvent !== null ||
+    calendarForm !== null ||
+    preparingCalendarForm ||
+    showYearMonthPicker ||
+    showCalendarList ||
+    seriesScopeTarget !== null
 
-  const {
-    value: familyMembers,
-    reload: reloadFamilyMembers,
-  } = useAsyncData<FamilyMember[]>({
-    enabled: Boolean(familyId),
-    initialValue: [],
-    reloadKey: familyId,
-    load: () => getFamilyMembers(familyId!),
-    onError: (e) => console.error('[CalendarTab] getFamilyMembers failed:', e),
-  })
+  const familyMembersCacheRef = useRef(new Map<string, FamilyMember[]>())
+  const familyMembersRequestsRef = useRef(new Map<string, Promise<FamilyMember[]>>())
+  const [familyMembersState, setFamilyMembersState] = useState<FamilyMembersState>(() => ({
+    familyId: familyId ?? null,
+    members: [],
+    status: familyId ? 'idle' : 'ready',
+  }))
 
   const [events, setEvents] = useState<CalendarEvent[]>([])
   const [adjacentMonthEvents, setAdjacentMonthEvents] = useState<CalendarEvent[]>([])
@@ -142,8 +213,130 @@ export function CalendarTab({
   const [eventsError, setEventsError] = useState<unknown>(null)
   const monthEventsCacheRef = useRef(new Map<string, CalendarEvent[]>())
   const monthEventsRequestsRef = useRef(new Map<string, Promise<CalendarEvent[]>>())
+  const currentFamilyIdRef = useRef<string | null>(familyId ?? null)
+  const calendarOpenRequestSeqRef = useRef(0)
   const previousFamilyIdRef = useRef<string | null>(familyId ?? null)
   const visibleMonthKeyRef = useRef<string | null>(familyId ? getMonthEventsKey(familyId, year, month) : null)
+  currentFamilyIdRef.current = familyId ?? null
+
+  useEffect(() => {
+    const nextFamilyId = familyId ?? null
+    currentFamilyIdRef.current = nextFamilyId
+    calendarOpenRequestSeqRef.current += 1
+    setShowCalendarList(false)
+    setCalendarForm(null)
+    setCalendarMemberIds([])
+    setPreparingCalendarForm(false)
+
+    if (!nextFamilyId) {
+      setFamilyMembersState({
+        familyId: null,
+        members: [],
+        status: 'ready',
+      })
+      return
+    }
+
+    const cachedMembers = familyMembersCacheRef.current.get(nextFamilyId)
+    setFamilyMembersState({
+      familyId: nextFamilyId,
+      members: cachedMembers ?? [],
+      status: cachedMembers ? 'ready' : 'idle',
+    })
+  }, [familyId])
+
+  const isCurrentCalendarOpenRequest = useCallback((requestFamilyId: string, requestSeq: number) => (
+    currentFamilyIdRef.current === requestFamilyId &&
+    calendarOpenRequestSeqRef.current === requestSeq
+  ), [])
+
+  const loadFamilyMembers = useCallback(async ({
+    force = false,
+    silent = false,
+  }: {
+    force?: boolean
+    // silent is only for background preload/refresh paths; user-initiated opens must surface failures.
+    silent?: boolean
+  } = {}) => {
+    if (!familyId) return []
+
+    const targetFamilyId = familyId
+    const inFlight = familyMembersRequestsRef.current.get(targetFamilyId)
+    if (inFlight) {
+      if (!silent) {
+        setFamilyMembersState((prev) => (
+          prev.familyId === targetFamilyId
+            ? { ...prev, status: 'loading' }
+            : prev
+        ))
+      }
+      try {
+        return await inFlight
+      } catch (error) {
+        if (!silent) {
+          setFamilyMembersState((prev) => (
+            prev.familyId === targetFamilyId
+              ? { ...prev, status: 'error' }
+              : prev
+          ))
+        }
+        throw error
+      }
+    }
+
+    if (!force) {
+      const cachedMembers = familyMembersCacheRef.current.get(targetFamilyId)
+      if (cachedMembers) {
+        setFamilyMembersState({
+          familyId: targetFamilyId,
+          members: cachedMembers,
+          status: 'ready',
+        })
+        return cachedMembers
+      }
+    }
+
+    if (!silent) {
+      setFamilyMembersState((prev) => (
+        prev.familyId === targetFamilyId
+          ? { ...prev, status: 'loading' }
+          : { familyId: targetFamilyId, members: [], status: 'loading' }
+      ))
+    }
+
+    const request = getFamilyMembers(targetFamilyId)
+      .then((members) => {
+        familyMembersRequestsRef.current.delete(targetFamilyId)
+        familyMembersCacheRef.current.set(targetFamilyId, members)
+        setFamilyMembersState((prev) => (
+          prev.familyId === targetFamilyId
+            ? { familyId: targetFamilyId, members, status: 'ready' }
+            : prev
+        ))
+        return members
+      })
+      .catch((error) => {
+        familyMembersRequestsRef.current.delete(targetFamilyId)
+        console.error('[CalendarTab] getFamilyMembers failed:', error)
+        if (!silent) {
+          setFamilyMembersState((prev) => (
+            prev.familyId === targetFamilyId
+              ? { ...prev, status: 'error' }
+              : prev
+          ))
+        }
+        throw error
+      })
+
+    familyMembersRequestsRef.current.set(targetFamilyId, request)
+    return request
+  }, [familyId])
+
+  const familyMembers = familyMembersState.familyId === familyId
+    ? familyMembersState.members
+    : []
+  const familyMembersReady = !familyId ||
+    (familyMembersState.familyId === familyId && familyMembersState.status === 'ready')
 
   const storeMonthEvents = useCallback((key: string, nextEvents: CalendarEvent[]) => {
     const cache = monthEventsCacheRef.current
@@ -344,6 +537,15 @@ export function CalendarTab({
     })
   }, [familyId, year, month, loadMonthEvents])
 
+  useEffect(() => {
+    if (!familyId) return
+
+    return scheduleIdleWork(() => {
+      void Promise.allSettled(calendarOverlayLoaders.map((loadOverlay) => loadOverlay()))
+      void loadFamilyMembers({ silent: true }).catch(() => {})
+    })
+  }, [familyId, loadFamilyMembers])
+
   const mergedEvents = useMemo(() => {
     if (adjacentMonthEvents.length === 0) return events
     const seen = new Set(events.map((e) => e.id))
@@ -385,8 +587,11 @@ export function CalendarTab({
   }, [familyId, year, month, loadMonthEvents])
 
   const reloadCalendarContext = useCallback(async () => {
-    await Promise.allSettled([reloadCalendars(), reloadFamilyMembers()])
-  }, [reloadCalendars, reloadFamilyMembers])
+    await Promise.allSettled([
+      reloadCalendars(),
+      loadFamilyMembers({ force: true, silent: true }),
+    ])
+  }, [reloadCalendars, loadFamilyMembers])
 
   const channelName = familyId ? `family_events_${familyId}` : null
   const broadcast = useRealtimeSync(channelName, refreshEvents)
@@ -441,22 +646,55 @@ export function CalendarTab({
     })
   }
 
-  const openCalendarForm = async (calendar?: Calendar) => {
+  const openCalendarList = async () => {
+    if (!familyId) return
+    const requestFamilyId = familyId
+    const requestSeq = ++calendarOpenRequestSeqRef.current
     setMutationError(null)
+    setShowCalendarList(true)
 
-    if (calendar) {
-      try {
-        const members = await getCalendarMembers(calendar.id)
-        setCalendarMemberIds(members.map((m) => m.user_id))
-      } catch (e) {
-        console.error('[CalendarTab] getCalendarMembers failed:', e)
+    try {
+      await loadFamilyMembers()
+    } catch {
+      if (!isCurrentCalendarOpenRequest(requestFamilyId, requestSeq)) return
+      setShowCalendarList(false)
+      setMutationError('가족 멤버를 불러오지 못했어요')
+    }
+  }
+
+  const openCalendarForm = async (calendar?: Calendar) => {
+    if (!familyId) return
+    const requestFamilyId = familyId
+    const requestSeq = ++calendarOpenRequestSeqRef.current
+    setMutationError(null)
+    setPreparingCalendarForm(true)
+
+    try {
+      const [familyMembersResult, calendarMembersResult] = await Promise.allSettled([
+        loadFamilyMembers(),
+        calendar ? getCalendarMembers(calendar.id) : Promise.resolve([]),
+      ])
+
+      if (!isCurrentCalendarOpenRequest(requestFamilyId, requestSeq)) return
+
+      if (familyMembersResult.status === 'rejected') {
+        setMutationError('가족 멤버를 불러오지 못했어요')
+        return
+      }
+
+      if (calendarMembersResult.status === 'rejected') {
+        console.error('[CalendarTab] getCalendarMembers failed:', calendarMembersResult.reason)
         setMutationError('캘린더 멤버를 불러오지 못했어요')
         return
       }
-    } else {
-      setCalendarMemberIds([])
+
+      setCalendarMemberIds(calendarMembersResult.value.map((m) => m.user_id))
+      setCalendarForm(calendar ? { calendar } : {})
+    } finally {
+      if (isCurrentCalendarOpenRequest(requestFamilyId, requestSeq)) {
+        setPreparingCalendarForm(false)
+      }
     }
-    setCalendarForm(calendar ? { calendar } : {})
   }
 
   const handleCalendarSave = async (name: string, color: string, memberUserIds: string[]) => {
@@ -713,7 +951,11 @@ export function CalendarTab({
   const fetchError = calendarsError
 
   const handleRetry = async () => {
-    await Promise.all([reloadCalendars(), reloadFamilyMembers(), reloadEvents()])
+    await Promise.allSettled([
+      reloadCalendars(),
+      loadFamilyMembers({ force: true, silent: true }),
+      reloadEvents(),
+    ])
   }
 
   if (fetchError) {
@@ -793,7 +1035,7 @@ export function CalendarTab({
             />
           </div>
           <button
-            onClick={() => setShowCalendarList(true)}
+            onClick={() => void openCalendarList()}
             className="shrink-0 p-1.5 text-stone-400 hover:text-stone-600 dark:hover:text-stone-300"
             aria-label="캘린더 리스트"
           >
@@ -907,7 +1149,11 @@ export function CalendarTab({
         />
       )}
 
-      {showCalendarList && user && (
+      {(showCalendarList && user && !familyMembersReady) || preparingCalendarForm ? (
+        <CalendarOverlayFallback />
+      ) : null}
+
+      {showCalendarList && user && familyMembersReady && (
         <CalendarListSheet
           calendars={calendars}
           familyMembers={familyMembers}
@@ -919,7 +1165,7 @@ export function CalendarTab({
         />
       )}
 
-      {calendarForm !== null && user && (
+      {calendarForm !== null && user && familyMembersReady && (
         <CalendarFormModal
           initial={calendarForm.calendar}
           initialMemberIds={calendarForm.calendar ? calendarMemberIds : undefined}


### PR DESCRIPTION
## Summary
- 캘린더 모달/시트 컴포넌트를 초기 번들에서 분리하고, 캘린더 화면이 뜬 뒤 idle 시간에 같은 loader로 백그라운드 preload합니다.
- 가족 멤버 조회를 첫 렌더 즉시 실행하지 않고, familyId별 캐시와 in-flight 요청 공유를 통해 캘린더 관리/편집 접근 전 또는 idle 시간에 준비합니다.
- 가족 전환 시 이전 가족 멤버가 섞이지 않도록 상태에 familyId를 함께 보관하고, 데이터나 코드 청크가 아직 준비되지 않은 첫 접근에는 공통 로딩 오버레이를 표시합니다.
- 가족 멤버 로드 실패 시 캘린더 리스트/편집 화면을 빈 멤버 상태로 열지 않고 기존 에러 배너로 안내하도록 방어했습니다.
- 동적 import 타이밍에 맞춰 CalendarTab 테스트를 조정하고, 초기 렌더에서 가족 멤버를 즉시 불러오지 않는 동작과 캘린더 리스트 접근 시 멤버 준비 후 표시되는 동작을 추가로 검증했습니다.

## 사용자 관점 변화
- 앱 첫 진입 시 캘린더 그리드와 일정 로딩을 먼저 처리하고, 캘린더 리스트/일정 상세/일정 작성/연월 선택/반복 범위/캘린더 편집 화면 코드는 뒤에서 미리 받아둡니다.
- idle preload가 끝난 일반적인 상황에서는 캘린더 리스트나 편집 화면을 눌렀을 때 기존처럼 바로 열립니다.
- idle preload가 끝나기 전에 빠르게 접근하면 짧은 로딩 오버레이가 먼저 보이고, 준비가 끝난 뒤 해당 화면이 열립니다.
- 가족 멤버 데이터가 필요한 캘린더 리스트/캘린더 생성/편집은 멤버 데이터가 준비된 뒤 열리므로, 공유 멤버가 비어 보이거나 잘못 저장되는 상황을 피합니다.
- 백그라운드 preload 실패만으로는 첫 화면에 에러가 뜨지 않습니다. 사용자가 해당 기능을 실제로 열 때도 실패하면 캘린더 상단 에러 배너로 안내됩니다.

## 리스크와 방어책
- 첫 접근 지연: idle preload 전에 기능을 누르면 로딩이 보일 수 있어 공통 로딩 오버레이를 추가했습니다.
- preload 경로 불일치: dynamic import와 idle preload가 같은 loader 함수를 공유하도록 해, preload한 청크와 실제 렌더 청크가 어긋나지 않게 했습니다.
- 중복 네트워크 요청: 가족 멤버 조회는 familyId별 in-flight 요청을 공유해 빠른 연속 접근에도 같은 요청을 재사용합니다.
- stale family data: familyId를 상태와 캐시에 함께 묶고, 현재 familyId와 맞는 멤버만 화면에 넘기도록 했습니다.
- 멤버 미준비 저장: 캘린더 리스트/폼은 가족 멤버가 ready 상태일 때만 렌더링되어 빈 멤버 목록으로 저장 화면이 열리지 않게 했습니다.
- 백그라운드 실패 역체감: idle preload 실패는 조용히 무시하고, 사용자가 실제로 기능을 열 때만 명시적인 오류를 보여줍니다.

## Testing
- `npx tsc --noEmit`
- `npm run lint`
- `npm run test -- --runInBand`
- `npm run build`는 권한 상승 후 실행했으며 컴파일과 TypeScript 단계는 통과했습니다. 이후 로컬 Supabase 설정 부재로 page data 수집에서 `supabaseUrl is required`가 발생해 실패했습니다.
