### PR TITLE
perf: keep holiday engine server-side

### DIFF
--- a/src/__tests__/hooks/useHolidays.test.ts
+++ b/src/__tests__/hooks/useHolidays.test.ts
@@ -1,6 +1,7 @@
-import { renderHook, waitFor } from '@testing-library/react'
+import { act, renderHook, waitFor } from '@testing-library/react'
 import { useHolidays, clearHolidayCache } from '@/hooks/useHolidays'
 import { getJsonWithAuth } from '@/lib/api-client'
+import type { Holiday } from '@/types/holidays'
 
 jest.mock('@/lib/api-client', () => ({
   getJsonWithAuth: jest.fn(),
@@ -8,119 +9,105 @@ jest.mock('@/lib/api-client', () => ({
 
 const mockGetJsonWithAuth = getJsonWithAuth as jest.MockedFunction<typeof getJsonWithAuth>
 
+const krHolidays: Holiday[] = [
+  { date: '2026-03-01', localName: '3·1절', countryCode: 'KR' },
+  { date: '2026-03-02', localName: '대체공휴일', countryCode: 'KR' },
+]
+
 beforeEach(() => {
   clearHolidayCache()
   jest.restoreAllMocks()
-  mockGetJsonWithAuth.mockRejectedValue(new Error('network unavailable'))
+  mockGetJsonWithAuth.mockReset()
 })
 
 describe('useHolidays', () => {
-  it('countryCodes가 빈 배열이면 빈 배열을 반환한다', () => {
+  it('countryCodes가 빈 배열이면 요청하지 않고 빈 배열을 반환한다', () => {
     const { result } = renderHook(() => useHolidays(2026, 2, []))
+
     expect(result.current).toEqual([])
+    expect(mockGetJsonWithAuth).not.toHaveBeenCalled()
   })
 
-  it('현재 월 공휴일을 포함해 반환한다', () => {
-    const { result } = renderHook(() => useHolidays(2026, 2, ['KR'])) // month=2 → March
-    const march = result.current.filter((h) => h.date.startsWith('2026-03'))
-    expect(march.length).toBeGreaterThan(0)
+  it('서버 응답 전에는 빈 배열을 반환하고 응답 후 휴일을 반영한다', async () => {
+    mockGetJsonWithAuth.mockResolvedValue({ holidays: krHolidays })
+
+    const { result } = renderHook(() => useHolidays(2026, 2, ['KR']))
+
+    expect(result.current).toEqual([])
+    await waitFor(() => expect(result.current).toEqual(krHolidays))
+    expect(mockGetJsonWithAuth).toHaveBeenCalledWith('/api/holidays?year=2026&month=2&countries=KR')
   })
 
-  describe('KR 대체공휴일', () => {
-    it('3·1절(2026-03-01 일요일)의 대체공휴일이 2026-03-02에 추가된다', () => {
-      const { result } = renderHook(() => useHolidays(2026, 2, ['KR']))
-      const dates = result.current.map((h) => h.date)
-      expect(dates).toContain('2026-03-01') // 3·1절
-      expect(dates).toContain('2026-03-02') // 대체공휴일
-    })
+  it('국가 코드를 정렬해 같은 조합은 하나의 캐시 키와 요청을 사용한다', async () => {
+    mockGetJsonWithAuth.mockResolvedValue({ holidays: krHolidays })
 
-    it('2026-03-02의 localName이 대체공휴일이다', () => {
-      const { result } = renderHook(() => useHolidays(2026, 2, ['KR']))
-      const substitute = result.current.find((h) => h.date === '2026-03-02')
-      expect(substitute?.localName).toBe('대체공휴일')
-    })
+    const first = renderHook(() => useHolidays(2026, 2, ['JP', 'KR']))
+    await waitFor(() => expect(first.result.current).toEqual(krHolidays))
+    first.unmount()
+
+    const second = renderHook(() => useHolidays(2026, 2, ['KR', 'JP']))
+
+    expect(second.result.current).toEqual(krHolidays)
+    expect(mockGetJsonWithAuth).toHaveBeenCalledTimes(1)
+    expect(mockGetJsonWithAuth).toHaveBeenCalledWith('/api/holidays?year=2026&month=2&countries=JP%2CKR')
   })
 
-  describe('JP Golden Week 2026 — 연속 휴일 대체공휴일', () => {
-    // 2026/5/3(일) 憲法記念日 → 5/4 みどりの日, 5/5 こどもの日 모두 휴일
-    // → 振替休日는 연속 휴일을 건너뛴 5/6(수)에 있어야 함
+  it('동일 범위의 동시 요청을 하나의 in-flight 요청으로 공유한다', async () => {
+    let resolveRequest: ((value: { holidays: Holiday[] }) => void) | null = null
+    mockGetJsonWithAuth.mockReturnValue(new Promise((resolve) => {
+      resolveRequest = resolve
+    }))
 
-    it('5/3 憲法記念日, 5/4 みどりの日, 5/5 こどもの日, 5/6 振替休日를 모두 포함한다', () => {
-      const { result } = renderHook(() => useHolidays(2026, 4, ['JP'])) // month=4 → May
-      const dates = result.current.map((h) => h.date)
-      expect(dates).toContain('2026-05-03') // 憲法記念日
-      expect(dates).toContain('2026-05-04') // みどりの日
-      expect(dates).toContain('2026-05-05') // こどもの日
-      expect(dates).toContain('2026-05-06') // 振替休日
+    const { result } = renderHook(() => [
+      useHolidays(2026, 2, ['KR']),
+      useHolidays(2026, 2, ['KR']),
+    ])
+
+    expect(mockGetJsonWithAuth).toHaveBeenCalledTimes(1)
+    await act(async () => {
+      resolveRequest?.({ holidays: krHolidays })
     })
-
-    it('5/3의 localName이 憲法記念日다', () => {
-      const { result } = renderHook(() => useHolidays(2026, 4, ['JP']))
-      const kenpo = result.current.find((h) => h.date === '2026-05-03')
-      expect(kenpo?.localName).toBe('憲法記念日')
-    })
-
-    it('5/6의 localName이 振替休日다 (원본 휴일명 포함 형식 아님)', () => {
-      const { result } = renderHook(() => useHolidays(2026, 4, ['JP']))
-      const substitute = result.current.find((h) => h.date === '2026-05-06')
-      expect(substitute?.localName).toBe('振替休日')
-    })
-
-    it('5/4와 5/5 사이에 振替休日가 없다 (연속 휴일을 올바르게 건너뜀)', () => {
-      const { result } = renderHook(() => useHolidays(2026, 4, ['JP']))
-      const may4 = result.current.find((h) => h.date === '2026-05-04')
-      const may5 = result.current.find((h) => h.date === '2026-05-05')
-      expect(may4?.localName).not.toBe('振替休日')
-      expect(may5?.localName).not.toBe('振替休日')
-    })
-  })
-
-  describe('인접 월 휴일 포함 — 그리드 범위 대응', () => {
-    it('5월 뷰에서 4/29 昭和の日가 반환된다', () => {
-      const { result } = renderHook(() => useHolidays(2026, 4, ['JP'])) // month=4 → May
-      const apr29 = result.current.find((h) => h.date === '2026-04-29')
-      expect(apr29).toBeDefined()
-      expect(apr29?.localName).toBe('昭和の日')
-    })
-
-    it('1월 뷰에서 전년 12월 크리스마스(KR)가 반환된다 — 연도 경계', () => {
-      const { result } = renderHook(() => useHolidays(2026, 0, ['KR'])) // month=0 → January 2026
-      const christmas = result.current.find((h) => h.date === '2025-12-25')
-      expect(christmas).toBeDefined()
-      expect(christmas?.localName).toBe('크리스마스')
-    })
-
-    it('12월 뷰에서 다음 연도 1월 元日(JP)이 반환된다 — 연도 경계', () => {
-      const { result } = renderHook(() => useHolidays(2025, 11, ['JP'])) // month=11 → December 2025
-      const jan1 = result.current.find((h) => h.date === '2026-01-01')
-      expect(jan1).toBeDefined()
-    })
-
-    it('현재 월 휴일이 기존과 동일하게 포함된다', () => {
-      const { result } = renderHook(() => useHolidays(2026, 2, ['KR'])) // month=2 → March
-      const samil = result.current.find((h) => h.date === '2026-03-01')
-      expect(samil).toBeDefined()
-    })
-  })
-
-  it('복수 국가의 공휴일을 합쳐서 반환하고 countryCode가 올바르게 설정된다', () => {
-    const { result } = renderHook(() => useHolidays(2026, 2, ['KR', 'JP'])) // March
-    const codes = result.current.map((h) => h.countryCode)
-    expect(codes).toContain('KR')
-  })
-
-  it('API 응답이 오면 KR 휴일을 서버 응답으로 갱신한다', async () => {
-    mockGetJsonWithAuth.mockResolvedValue({
-      holidays: [
-        { date: '2026-05-01', localName: '노동절', countryCode: 'KR' },
-        { date: '2026-05-05', localName: '어린이날', countryCode: 'KR' },
-      ],
-    })
-
-    const { result } = renderHook(() => useHolidays(2026, 4, ['KR']))
-
     await waitFor(() => {
-      expect(result.current.some((h) => h.date === '2026-05-01' && h.localName === '노동절')).toBe(true)
+      expect(result.current[0]).toEqual(krHolidays)
+      expect(result.current[1]).toEqual(krHolidays)
     })
+  })
+
+  it('이전 범위의 늦은 응답이 현재 범위 휴일을 덮어쓰지 않는다', async () => {
+    let resolveKr: ((value: { holidays: Holiday[] }) => void) | null = null
+    let resolveJp: ((value: { holidays: Holiday[] }) => void) | null = null
+    const jpHolidays: Holiday[] = [
+      { date: '2026-05-03', localName: '憲法記念日', countryCode: 'JP' },
+    ]
+
+    mockGetJsonWithAuth.mockImplementation((url) => new Promise((resolve) => {
+      if (String(url).includes('countries=KR')) resolveKr = resolve
+      else resolveJp = resolve
+    }))
+
+    const { result, rerender } = renderHook(
+      ({ month, countries }) => useHolidays(2026, month, countries),
+      { initialProps: { month: 2, countries: ['KR'] } }
+    )
+
+    rerender({ month: 4, countries: ['JP'] })
+    await act(async () => {
+      resolveJp?.({ holidays: jpHolidays })
+    })
+    await waitFor(() => expect(result.current).toEqual(jpHolidays))
+
+    await act(async () => {
+      resolveKr?.({ holidays: krHolidays })
+    })
+    expect(result.current).toEqual(jpHolidays)
+  })
+
+  it('서버 요청이 실패해도 화면 렌더를 막지 않고 빈 배열을 유지한다', async () => {
+    mockGetJsonWithAuth.mockRejectedValue(new Error('network unavailable'))
+
+    const { result } = renderHook(() => useHolidays(2026, 2, ['KR']))
+
+    await waitFor(() => expect(mockGetJsonWithAuth).toHaveBeenCalledTimes(1))
+    expect(result.current).toEqual([])
   })
 })

--- a/src/__tests__/lib/holidays.test.ts
+++ b/src/__tests__/lib/holidays.test.ts
@@ -15,6 +15,39 @@ describe('holiday helpers', () => {
     expect(christmas?.localName).toBe('크리스마스')
   })
 
+  it('KR 일요일 공휴일의 대체공휴일을 계산한다', () => {
+    const holidays = getFallbackHolidaysForRange(2026, 2, ['KR'])
+
+    expect(holidays).toContainEqual(expect.objectContaining({
+      date: '2026-03-01',
+      countryCode: 'KR',
+    }))
+    expect(holidays).toContainEqual(expect.objectContaining({
+      date: '2026-03-02',
+      localName: '대체공휴일',
+      countryCode: 'KR',
+    }))
+  })
+
+  it('JP 연속 휴일 뒤 대체공휴일을 계산한다', () => {
+    const holidays = getFallbackHolidaysForRange(2026, 4, ['JP'])
+
+    expect(holidays).toContainEqual(expect.objectContaining({ date: '2026-05-03', localName: '憲法記念日' }))
+    expect(holidays).toContainEqual(expect.objectContaining({ date: '2026-05-04', localName: 'みどりの日' }))
+    expect(holidays).toContainEqual(expect.objectContaining({ date: '2026-05-05', localName: 'こどもの日' }))
+    expect(holidays).toContainEqual(expect.objectContaining({ date: '2026-05-06', localName: '振替休日' }))
+  })
+
+  it('캘린더 그리드에 필요한 인접 월과 연도 경계 휴일을 포함한다', () => {
+    const may = getFallbackHolidaysForRange(2026, 4, ['JP'])
+    const january = getFallbackHolidaysForRange(2026, 0, ['KR'])
+    const december = getFallbackHolidaysForRange(2025, 11, ['JP'])
+
+    expect(may).toContainEqual(expect.objectContaining({ date: '2026-04-29', localName: '昭和の日' }))
+    expect(january).toContainEqual(expect.objectContaining({ date: '2025-12-25', localName: '크리스마스' }))
+    expect(december).toContainEqual(expect.objectContaining({ date: '2026-01-01' }))
+  })
+
   it('API 키 만료 90일 이내이면 경고 문구를 반환한다', () => {
     const warning = getKasiApiKeyExpiryWarning(
       '2028-04-23',

--- a/src/components/calendar/CalendarGrid.tsx
+++ b/src/components/calendar/CalendarGrid.tsx
@@ -4,7 +4,7 @@ import { type CSSProperties, useEffect, useMemo, useRef, useState } from 'react'
 import KoreanLunarCalendar from 'korean-lunar-calendar'
 import type { Calendar, CalendarEvent } from '@/lib/calendar'
 import { toDisplayColor } from '@/lib/label-colors'
-import type { Holiday } from '@/lib/holidays'
+import type { Holiday } from '@/types/holidays'
 
 const DOW = ['일', '월', '화', '수', '목', '금', '토']
 const DATE_HEADER_HEIGHT = 28  // px – date circle (h-6=24) + mb-0.5 (2) + border (1) ≈ 28

--- a/src/hooks/useHolidays.ts
+++ b/src/hooks/useHolidays.ts
@@ -1,21 +1,47 @@
-import { useEffect, useMemo, useState } from 'react'
-import {
-  clearFallbackHolidayCache,
-  getFallbackHolidaysForRange,
-  type Holiday,
-} from '@/lib/holidays'
+import { useEffect, useState } from 'react'
 import { getJsonWithAuth } from '@/lib/api-client'
+import type { Holiday } from '@/types/holidays'
 
 /** Test utility: clears the in-memory cache between test cases. */
 export function clearHolidayCache() {
-  clearFallbackHolidayCache()
+  cacheGeneration += 1
   apiCache.clear()
+  apiRequests.clear()
 }
 
 const apiCache = new Map<string, Holiday[]>()
+const apiRequests = new Map<string, Promise<Holiday[]>>()
+let cacheGeneration = 0
+
 interface ApiHolidayResult {
   key: string
   holidays: Holiday[]
+}
+
+function loadHolidays(cacheKey: string, url: string): Promise<Holiday[]> {
+  const cached = apiCache.get(cacheKey)
+  if (cached) return Promise.resolve(cached)
+
+  const inFlight = apiRequests.get(cacheKey)
+  if (inFlight) return inFlight
+
+  const requestGeneration = cacheGeneration
+  const request = getJsonWithAuth<{ holidays?: Holiday[] }>(url)
+    .then((body) => Array.isArray(body.holidays) ? body.holidays : [])
+    .then((holidays) => {
+      if (requestGeneration === cacheGeneration) {
+        apiCache.set(cacheKey, holidays)
+      }
+      return holidays
+    })
+    .finally(() => {
+      if (apiRequests.get(cacheKey) === request) {
+        apiRequests.delete(cacheKey)
+      }
+    })
+
+  apiRequests.set(cacheKey, request)
+  return request
 }
 
 export function useHolidays(
@@ -24,40 +50,32 @@ export function useHolidays(
   countryCodes: string[]
 ): Holiday[] {
   const countryKey = [...countryCodes].sort().join(',')
-  const fallbackHolidays = useMemo(() => {
-    if (!countryKey) return []
-    return getFallbackHolidaysForRange(year, month, countryKey.split(','))
-  }, [year, month, countryKey])
-
   const cacheKey = `${year}-${month}-${countryKey}`
   const [apiResult, setApiResult] = useState<ApiHolidayResult | null>(null)
 
   useEffect(() => {
     if (!countryKey || apiCache.has(cacheKey)) return
 
-    const controller = new AbortController()
+    let cancelled = false
     const params = new URLSearchParams({
       year: String(year),
       month: String(month),
       countries: countryKey,
     })
 
-    getJsonWithAuth<{ holidays?: Holiday[] }>(`/api/holidays?${params.toString()}`, {
-      signal: controller.signal,
-    })
-      .then((body) => {
-        const nextHolidays = Array.isArray(body.holidays) ? body.holidays : fallbackHolidays
-        apiCache.set(cacheKey, nextHolidays)
-        setApiResult({ key: cacheKey, holidays: nextHolidays })
+    loadHolidays(cacheKey, `/api/holidays?${params.toString()}`)
+      .then((holidays) => {
+        if (!cancelled) setApiResult({ key: cacheKey, holidays })
       })
-      .catch((error) => {
-        if (error instanceof DOMException && error.name === 'AbortError') return
-      })
+      .catch(() => {})
 
-    return () => controller.abort()
-  }, [cacheKey, countryKey, fallbackHolidays, month, year])
+    return () => {
+      cancelled = true
+    }
+  }, [cacheKey, countryKey, month, year])
 
-  return apiCache.get(cacheKey) ?? (apiResult?.key === cacheKey ? apiResult.holidays : fallbackHolidays)
+  if (!countryKey) return []
+  return apiCache.get(cacheKey) ?? (apiResult?.key === cacheKey ? apiResult.holidays : [])
 }
 
 export type { Holiday }

--- a/src/lib/holidays.ts
+++ b/src/lib/holidays.ts
@@ -1,10 +1,7 @@
 import Holidays from 'date-holidays'
+import type { Holiday } from '@/types/holidays'
 
-export interface Holiday {
-  date: string
-  localName: string
-  countryCode: string
-}
+export type { Holiday } from '@/types/holidays'
 
 const COUNTRY_LANGUAGE: Record<string, string> = {
   KR: 'ko',

--- a/src/lib/kasi-holidays.ts
+++ b/src/lib/kasi-holidays.ts
@@ -3,8 +3,8 @@ import {
   getAdjacentMonths,
   getFallbackHolidaysForRange,
   normalizeHolidayName,
-  type Holiday,
 } from '@/lib/holidays'
+import type { Holiday } from '@/types/holidays'
 
 const KASI_ENDPOINT =
   'https://apis.data.go.kr/B090041/openapi/service/SpcdeInfoService/getRestDeInfo'

--- a/src/types/holidays.ts
+++ b/src/types/holidays.ts
@@ -1,0 +1,5 @@
+export interface Holiday {
+  date: string
+  localName: string
+  countryCode: string
+}


### PR DESCRIPTION
## Summary
- `date-holidays`와 연관된 대형 휴일 계산 의존성을 서버 경계 안으로 이동해 초기 브라우저 번들에서 제거했습니다.
- 브라우저에서 필요한 `Holiday` 타입을 경량 타입 모듈로 분리했습니다.
- 휴일 API 요청은 범위별 캐시와 in-flight 공유를 사용하고, 화면 전환 후 도착한 오래된 응답이 현재 월을 덮어쓰지 않도록 방어했습니다.
- 사용자 관점에서는 캘린더와 일정이 먼저 표시되고 휴일이 서버 응답 후 이어서 표시됩니다. 휴일 요청이 실패해도 캘린더 사용은 막히지 않으며 빈 휴일 상태를 유지합니다.
- 서버의 KASI 조회, KR/JP 로컬 fallback, 인증 정책은 기존과 동일하게 유지했습니다.
- 분석 기준 최대 클라이언트 청크가 약 1.65MB에서 227KB로 감소했고, 브라우저 청크의 `date-holidays`, `moment-timezone`, `astronomia` 포함 여부가 0건임을 확인했습니다.

## Testing
- `npm run test -- --runInBand` (68 suites, 689 tests passed)
- `npx tsc --noEmit`
- `npm run lint`
- `git diff --check`
- `npx next experimental-analyze --output`
- analyzer 데이터에서 휴일 엔진 의존성의 client chunk 포함 여부와 최대 chunk 크기 확인