### PR TITLE
polish: clarify reminder clear action

### DIFF
--- a/src/__tests__/reminders/ReminderDetailView.test.tsx
+++ b/src/__tests__/reminders/ReminderDetailView.test.tsx
@@ -568,7 +568,10 @@ describe('ReminderDetailView', () => {
       />
     )
 
-    await user.click(await screen.findByLabelText('아이템 비우기'))
+    const clearButton = await screen.findByLabelText('아이템 비우기')
+    expect(clearButton).toHaveTextContent('비우기')
+
+    await user.click(clearButton)
 
     expect(screen.getByRole('dialog', { name: '아이템 비우기' })).toBeInTheDocument()
     expect(screen.getByText('이 리마인더의 아이템 2개를 모두 삭제할까요?')).toBeInTheDocument()

--- a/src/components/reminders/ReminderDetailView.tsx
+++ b/src/components/reminders/ReminderDetailView.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { ArrowLeft, ListChecks, Plus, Trash2 } from 'lucide-react'
+import { ArrowLeft, ListChecks, Plus } from 'lucide-react'
 import {
   DndContext,
   PointerSensor,
@@ -582,10 +582,10 @@ export function ReminderDetailView({
                 type="button"
                 onClick={handleOpenClearConfirm}
                 disabled={clearingItems}
-                className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl text-stone-400 transition-colors hover:bg-red-50 hover:text-red-500 disabled:opacity-50 dark:text-stone-500 dark:hover:bg-red-950/40 dark:hover:text-red-400"
+                className="h-10 shrink-0 rounded-xl border border-red-200 px-3 text-sm font-semibold text-red-500 transition-colors hover:bg-red-50 disabled:opacity-50 dark:border-red-900/60 dark:hover:bg-red-950/30"
                 aria-label="아이템 비우기"
               >
-                <Trash2 size={17} />
+                비우기
               </button>
             )}
           </div>


### PR DESCRIPTION
## Summary

- Replace the reminder detail header trash icon with a visible `비우기` text button.
- Keep the existing confirmation flow and accessible action label intact.
- Verify the clear action button exposes its visible label.

## Testing

- `npm run test -- --testPathPatterns=src/__tests__/reminders/ReminderDetailView.test.tsx`
- `npx tsc --noEmit`