### PR TITLE
feat: clear reminder items

### DIFF
--- a/src/__tests__/lib/reminder-lists.test.ts
+++ b/src/__tests__/lib/reminder-lists.test.ts
@@ -14,6 +14,7 @@ import {
   addReminderItem,
   checkReminderItem,
   deleteReminderItem,
+  clearReminderItems,
   renameReminderList,
   updateReminderListGroup,
   renameReminderItem,
@@ -431,6 +432,24 @@ describe('deleteReminderItem', () => {
   it('error가 있으면 throw한다', async () => {
     mockFrom.mockReturnValue(makeChain({ data: null, error: { message: 'delete error' } }))
     await expect(deleteReminderItem('item-1')).rejects.toEqual({ message: 'delete error' })
+  })
+})
+
+describe('clearReminderItems', () => {
+  it('list_id 기준으로 아이템을 모두 삭제한다', async () => {
+    const chain = makeChain({ data: null, error: null })
+    mockFrom.mockReturnValue(chain)
+
+    await expect(clearReminderItems('list-1')).resolves.toBeUndefined()
+
+    expect(mockFrom).toHaveBeenCalledWith('shopping_items')
+    expect(chain.delete).toHaveBeenCalled()
+    expect(chain.eq).toHaveBeenCalledWith('list_id', 'list-1')
+  })
+
+  it('error가 있으면 throw한다', async () => {
+    mockFrom.mockReturnValue(makeChain({ data: null, error: { message: 'clear error' } }))
+    await expect(clearReminderItems('list-1')).rejects.toEqual({ message: 'clear error' })
   })
 })
 

--- a/src/__tests__/reminders/ReminderDetailView.test.tsx
+++ b/src/__tests__/reminders/ReminderDetailView.test.tsx
@@ -6,6 +6,7 @@ import {
   addReminderItem,
   checkReminderItem,
   deleteReminderItem,
+  clearReminderItems,
   getReminderItems,
   getReminderList,
   renameReminderItem,
@@ -31,6 +32,7 @@ jest.mock('@/lib/reminder-lists', () => ({
   addReminderItem: jest.fn(),
   checkReminderItem: jest.fn(),
   deleteReminderItem: jest.fn(),
+  clearReminderItems: jest.fn(),
   renameReminderItem: jest.fn(),
   reorderReminderItems: jest.fn(),
   updateReminderListGroup: jest.fn(),
@@ -67,6 +69,7 @@ const mockGetReminderItems = getReminderItems as jest.MockedFunction<typeof getR
 const mockAddReminderItem = addReminderItem as jest.MockedFunction<typeof addReminderItem>
 const mockCheckReminderItem = checkReminderItem as jest.MockedFunction<typeof checkReminderItem>
 const mockDeleteReminderItem = deleteReminderItem as jest.MockedFunction<typeof deleteReminderItem>
+const mockClearReminderItems = clearReminderItems as jest.MockedFunction<typeof clearReminderItems>
 const mockRenameReminderItem = renameReminderItem as jest.MockedFunction<typeof renameReminderItem>
 const mockReorderReminderItems = reorderReminderItems as jest.MockedFunction<typeof reorderReminderItems>
 const mockUpdateReminderListGroup = updateReminderListGroup as jest.MockedFunction<typeof updateReminderListGroup>
@@ -103,6 +106,7 @@ describe('ReminderDetailView', () => {
     mockRenameReminderItem.mockResolvedValue(undefined as never)
     mockCheckReminderItem.mockResolvedValue(undefined as never)
     mockDeleteReminderItem.mockResolvedValue(undefined as never)
+    mockClearReminderItems.mockResolvedValue(undefined as never)
     mockReorderReminderItems.mockResolvedValue(undefined as never)
     mockUpdateReminderListGroup.mockResolvedValue({
       id: 'list-1',
@@ -526,6 +530,93 @@ describe('ReminderDetailView', () => {
 
     await user.click(screen.getByLabelText('삭제 확인'))
     expect(mockDeleteReminderItem).toHaveBeenCalledWith('item-1')
+  })
+
+  it('아이템 비우기 확인 후 현재 리마인더 아이템을 모두 삭제한다', async () => {
+    const user = userEvent.setup()
+    mockGetReminderItems.mockResolvedValueOnce([
+      {
+        id: 'item-1',
+        list_id: 'list-1',
+        created_by: 'user-1',
+        name: '우유',
+        is_checked: false,
+        checked_by: null,
+        checked_at: null,
+        sort_order: 0,
+        created_at: '2026-01-01T00:00:00Z',
+      },
+      {
+        id: 'item-2',
+        list_id: 'list-1',
+        created_by: 'user-1',
+        name: '달걀',
+        is_checked: true,
+        checked_by: 'user-1',
+        checked_at: '2026-01-01T00:00:00Z',
+        sort_order: 1,
+        created_at: '2026-01-01T00:00:00Z',
+      },
+    ] as never)
+
+    render(
+      <ReminderDetailView
+        listId="list-1"
+        user={mockUser}
+        onClose={onClose}
+        onPreviewItemsChange={onPreviewItemsChange}
+      />
+    )
+
+    await user.click(await screen.findByLabelText('아이템 비우기'))
+
+    expect(screen.getByRole('dialog', { name: '아이템 비우기' })).toBeInTheDocument()
+    expect(screen.getByText('이 리마인더의 아이템 2개를 모두 삭제할까요?')).toBeInTheDocument()
+
+    await user.click(screen.getByLabelText('아이템 비우기 확인'))
+
+    expect(mockClearReminderItems).toHaveBeenCalledWith('list-1')
+    await waitFor(() => {
+      expect(screen.queryByText('우유')).not.toBeInTheDocument()
+    })
+    expect(screen.getByText('아직 아이템이 없어요')).toBeInTheDocument()
+    expect(onPreviewItemsChange).toHaveBeenCalledWith('list-1', [])
+    expect(mockBroadcast).toHaveBeenCalled()
+  })
+
+  it('아이템 비우기에 실패하면 이전 아이템을 복원한다', async () => {
+    const user = userEvent.setup()
+    mockClearReminderItems.mockRejectedValueOnce(new Error('clear failed'))
+    mockGetReminderItems.mockResolvedValueOnce([
+      {
+        id: 'item-1',
+        list_id: 'list-1',
+        created_by: 'user-1',
+        name: '우유',
+        is_checked: false,
+        checked_by: null,
+        checked_at: null,
+        sort_order: 0,
+        created_at: '2026-01-01T00:00:00Z',
+      },
+    ] as never)
+
+    render(
+      <ReminderDetailView
+        listId="list-1"
+        user={mockUser}
+        onClose={onClose}
+        onPreviewItemsChange={onPreviewItemsChange}
+      />
+    )
+
+    await user.click(await screen.findByLabelText('아이템 비우기'))
+    await user.click(screen.getByLabelText('아이템 비우기 확인'))
+
+    await waitFor(() => {
+      expect(screen.getByText('아이템을 비우지 못했어요')).toBeInTheDocument()
+    })
+    expect(screen.getByText('우유')).toBeInTheDocument()
   })
 
   it('인라인 입력 기준 아이템을 완료 처리하면 인라인 입력창을 닫는다', async () => {

--- a/src/components/reminders/ReminderDetailView.tsx
+++ b/src/components/reminders/ReminderDetailView.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { ArrowLeft, ListChecks, Plus } from 'lucide-react'
+import { ArrowLeft, ListChecks, Plus, Trash2 } from 'lucide-react'
 import {
   DndContext,
   PointerSensor,
@@ -17,6 +17,7 @@ import {
   addReminderItem,
   checkReminderItem,
   deleteReminderItem,
+  clearReminderItems,
   renameReminderItem,
   reorderReminderItems,
   updateReminderListGroup,
@@ -81,6 +82,8 @@ export function ReminderDetailView({
   const [editingItemId, setEditingItemId] = useState<string | null>(null)
   const [addSession, setAddSession] = useState<AddSession>(null)
   const [deleteConfirmItem, setDeleteConfirmItem] = useState<ReminderItemType | null>(null)
+  const [clearConfirmOpen, setClearConfirmOpen] = useState(false)
+  const [clearingItems, setClearingItems] = useState(false)
   const addInputRef = useRef<HTMLInputElement>(null)
   const shellRef = useRef<HTMLDivElement>(null)
 
@@ -364,6 +367,33 @@ export function ReminderDetailView({
     }
   }
 
+  const handleClearItems = async () => {
+    if (items.length === 0 || clearingItems) {
+      setClearConfirmOpen(false)
+      return
+    }
+
+    setMutationError(null)
+    setClearConfirmOpen(false)
+    setDeleteConfirmItem(null)
+    setEditingItemId(null)
+    setAddSession(null)
+    setClearingItems(true)
+    const previousItems = items
+    setItemsWithPreview([])
+
+    try {
+      await clearReminderItems(listId)
+      broadcast()
+    } catch (e) {
+      console.error('[ReminderDetailView] clearReminderItems failed:', e)
+      setItemsWithPreview(previousItems)
+      setMutationError('아이템을 비우지 못했어요')
+    } finally {
+      setClearingItems(false)
+    }
+  }
+
   const handleRename = async (itemId: string, name: string): Promise<boolean> => {
     setMutationError(null)
     const previousItems = items
@@ -485,6 +515,16 @@ export function ReminderDetailView({
     if (!deleteConfirmItem) return
     void handleDelete(deleteConfirmItem.id)
   }
+  const handleOpenClearConfirm = () => {
+    setAddSession(null)
+    setEditingItemId(null)
+    setDeleteConfirmItem(null)
+    setClearConfirmOpen(true)
+  }
+  const handleCancelClear = () => setClearConfirmOpen(false)
+  const handleConfirmClear = () => {
+    void handleClearItems()
+  }
 
   return (
     <div
@@ -525,7 +565,7 @@ export function ReminderDetailView({
             >
               <ArrowLeft size={20} />
             </button>
-            <div>
+            <div className="min-w-0 flex-1">
               <h2 className="text-xl font-bold text-stone-800 dark:text-stone-100">
                 {list?.name ?? '리마인더'}
               </h2>
@@ -537,6 +577,17 @@ export function ReminderDetailView({
                   : '아이템을 추가해보세요'}
               </p>
             </div>
+            {items.length > 0 && (
+              <button
+                type="button"
+                onClick={handleOpenClearConfirm}
+                disabled={clearingItems}
+                className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl text-stone-400 transition-colors hover:bg-red-50 hover:text-red-500 disabled:opacity-50 dark:text-stone-500 dark:hover:bg-red-950/40 dark:hover:text-red-400"
+                aria-label="아이템 비우기"
+              >
+                <Trash2 size={17} />
+              </button>
+            )}
           </div>
 
           {list && groups.length > 0 && (
@@ -714,6 +765,42 @@ export function ReminderDetailView({
                     aria-label="삭제 확인"
                   >
                     삭제
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {clearConfirmOpen && (
+            <div
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby="reminder-items-clear-title"
+              className="fixed inset-0 z-[60] flex items-end justify-center p-4 sm:items-center"
+            >
+              <div className="absolute inset-0 bg-black/40" onClick={handleCancelClear} />
+              <div className="relative w-full rounded-2xl bg-stone-50 p-6 shadow-xl dark:bg-stone-900 sm:max-w-xs">
+                <p id="reminder-items-clear-title" className="mb-1 font-semibold text-stone-800 dark:text-stone-100">
+                  아이템 비우기
+                </p>
+                <p className="mb-6 text-sm text-stone-500 dark:text-stone-400">
+                  이 리마인더의 아이템 {items.length}개를 모두 삭제할까요?
+                </p>
+                <div className="flex gap-3">
+                  <button
+                    onClick={handleCancelClear}
+                    className="flex-1 rounded-xl bg-stone-100 py-2.5 text-sm font-semibold text-stone-700 transition-colors hover:bg-stone-200 dark:bg-stone-800 dark:text-stone-300 dark:hover:bg-stone-700"
+                    aria-label="취소"
+                  >
+                    취소
+                  </button>
+                  <button
+                    onClick={handleConfirmClear}
+                    disabled={clearingItems}
+                    className="flex-1 rounded-xl bg-red-500 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-red-600 disabled:opacity-50"
+                    aria-label="아이템 비우기 확인"
+                  >
+                    비우기
                   </button>
                 </div>
               </div>

--- a/src/lib/reminder-lists.ts
+++ b/src/lib/reminder-lists.ts
@@ -261,6 +261,11 @@ export async function deleteReminderItem(itemId: string): Promise<void> {
   if (error) throw error
 }
 
+export async function clearReminderItems(listId: string): Promise<void> {
+  const { error } = await supabase.from('shopping_items').delete().eq('list_id', listId)
+  if (error) throw error
+}
+
 export async function renameReminderList(listId: string, name: string): Promise<void> {
   const { error } = await supabase
     .from('shopping_lists')


### PR DESCRIPTION
## Summary

- Add a bulk clear action to reminder detail headers for removing all items in the current list.
- Add a list-scoped reminder item delete helper and optimistic UI rollback on failure.
- Cover the data helper and detail view clear flow with focused tests.

## Testing

- npm run test -- --testPathPatterns=src/__tests__/lib/reminder-lists.test.ts
- npm run test -- --testPathPatterns=src/__tests__/reminders/ReminderDetailView.test.tsx
- npx tsc --noEmit