### PR TITLE
perf: parallelize calendar startup

### DIFF
--- a/src/__tests__/TabsShell.test.tsx
+++ b/src/__tests__/TabsShell.test.tsx
@@ -59,7 +59,16 @@ jest.mock('@/components/AppSplash', () => ({
 }))
 
 jest.mock('@/components/tabs/CalendarTab', () => ({
-  CalendarTab: () => <div data-testid="calendar-tab" />,
+  CalendarTab: ({ calendarsLoading, calendarsError }: {
+    calendarsLoading: boolean
+    calendarsError: unknown
+  }) => (
+    <div
+      data-testid="calendar-tab"
+      data-calendars-loading={String(calendarsLoading)}
+      data-calendars-error={String(Boolean(calendarsError))}
+    />
+  ),
 }))
 
 jest.mock('@/components/tabs/ReminderTab', () => ({
@@ -105,11 +114,12 @@ describe('TabsShell', () => {
     expect(screen.queryByTestId('bottom-nav')).not.toBeInTheDocument()
   })
 
-  it('캘린더 데이터 로딩 중에도 AppSplash를 표시한다', () => {
+  it('캘린더 데이터 로딩 중에는 splash를 닫고 캘린더 셸을 표시한다', () => {
     mockCalendarsLoading = true
     render(<TabsShell />)
-    expect(screen.getByTestId('app-splash')).toBeInTheDocument()
-    expect(screen.queryByTestId('bottom-nav')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('app-splash')).not.toBeInTheDocument()
+    expect(screen.getByTestId('calendar-tab')).toHaveAttribute('data-calendars-loading', 'true')
+    expect(screen.getByTestId('bottom-nav')).toBeInTheDocument()
   })
 
   it('미인증 상태에서는 탭을 렌더링하지 않는다', () => {
@@ -162,8 +172,8 @@ describe('TabsShell', () => {
     expect(registerPushSubscription).not.toHaveBeenCalled()
   })
 
-  it('초기 로딩 실패 시 splash 위 에러 다이얼로그를 표시한다', () => {
-    mockCalendarsError = new Error('calendar failed')
+  it('가족 초기 로딩 실패 시 splash 위 에러 다이얼로그를 표시한다', () => {
+    mockFamilyError = new Error('family failed')
     render(<TabsShell />)
 
     expect(screen.getByTestId('app-splash')).toBeInTheDocument()
@@ -171,8 +181,8 @@ describe('TabsShell', () => {
     expect(screen.getByText('앱을 시작하지 못했어요')).toBeInTheDocument()
   })
 
-  it('다시 시도 버튼 클릭 시 가족과 캘린더 로드를 모두 재시도한다', async () => {
-    mockCalendarsError = new Error('calendar failed')
+  it('가족 초기 로딩 다시 시도 시 가족과 캘린더 로드를 모두 재시도한다', async () => {
+    mockFamilyError = new Error('family failed')
     const user = userEvent.setup()
 
     render(<TabsShell />)
@@ -180,5 +190,23 @@ describe('TabsShell', () => {
 
     expect(mockReloadFamily).toHaveBeenCalled()
     expect(mockReloadCalendars).toHaveBeenCalled()
+  })
+
+  it('캘린더 로드 실패는 앱 전체를 막지 않고 캘린더 탭에 전달한다', () => {
+    mockCalendarsError = new Error('calendar failed')
+    render(<TabsShell />)
+
+    expect(screen.queryByTestId('app-splash')).not.toBeInTheDocument()
+    expect(screen.getByTestId('calendar-tab')).toHaveAttribute('data-calendars-error', 'true')
+    expect(screen.getByTestId('bottom-nav')).toBeInTheDocument()
+  })
+
+  it('캘린더 로드 실패 중에도 URL로 선택한 리마인더 탭을 연다', async () => {
+    mockTabParam = 'reminders'
+    mockCalendarsError = new Error('calendar failed')
+    render(<TabsShell />)
+
+    expect((await screen.findByTestId('reminder-tab')).parentElement).not.toHaveClass('hidden')
+    expect(screen.queryByTestId('app-splash')).not.toBeInTheDocument()
   })
 })

--- a/src/__tests__/api/family-me.test.ts
+++ b/src/__tests__/api/family-me.test.ts
@@ -5,28 +5,20 @@ import { POST } from '@/app/api/family/me/route'
 import { NextRequest } from 'next/server'
 
 const mockRpc = jest.fn()
-const mockFrom = jest.fn()
-const mockGetAuthenticatedUser = jest.fn()
+const mockGetAuthenticatedSessionUser = jest.fn()
+const mockGetAllowedAppRole = jest.fn()
 
 jest.mock('@supabase/supabase-js', () => ({
   createClient: () => ({
     rpc: (...args: unknown[]) => mockRpc(...args),
-    from: (...args: unknown[]) => mockFrom(...args),
     auth: { getUser: jest.fn() },
   }),
 }))
 
 jest.mock('@/lib/api-auth', () => ({
-  getAuthenticatedUser: (...args: unknown[]) => mockGetAuthenticatedUser(...args),
+  getAuthenticatedSessionUser: (...args: unknown[]) => mockGetAuthenticatedSessionUser(...args),
+  getAllowedAppRole: (...args: unknown[]) => mockGetAllowedAppRole(...args),
 }))
-
-function makeChain(result: { data: unknown; error: unknown }) {
-  const p = Promise.resolve(result)
-  const chain: Record<string, unknown> = {}
-  ;['select', 'eq'].forEach((m) => { chain[m] = jest.fn().mockReturnValue(chain) })
-  chain.maybeSingle = jest.fn().mockReturnValue(p)
-  return chain
-}
 
 function makeRequest() {
   return new NextRequest('http://localhost/api/family/me', { method: 'POST' })
@@ -34,16 +26,21 @@ function makeRequest() {
 
 beforeEach(() => {
   jest.clearAllMocks()
-  mockGetAuthenticatedUser.mockResolvedValue({ id: 'user-1', email: 'test@example.com' })
+  jest.spyOn(console, 'error').mockImplementation(() => {})
+  mockGetAuthenticatedSessionUser.mockResolvedValue({ id: 'user-1', email: 'test@example.com' })
+  mockGetAllowedAppRole.mockResolvedValue('member')
   mockRpc.mockResolvedValue({ data: 'fam-1', error: null })
-  mockFrom.mockReturnValue(makeChain({ data: { app_role: 'member' }, error: null }))
   process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://localhost'
   process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key'
 })
 
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
 describe('POST /api/family/me', () => {
   it('인증 사용자가 없으면 401을 반환한다', async () => {
-    mockGetAuthenticatedUser.mockResolvedValue(null)
+    mockGetAuthenticatedSessionUser.mockResolvedValue(null)
     const res = await POST(makeRequest())
     expect(res.status).toBe(401)
   })
@@ -54,6 +51,23 @@ describe('POST /api/family/me', () => {
     const body = await res.json()
     expect(body.familyId).toBe('fam-1')
     expect(body.appRole).toBe('member')
+  })
+
+  it('가족과 allowlist 조회를 같은 대기 구간에서 시작한다', async () => {
+    let resolveFamily: (value: { data: string; error: null }) => void = () => undefined
+    mockRpc.mockReturnValue(new Promise((resolve) => {
+      resolveFamily = resolve
+    }))
+
+    const responsePromise = POST(makeRequest())
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(mockRpc).toHaveBeenCalledWith('get_my_family', { p_user_id: 'user-1' })
+    expect(mockGetAllowedAppRole).toHaveBeenCalledWith('test@example.com')
+
+    resolveFamily({ data: 'fam-1', error: null })
+    await expect(responsePromise).resolves.toHaveProperty('status', 200)
   })
 
   it('가족이 없는 경우 familyId가 null이다', async () => {
@@ -70,16 +84,27 @@ describe('POST /api/family/me', () => {
   })
 
   it('allowed_emails에 admin이면 appRole이 admin이다', async () => {
-    mockFrom.mockReturnValue(makeChain({ data: { app_role: 'admin' }, error: null }))
+    mockGetAllowedAppRole.mockResolvedValue('admin')
     const res = await POST(makeRequest())
     const body = await res.json()
     expect(body.appRole).toBe('admin')
   })
 
-  it('appRole 조회 결과가 없으면 member 기본값이다', async () => {
-    mockFrom.mockReturnValue(makeChain({ data: null, error: null }))
+  it('allowlist 조회 결과가 없으면 401을 반환한다', async () => {
+    mockGetAllowedAppRole.mockResolvedValue(null)
     const res = await POST(makeRequest())
-    const body = await res.json()
-    expect(body.appRole).toBe('member')
+    expect(res.status).toBe(401)
+  })
+
+  it('allowlist 조회가 실패하면 500을 반환한다', async () => {
+    mockGetAllowedAppRole.mockRejectedValue(new Error('DB unavailable'))
+
+    const res = await POST(makeRequest())
+
+    expect(res.status).toBe(500)
+    expect(console.error).toHaveBeenCalledWith(
+      '[API /family/me] bootstrap lookup failed:',
+      expect.any(Error)
+    )
   })
 })

--- a/src/__tests__/components/CalendarFilter.test.tsx
+++ b/src/__tests__/components/CalendarFilter.test.tsx
@@ -28,6 +28,14 @@ describe('CalendarFilter', () => {
     expect(screen.getByText('테스트2')).toBeInTheDocument()
   })
 
+  it('로딩 중에는 캘린더 조작 대신 고정 크기 placeholder를 표시한다', () => {
+    render(<CalendarFilter {...defaultProps} loading />)
+
+    expect(screen.getByRole('status', { name: '캘린더 목록을 불러오는 중' })).toBeInTheDocument()
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    expect(defaultProps.onAdd).not.toHaveBeenCalled()
+  })
+
   it('짧게 누르면 onToggle이 호출된다', () => {
     render(<CalendarFilter {...defaultProps} />)
     const btn = screen.getByText('테스트1').closest('button')!

--- a/src/__tests__/components/CalendarTab.adjacent-events.test.tsx
+++ b/src/__tests__/components/CalendarTab.adjacent-events.test.tsx
@@ -125,6 +125,7 @@ const defaultProps = {
   familyId: 'fam-1',
   isInitializing: false,
   calendars: [],
+  calendarsLoading: false,
   calendarsError: null,
   reloadCalendars: jest.fn().mockResolvedValue(undefined),
 }

--- a/src/__tests__/components/CalendarTab.picker.integration.test.tsx
+++ b/src/__tests__/components/CalendarTab.picker.integration.test.tsx
@@ -63,6 +63,7 @@ const defaultProps = {
   familyId: 'fam-1',
   isInitializing: false,
   calendars: [],
+  calendarsLoading: false,
   calendarsError: null,
   reloadCalendars: jest.fn(),
 }

--- a/src/__tests__/components/CalendarTab.test.tsx
+++ b/src/__tests__/components/CalendarTab.test.tsx
@@ -44,7 +44,8 @@ jest.mock('next/navigation', () => ({
   useRouter: () => ({ replace: jest.fn() }),
 }))
 jest.mock('@/components/calendar/CalendarFilter', () => ({
-  CalendarFilter: ({ onEdit }: {
+  CalendarFilter: ({ onEdit, loading }: {
+    loading?: boolean
     onEdit: (calendar: {
       id: string
       family_id: string
@@ -57,6 +58,7 @@ jest.mock('@/components/calendar/CalendarFilter', () => ({
   }) => (
     <button
       data-testid="calendar-filter-edit"
+      disabled={loading}
       onClick={() => onEdit({
         id: 'cal-1',
         family_id: 'fam-1',
@@ -259,6 +261,7 @@ const defaultProps = {
   familyId: 'fam-1',
   isInitializing: false,
   calendars: mockCalendars,
+  calendarsLoading: false,
   calendarsError: null,
   reloadCalendars: mockReloadCalendars,
 }
@@ -284,6 +287,17 @@ describe('CalendarTab — touch-action 스크롤 차단', () => {
     mockGetRecurrenceRule.mockResolvedValue({ freq: 'weekly', interval: 1, daysOfWeek: [5] })
     mockDeleteWithAuth.mockResolvedValue(undefined)
     mockPatchJsonWithAuth.mockResolvedValue(undefined)
+  })
+
+  it('캘린더 목록 로딩 중에는 목록 의존 진입점을 비활성화한다', () => {
+    render(<CalendarTab {...defaultProps} calendars={[]} calendarsLoading />)
+
+    expect(screen.getByTestId('calendar-filter-edit')).toBeDisabled()
+    expect(screen.getByRole('button', { name: '캘린더 리스트' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: '일정 추가' })).toBeDisabled()
+
+    fireEvent.click(screen.getByTestId('select-date'))
+    expect(screen.queryByTestId('day-events-sheet')).not.toBeInTheDocument()
   })
 
   it('가족 단위 채널명을 사용하고 연/월을 포함하지 않는다', async () => {

--- a/src/__tests__/hooks/useCalendars.test.ts
+++ b/src/__tests__/hooks/useCalendars.test.ts
@@ -1,6 +1,7 @@
 import { renderHook, waitFor } from '@testing-library/react'
 import { useCalendars } from '@/hooks/useCalendars'
 import * as calendarLib from '@/lib/calendar'
+import type { Calendar } from '@/lib/calendar'
 
 jest.mock('@/lib/calendar', () => ({
   getCalendars: jest.fn(),
@@ -68,5 +69,52 @@ describe('useCalendars', () => {
 
     expect(result.current.calendars).toEqual([])
     expect(result.current.loading).toBe(true)
+  })
+
+  it('가족 전환 직후에는 이전 가족 캘린더를 노출하지 않는다', async () => {
+    const firstFamilyCalendars = [{ id: 'cal-1', name: '가족 1', color: '#f97316', family_id: 'fam-1', created_by: 'user-1', created_at: '', updated_at: '' }]
+    const secondFamilyCalendars = [{ id: 'cal-2', name: '가족 2', color: '#3b82f6', family_id: 'fam-2', created_by: 'user-2', created_at: '', updated_at: '' }]
+    let resolveSecond: (value: typeof firstFamilyCalendars) => void = () => undefined
+
+    mockGetCalendars.mockImplementation((familyId) => {
+      if (familyId === 'fam-1') return Promise.resolve(firstFamilyCalendars)
+      return new Promise((resolve) => {
+        resolveSecond = resolve
+      })
+    })
+
+    const { result, rerender } = renderHook(({ familyId }) => useCalendars(familyId), {
+      initialProps: { familyId: 'fam-1' as string | null },
+    })
+    await waitFor(() => expect(result.current.calendars).toEqual(firstFamilyCalendars))
+
+    rerender({ familyId: 'fam-2' })
+    expect(result.current.calendars).toEqual([])
+    expect(result.current.loading).toBe(true)
+
+    resolveSecond(secondFamilyCalendars)
+    await waitFor(() => expect(result.current.calendars).toEqual(secondFamilyCalendars))
+  })
+
+  it('가족 전환 직후에는 이전 가족의 로드 오류를 노출하지 않는다', async () => {
+    let resolveSecond: (value: Calendar[]) => void = () => undefined
+    mockGetCalendars.mockImplementation((familyId) => {
+      if (familyId === 'fam-1') return Promise.reject(new Error('family 1 failed'))
+      return new Promise((resolve) => {
+        resolveSecond = resolve
+      })
+    })
+
+    const { result, rerender } = renderHook(({ familyId }) => useCalendars(familyId), {
+      initialProps: { familyId: 'fam-1' },
+    })
+    await waitFor(() => expect(result.current.error).toEqual(expect.any(Error)))
+
+    rerender({ familyId: 'fam-2' })
+    expect(result.current.error).toBeNull()
+    expect(result.current.loading).toBe(true)
+
+    resolveSecond([])
+    await waitFor(() => expect(result.current.loading).toBe(false))
   })
 })

--- a/src/__tests__/lib/api-auth.test.ts
+++ b/src/__tests__/lib/api-auth.test.ts
@@ -3,6 +3,7 @@
  */
 import { NextRequest } from 'next/server'
 import {
+  getAllowedAppRole,
   getAuthenticatedSessionUser,
   getAuthenticatedUser,
   isAppAdmin,
@@ -87,5 +88,14 @@ describe('api-auth helpers', () => {
     }))
 
     await expect(isAppAdmin('admin@example.com')).resolves.toBe(true)
+  })
+
+  it('getAllowedAppRole은 허용된 사용자의 역할을 반환한다', async () => {
+    mockFrom.mockReturnValue(makeAllowedEmailChain({
+      data: { app_role: 'admin' },
+      error: null,
+    }))
+
+    await expect(getAllowedAppRole('ADMIN@EXAMPLE.COM')).resolves.toBe('admin')
   })
 })

--- a/src/app/api/family/me/route.ts
+++ b/src/app/api/family/me/route.ts
@@ -1,21 +1,31 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { getAuthenticatedUser } from '@/lib/api-auth'
+import { getAllowedAppRole, getAuthenticatedSessionUser } from '@/lib/api-auth'
 import { supabaseAdmin } from '@/lib/supabase-admin'
 
 export async function POST(req: NextRequest) {
-  const authUser = await getAuthenticatedUser(req)
+  const authUser = await getAuthenticatedSessionUser(req)
   if (!authUser) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  const [{ data: familyId, error: familyError }, { data: emailRecord }] = await Promise.all([
-    supabaseAdmin.rpc('get_my_family', { p_user_id: authUser.id }),
-    supabaseAdmin
-      .from('allowed_emails')
-      .select('app_role')
-      .eq('email', authUser.email.toLowerCase())
-      .maybeSingle(),
-  ])
+  let familyResult: Awaited<ReturnType<typeof supabaseAdmin.rpc>>
+  let appRole: 'admin' | 'member' | null
+
+  try {
+    ;[familyResult, appRole] = await Promise.all([
+      supabaseAdmin.rpc('get_my_family', { p_user_id: authUser.id }),
+      getAllowedAppRole(authUser.email),
+    ])
+  } catch (error) {
+    console.error('[API /family/me] bootstrap lookup failed:', error)
+    return NextResponse.json({ error: 'DB error' }, { status: 500 })
+  }
+
+  if (!appRole) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { data: familyId, error: familyError } = familyResult
 
   if (familyError) {
     console.error('[API /family/me] get_my_family error:', familyError)
@@ -24,6 +34,6 @@ export async function POST(req: NextRequest) {
 
   return NextResponse.json({
     familyId: familyId ?? null,
-    appRole: emailRecord?.app_role ?? 'member',
+    appRole,
   })
 }

--- a/src/components/TabsShell.tsx
+++ b/src/components/TabsShell.tsx
@@ -64,9 +64,8 @@ export function TabsShell() {
     reload: reloadCalendars,
   } = useCalendars(familyId)
   const { preferences, updatePreferences } = useUserPreferences(user)
-  const shouldLoadCalendars = Boolean(familyId) && !familyError
-  const isInitializing = authLoading || familyLoading || (shouldLoadCalendars && calendarsLoading)
-  const startupError = !isInitializing ? (familyError || calendarsError) : null
+  const isInitializing = authLoading || familyLoading
+  const startupError = !isInitializing ? familyError : null
 
   // 인증됨 + 앱 접근권 있음 + 아직 가족 없음 → 온보딩 필요
   // familyError가 있으면 DB 장애로 판단, 온보딩으로 잘못 보내지 않는다
@@ -189,6 +188,7 @@ export function TabsShell() {
             familyId={familyId}
             isInitializing={isInitializing}
             calendars={calendars}
+            calendarsLoading={calendarsLoading}
             calendarsError={calendarsError}
             reloadCalendars={reloadCalendars}
           />

--- a/src/components/calendar/CalendarFilter.tsx
+++ b/src/components/calendar/CalendarFilter.tsx
@@ -9,13 +9,14 @@ const LONG_PRESS_MS = 500
 
 interface Props {
   calendars: Calendar[]
+  loading?: boolean
   activeIds: Set<string>
   onToggle: (id: string) => void
   onAdd: () => void
   onEdit: (calendar: Calendar) => void
 }
 
-export function CalendarFilter({ calendars, activeIds, onToggle, onAdd, onEdit }: Props) {
+export function CalendarFilter({ calendars, loading = false, activeIds, onToggle, onAdd, onEdit }: Props) {
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const didLongPressRef = useRef(false)
 
@@ -34,6 +35,24 @@ export function CalendarFilter({ calendars, activeIds, onToggle, onAdd, onEdit }
   const handleClick = (cal: Calendar) => {
     if (didLongPressRef.current) return
     onToggle(cal.id)
+  }
+
+  if (loading) {
+    return (
+      <div
+        className="flex h-8 items-center gap-2 overflow-hidden pb-1"
+        role="status"
+        aria-label="캘린더 목록을 불러오는 중"
+      >
+        {[72, 60, 84].map((width) => (
+          <span
+            key={width}
+            className="h-7 shrink-0 animate-pulse rounded-full bg-stone-100 dark:bg-stone-800"
+            style={{ width }}
+          />
+        ))}
+      </div>
+    )
   }
 
   return (

--- a/src/components/tabs/CalendarTab.tsx
+++ b/src/components/tabs/CalendarTab.tsx
@@ -32,6 +32,7 @@ interface Props extends AuthState {
   preferences: UserPreferences | null
   updatePreferences: (updates: Partial<Omit<UserPreferences, 'user_id' | 'created_at' | 'updated_at'>>) => Promise<void>
   calendars: Calendar[]
+  calendarsLoading: boolean
   calendarsError: unknown
   reloadCalendars: () => Promise<unknown>
 }
@@ -161,6 +162,7 @@ export function CalendarTab({
   user,
   familyId,
   calendars,
+  calendarsLoading,
   calendarsError,
   reloadCalendars,
 }: Props) {
@@ -169,6 +171,7 @@ export function CalendarTab({
   const [month, setMonth] = useState(today.getMonth())
 
   const holidays = useHolidays(year, month, preferences?.holiday_countries ?? [])
+  const calendarContextReady = !calendarsLoading && !calendarsError
   const [activeIds, setActiveIds] = useState<Set<string>>(new Set())
 
   const [selectedDate, setSelectedDate] = useState<Date | null>(null)
@@ -1028,6 +1031,7 @@ export function CalendarTab({
           <div className="flex-1 min-w-0">
             <CalendarFilter
               calendars={calendars}
+              loading={calendarsLoading}
               activeIds={activeIds}
               onToggle={toggleCalendar}
               onAdd={() => openCalendarForm()}
@@ -1036,7 +1040,8 @@ export function CalendarTab({
           </div>
           <button
             onClick={() => void openCalendarList()}
-            className="shrink-0 p-1.5 text-stone-400 hover:text-stone-600 dark:hover:text-stone-300"
+            disabled={!calendarContextReady}
+            className="shrink-0 p-1.5 text-stone-400 hover:text-stone-600 disabled:cursor-default disabled:opacity-40 dark:hover:text-stone-300"
             aria-label="캘린더 리스트"
           >
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -1079,6 +1084,7 @@ export function CalendarTab({
           holidays={holidays}
           selectedDate={selectedDate}
           onSelectDate={(date) => {
+            if (!calendarContextReady) return
             setSelectedDate((prev) =>
               prev?.toDateString() === date.toDateString() ? null : date
             )
@@ -1091,7 +1097,8 @@ export function CalendarTab({
       <button
         aria-label="일정 추가"
         onClick={() => setEditingEvent({ date: selectedDate ?? today })}
-        className="absolute right-4 bottom-4 w-11 h-11 rounded-full bg-accent-400 hover:bg-accent-500 text-white shadow-lg flex items-center justify-center transition-colors z-30"
+        disabled={!calendarContextReady}
+        className="absolute right-4 bottom-4 w-11 h-11 rounded-full bg-accent-400 hover:bg-accent-500 disabled:cursor-default disabled:bg-stone-300 disabled:shadow-none dark:disabled:bg-stone-700 text-white shadow-lg flex items-center justify-center transition-colors z-30"
       >
         <Plus size={18} />
       </button>

--- a/src/hooks/useCalendars.ts
+++ b/src/hooks/useCalendars.ts
@@ -2,22 +2,39 @@
 
 import { getCalendars, type Calendar } from '@/lib/calendar'
 import { useAsyncData } from '@/hooks/useAsyncData'
+import { useState } from 'react'
 
 export function useCalendars(familyId: string | null) {
-  const { value: calendars, loading, error, reload } = useAsyncData<Calendar[]>({
+  const [errorFamilyId, setErrorFamilyId] = useState<string | null>(null)
+  const { value, loading, error, reload } = useAsyncData<{
+    familyId: string | null
+    calendars: Calendar[]
+  }>({
     enabled: Boolean(familyId),
-    initialValue: [],
+    initialValue: { familyId: null, calendars: [] },
     reloadKey: familyId,
-    load: () => getCalendars(familyId!),
+    load: async () => ({
+      familyId,
+      calendars: await getCalendars(familyId!),
+    }),
+    onSuccess: () => {
+      setErrorFamilyId(null)
+    },
     onError: (e) => {
+      setErrorFamilyId(familyId)
       console.error('[useCalendars] fetch failed:', e)
     },
   })
 
+  const hasCurrentFamilyData = Boolean(familyId) && value.familyId === familyId
+  const currentError = errorFamilyId === familyId ? error : null
+
   return {
-    calendars,
-    loading,
-    error,
+    calendars: hasCurrentFamilyData ? value.calendars : [],
+    loading: familyId
+      ? loading || (!hasCurrentFamilyData && !currentError)
+      : true,
+    error: currentError,
     reload,
   }
 }

--- a/src/lib/api-auth.ts
+++ b/src/lib/api-auth.ts
@@ -43,9 +43,14 @@ async function getAllowedEmailRecord(email: string): Promise<{ app_role: string 
   return data
 }
 
-export async function isAppAdmin(email: string): Promise<boolean> {
+export async function getAllowedAppRole(email: string): Promise<'admin' | 'member' | null> {
   const record = await getAllowedEmailRecord(email)
-  return record?.app_role === 'admin'
+  if (!record) return null
+  return record.app_role === 'admin' ? 'admin' : 'member'
+}
+
+export async function isAppAdmin(email: string): Promise<boolean> {
+  return await getAllowedAppRole(email) === 'admin'
 }
 
 export async function getAuthenticatedSessionUser(
@@ -74,8 +79,8 @@ export async function getAuthenticatedUser(
   const user = await getAuthenticatedSessionUser(req)
   if (!user) return null
 
-  const allowedEmail = await getAllowedEmailRecord(user.email)
-  if (!allowedEmail) return null
+  const appRole = await getAllowedAppRole(user.email)
+  if (!appRole) return null
 
   return user
 }


### PR DESCRIPTION
## Summary
- 가족 bootstrap API에서 allowlist 역할 조회와 가족 조회를 병렬로 시작하고, 중복 allowlist 조회를 제거했습니다.
- 앱 전체 splash는 인증과 가족 확인까지만 유지하고 캘린더 목록 로딩을 기다리지 않도록 변경했습니다.
- 가족 확인 후 캘린더 셸과 하단 탭을 먼저 표시해 캘린더 목록과 일정 조회가 병렬로 진행되도록 했습니다.
- 캘린더 목록 로딩 중에는 필터 placeholder를 표시하고, 캘린더 목록·일정 생성처럼 목록에 의존하는 조작만 비활성화했습니다.
- 캘린더 목록 실패를 앱 전체 시작 실패에서 캘린더 탭 내부 오류로 격리해 리마인더와 설정 탭은 계속 사용할 수 있습니다.
- 가족 전환 시 이전 가족의 캘린더 데이터나 오류가 새 가족 화면에 잠깐 노출되지 않도록 상태를 familyId에 귀속했습니다.

## 사용자 관점 변화
- 기존: splash가 인증 → 가족 → 캘린더 목록 로딩이 모두 끝날 때까지 유지되고, 그 뒤 캘린더와 일정 로딩이 시작됩니다.
- 변경: 인증과 가족 확인이 끝나면 빈 캘린더 골격과 하단 탭이 먼저 보입니다. 캘린더 필터는 placeholder로 표시되고 일정·필터·휴일이 각 응답 순서대로 채워집니다.
- 캘린더 목록을 불러오는 짧은 동안 일정 추가와 캘린더 관리 버튼은 비활성화되며, 준비되면 자동으로 활성화됩니다.
- 캘린더 목록 조회만 실패한 경우 캘린더 탭에 재시도 화면이 표시되지만 리마인더·설정 탭 접근은 막히지 않습니다.

## Testing
- `npm run test -- --runInBand` (68 suites, 698 tests passed)
- `npx tsc --noEmit`
- `npm run lint`
- `git diff --check`
- 캘린더 로딩 중 조작 차단, 캘린더 오류 격리, 가족 전환 stale 데이터·오류 방어, 가족/allowlist 병렬 시작 테스트 추가