### PR TITLE
perf: fetch visible event range once

### DIFF
--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -74,8 +74,8 @@ DB migration -> src/types/database.ts -> src/lib/* -> src/hooks/* -> src/app/* -
 
 ## 6. Calendar Patterns
 
-- 월 이벤트 조회는 `getEventsByMonth(familyId, year, month)`처럼 month window 단위로 제한한다.
-- 현재 월 외에도 인접 월 prefetch를 허용하지만, cache는 유한 크기로 유지한다.
+- 이벤트 조회는 `getEventsByRange(familyId, start, endExclusive)`로 현재 캘린더 그리드에 보이는 날짜 범위만 요청한다.
+- 표시 범위 cache는 유한 크기로 유지하고, 강제 갱신 시 이전 in-flight 결과가 최신 상태를 덮어쓰지 않게 한다.
 - `events.calendar_id = null`은 가족 전체 일정이다.
 - 캘린더 생성 시 owner 멤버를 먼저 insert하고 일반 멤버를 그 다음에 넣는다.
 - 캘린더 멤버 수정은 "owner 유지 + 나머지 전체 교체" 패턴으로 다룬다.

--- a/docs/PROJECT_MAP.md
+++ b/docs/PROJECT_MAP.md
@@ -138,7 +138,7 @@ Current behavior:
   - `src/components/calendar/YearMonthPickerSheet.tsx`
 
 Current behavior:
-- 월 단위로 이벤트를 로드하고 인접 월을 prefetch한다.
+- 캘린더 그리드에 표시되는 전체 날짜 범위의 이벤트를 한 번에 로드한다.
 - 월 이벤트 캐시는 최대 12개월까지 유지된다.
 - 가족 전체 일정과 캘린더 전용 일정을 함께 지원한다.
 - 캘린더 생성/수정/삭제와 멤버 관리가 가능하다.

--- a/src/__tests__/components/CalendarTab.adjacent-events.test.tsx
+++ b/src/__tests__/components/CalendarTab.adjacent-events.test.tsx
@@ -1,7 +1,7 @@
 import { render, act, waitFor, fireEvent } from '@testing-library/react'
 import type { User } from '@supabase/supabase-js'
 import { CalendarTab } from '@/components/tabs/CalendarTab'
-import { getEventsByMonth } from '@/lib/calendar'
+import { getEventsByRange } from '@/lib/calendar'
 
 const FIXED_NOW = new Date('2026-04-18T12:00:00Z')
 const RealDate = Date
@@ -18,6 +18,26 @@ class MockDate extends Date {
     }
     if (args.length === 1) {
       super(args[0])
+      return
+    }
+    if (args.length === 2) {
+      super(args[0], args[1])
+      return
+    }
+    if (args.length === 3) {
+      super(args[0], args[1], args[2])
+      return
+    }
+    if (args.length === 4) {
+      super(args[0], args[1], args[2], args[3])
+      return
+    }
+    if (args.length === 5) {
+      super(args[0], args[1], args[2], args[3], args[4])
+      return
+    }
+    if (args.length === 6) {
+      super(args[0], args[1], args[2], args[3], args[4], args[5])
       return
     }
     super(args[0], args[1], args[2], args[3], args[4], args[5], args[6])
@@ -59,9 +79,15 @@ jest.mock('@/lib/supabase', () => ({
 }))
 
 let capturedRefresh: (() => Promise<void>) | null = null
+let capturedRealtimeOptions: { refreshOnSubscribed?: boolean } | undefined
 jest.mock('@/hooks/useRealtimeSync', () => ({
-  useRealtimeSync: (_channel: unknown, refresh: () => Promise<void>) => {
+  useRealtimeSync: (
+    _channel: unknown,
+    refresh: () => Promise<void>,
+    options?: { refreshOnSubscribed?: boolean }
+  ) => {
     capturedRefresh = refresh
+    capturedRealtimeOptions = options
     return jest.fn()
   },
 }))
@@ -79,7 +105,7 @@ jest.mock('@/lib/api-client', () => ({
   deleteWithAuth: jest.fn().mockResolvedValue(undefined),
 }))
 jest.mock('@/lib/calendar', () => ({
-  getEventsByMonth: jest.fn().mockResolvedValue([]),
+  getEventsByRange: jest.fn().mockResolvedValue([]),
   createCalendar: jest.fn(),
   updateCalendar: jest.fn(),
   deleteCalendar: jest.fn(),
@@ -96,7 +122,7 @@ jest.mock('@/lib/calendar', () => ({
   REMINDER_OPTIONS: [],
 }))
 
-const mockGetEventsByMonth = getEventsByMonth as jest.MockedFunction<typeof getEventsByMonth>
+const mockGetEventsByRange = getEventsByRange as jest.MockedFunction<typeof getEventsByRange>
 
 function makeEvent(id: string, startAt: string) {
   return {
@@ -134,6 +160,7 @@ beforeEach(() => {
   global.Date = MockDate as DateConstructor
   jest.clearAllMocks()
   capturedRefresh = null
+  capturedRealtimeOptions = undefined
   jest.spyOn(console, 'error').mockImplementation(() => {})
 })
 
@@ -142,20 +169,14 @@ afterEach(() => {
   jest.restoreAllMocks()
 })
 
-// today = 2026-04-18, so current month = April (month index 3)
-// prev = March (2), next = May (4)
-describe('CalendarTab — 인접 월 이벤트 표시', () => {
-  it('현재 월 이벤트와 전월/다음월 이벤트가 모두 CalendarGrid 에 전달된다', async () => {
+// today = 2026-04-18, so April grid spans March 29 through May 2.
+describe('CalendarTab — 표시 범위 이벤트 조회', () => {
+  it('현재 월과 전월/다음월 셀 이벤트를 한 번의 범위 조회로 표시한다', async () => {
     const currentEvent = makeEvent('curr-1', '2026-04-15T09:00:00Z') // April
     const prevEvent    = makeEvent('prev-1', '2026-03-29T09:00:00Z') // March
     const nextEvent    = makeEvent('next-1', '2026-05-01T09:00:00Z') // May
 
-    mockGetEventsByMonth.mockImplementation((_fid, _year, month) => {
-      if (month === 3) return Promise.resolve([currentEvent]) // April
-      if (month === 2) return Promise.resolve([prevEvent])    // March
-      if (month === 4) return Promise.resolve([nextEvent])    // May
-      return Promise.resolve([])
-    })
+    mockGetEventsByRange.mockResolvedValue([currentEvent, prevEvent, nextEvent])
 
     const { getByTestId } = render(<CalendarTab {...defaultProps} />)
 
@@ -165,96 +186,67 @@ describe('CalendarTab — 인접 월 이벤트 표시', () => {
       expect(ids).toContain('prev-1')
       expect(ids).toContain('next-1')
     }, { timeout: 3000 })
+    expect(mockGetEventsByRange).toHaveBeenCalledTimes(1)
+
+    const [, start, endExclusive] = mockGetEventsByRange.mock.calls[0]
+    expect([start.getFullYear(), start.getMonth(), start.getDate()]).toEqual([2026, 2, 29])
+    expect([endExclusive.getFullYear(), endExclusive.getMonth(), endExclusive.getDate()]).toEqual([2026, 4, 3])
   })
 
-  it('같은 id 이벤트는 mergedEvents 에서 중복 없이 한 번만 포함된다', async () => {
-    const event = makeEvent('dup-1', '2026-04-15T09:00:00Z')
-    mockGetEventsByMonth.mockResolvedValue([event])
-
-    const { getByTestId } = render(<CalendarTab {...defaultProps} />)
-
-    await waitFor(() => {
-      const ids = (getByTestId('calendar-grid').getAttribute('data-event-ids') ?? '')
-        .split(',').filter(Boolean)
-      expect(ids.filter((id) => id === 'dup-1')).toHaveLength(1)
-    }, { timeout: 3000 })
-  })
-
-  it('다음 달로 이동 후 이전 달의 stale adjacentMonthEvents 가 현재 뷰를 덮어쓰지 않는다', async () => {
-    // April 뷰에서 March fetch 가 지연되는 상황
+  it('다음 달로 이동한 뒤 이전 표시 범위의 늦은 응답을 무시한다', async () => {
     const aprilEvent = makeEvent('apr-1', '2026-04-15T09:00:00Z')
-    const marchEvent = makeEvent('mar-1', '2026-03-29T09:00:00Z') // April 기준 전월
     const mayEvent   = makeEvent('may-1', '2026-05-10T09:00:00Z')
-    const juneEvent  = makeEvent('jun-1', '2026-06-01T09:00:00Z') // May 기준 다음월
 
-    let resolveMarch!: (v: ReturnType<typeof makeEvent>[]) => void
-    const marchPromise = new Promise<ReturnType<typeof makeEvent>[]>((res) => { resolveMarch = res })
-
-    mockGetEventsByMonth.mockImplementation((_fid, _year, month) => {
-      if (month === 3) return Promise.resolve([aprilEvent])
-      if (month === 2) return marchPromise              // March 지연 (April 의 인접 월)
-      if (month === 4) return Promise.resolve([mayEvent])
-      if (month === 5) return Promise.resolve([juneEvent])
-      return Promise.resolve([])
+    let resolveApril!: (value: ReturnType<typeof makeEvent>[]) => void
+    const aprilPromise = new Promise<ReturnType<typeof makeEvent>[]>((resolve) => {
+      resolveApril = resolve
     })
 
+    mockGetEventsByRange
+      .mockReturnValueOnce(aprilPromise)
+      .mockResolvedValueOnce([mayEvent])
+
     const { getByTestId, getByRole } = render(<CalendarTab {...defaultProps} />)
-    await act(async () => {})
+    await waitFor(() => expect(mockGetEventsByRange).toHaveBeenCalledTimes(1))
 
-    // 다음 달(May)로 이동
     fireEvent.click(getByRole('button', { name: '다음 달' }))
-    await act(async () => {})
+    await waitFor(() => {
+      expect(getByTestId('calendar-grid')).toHaveAttribute('data-event-ids', 'may-1')
+    })
 
-    // April 기준 March fetch 완료 (이미 May 뷰 상태)
-    await act(async () => { resolveMarch([marchEvent]) })
-    await act(async () => {})
-
-    // race guard 가 동작해 March 이벤트가 May 뷰에 표시되면 안 됨
-    const ids = getByTestId('calendar-grid').getAttribute('data-event-ids') ?? ''
-    expect(ids).not.toContain('mar-1')
-    expect(ids).toContain('may-1')
+    await act(async () => { resolveApril([aprilEvent]) })
+    expect(getByTestId('calendar-grid')).toHaveAttribute('data-event-ids', 'may-1')
   })
 })
 
-describe('CalendarTab — refreshEvents 인접 월 invalidation', () => {
-  it('broadcast refresh 시 in-flight 상태의 인접 월 요청을 무효화하고 새로 fetch한다', async () => {
-    // today = April (month=3). prev = March (2), next = May (4)
-    const aprilEvent = makeEvent('apr-1', '2026-04-15T09:00:00Z')
-    const marchFresh = makeEvent('mar-fresh', '2026-03-28T09:00:00Z')
+describe('CalendarTab — Realtime 강제 갱신', () => {
+  it('구독 성립 시 gap 보정 갱신을 비활성화하지 않는다', () => {
+    render(<CalendarTab {...defaultProps} />)
 
-    let marchCallCount = 0
-    mockGetEventsByMonth.mockImplementation((_fid, _year, month) => {
-      if (month === 3) return Promise.resolve([aprilEvent])
-      if (month === 2) {
-        marchCallCount++
-        if (marchCallCount === 1) {
-          // 1st call: never resolves — stays in-flight during refresh
-          return new Promise(() => {})
-        }
-        // 2nd call (after invalidation): resolves with fresh data
-        return Promise.resolve([marchFresh])
-      }
-      return Promise.resolve([])
-    })
+    expect(capturedRealtimeOptions?.refreshOnSubscribed).not.toBe(false)
+  })
+
+  it('broadcast refresh가 기존 요청을 대체하고 기존 응답의 stale commit을 막는다', async () => {
+    const staleEvent = makeEvent('stale', '2026-04-15T09:00:00Z')
+    const freshEvent = makeEvent('fresh', '2026-04-16T09:00:00Z')
+    let resolveInitial!: (value: ReturnType<typeof makeEvent>[]) => void
+
+    mockGetEventsByRange.mockImplementationOnce(() => new Promise((resolve) => {
+      resolveInitial = resolve
+    })).mockResolvedValueOnce([freshEvent])
 
     const { getByTestId } = render(<CalendarTab {...defaultProps} />)
-    await act(async () => {})
+    await waitFor(() => expect(mockGetEventsByRange).toHaveBeenCalledTimes(1))
 
-    // 초기 prefetch: March 1st call이 in-flight 상태 (resolve 안 됨)
-    expect(marchCallCount).toBe(1)
-
-    // broadcast refresh 트리거 — March in-flight 이 resolve되기 전에 실행
     expect(capturedRefresh).not.toBeNull()
     await act(async () => { await capturedRefresh!() })
 
-    // refreshEvents가 monthEventsRequestsRef 에서 March를 제거했으므로
-    // prefetchAdjacentMonths가 새 fetch를 시작해야 함
-    expect(marchCallCount).toBe(2)
+    expect(mockGetEventsByRange).toHaveBeenCalledTimes(2)
+    expect(getByTestId('calendar-grid')).toHaveAttribute('data-event-ids', 'fresh')
 
-    // 새 fetch의 fresh 데이터가 표시돼야 함
-    await waitFor(() => {
-      const ids = getByTestId('calendar-grid').getAttribute('data-event-ids') ?? ''
-      expect(ids).toContain('mar-fresh')
-    }, { timeout: 3000 })
+    await act(async () => {
+      resolveInitial([staleEvent])
+    })
+    expect(getByTestId('calendar-grid')).toHaveAttribute('data-event-ids', 'fresh')
   })
 })

--- a/src/__tests__/components/CalendarTab.picker.integration.test.tsx
+++ b/src/__tests__/components/CalendarTab.picker.integration.test.tsx
@@ -14,7 +14,7 @@ jest.mock('@/hooks/useHolidays', () => ({
   useHolidays: () => [],
 }))
 jest.mock('@/lib/calendar', () => ({
-  getEventsByMonth: jest.fn().mockResolvedValue([]),
+  getEventsByRange: jest.fn().mockResolvedValue([]),
   createCalendar: jest.fn(),
   updateCalendar: jest.fn(),
   deleteCalendar: jest.fn(),

--- a/src/__tests__/components/CalendarTab.test.tsx
+++ b/src/__tests__/components/CalendarTab.test.tsx
@@ -1,7 +1,7 @@
 import { render, act, fireEvent, screen, waitFor } from '@testing-library/react'
 import type { User } from '@supabase/supabase-js'
 import { CalendarTab } from '@/components/tabs/CalendarTab'
-import { getCalendarMembers, getEventsByMonth, getFamilyMembers, getRecurrenceRule, setCalendarMembers, updateCalendar } from '@/lib/calendar'
+import { getCalendarMembers, getEventsByRange, getFamilyMembers, getRecurrenceRule, setCalendarMembers, updateCalendar } from '@/lib/calendar'
 import { deleteWithAuth, patchJsonWithAuth } from '@/lib/api-client'
 
 // ── 의존성 모킹 ──────────────────────────────────────────────
@@ -13,7 +13,7 @@ jest.mock('@/hooks/useHolidays', () => ({
   useHolidays: () => [],
 }))
 jest.mock('@/lib/calendar', () => ({
-  getEventsByMonth: jest.fn().mockResolvedValue([]),
+  getEventsByRange: jest.fn().mockResolvedValue([]),
   createCalendar: jest.fn(),
   updateCalendar: jest.fn(),
   deleteCalendar: jest.fn(),
@@ -235,7 +235,7 @@ jest.mock('@/components/calendar/YearMonthPickerSheet', () => ({
   ),
 }))
 
-const mockGetEventsByMonth = getEventsByMonth as jest.MockedFunction<typeof getEventsByMonth>
+const mockGetEventsByRange = getEventsByRange as jest.MockedFunction<typeof getEventsByRange>
 const mockGetFamilyMembers = getFamilyMembers as jest.MockedFunction<typeof getFamilyMembers>
 const mockGetCalendarMembers = getCalendarMembers as jest.MockedFunction<typeof getCalendarMembers>
 const mockGetRecurrenceRule = getRecurrenceRule as jest.MockedFunction<typeof getRecurrenceRule>
@@ -281,7 +281,7 @@ describe('CalendarTab — touch-action 스크롤 차단', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-    mockGetEventsByMonth.mockResolvedValue([])
+    mockGetEventsByRange.mockResolvedValue([])
     mockGetFamilyMembers.mockResolvedValue([])
     mockGetCalendarMembers.mockResolvedValue([])
     mockGetRecurrenceRule.mockResolvedValue({ freq: 'weekly', interval: 1, daysOfWeek: [5] })
@@ -316,13 +316,7 @@ describe('CalendarTab — touch-action 스크롤 차단', () => {
     expect(header.className).not.toContain('pt-8')
   })
 
-  it('broadcast 수신 시 인접하지 않은 달의 캐시도 무효화하여 재탐색 시 새로 불러온다', async () => {
-    const today = new Date()
-    const y = today.getFullYear()
-    const m = today.getMonth()
-    let farYear = y, farMonth = m + 2
-    if (farMonth > 11) { farYear += 1; farMonth -= 12 }
-
+  it('broadcast 수신 시 다른 표시 범위의 캐시도 무효화하여 재탐색 시 새로 불러온다', async () => {
     let broadcastCb: (() => void) | undefined
     const { supabase: mockSupabase } = jest.requireMock('@/lib/supabase') as {
       supabase: { channel: jest.Mock }
@@ -352,20 +346,16 @@ describe('CalendarTab — touch-action 스크롤 차단', () => {
     fireEvent.click(screen.getByRole('button', { name: '이전 달' }))
     await act(async () => {})
 
-    const callsBefore = mockGetEventsByMonth.mock.calls.filter(
-      ([, ey, em]) => ey === farYear && em === farMonth
-    ).length
+    const callsBefore = mockGetEventsByRange.mock.calls.length
 
     // broadcast 수신 → 전체 캐시 무효화
     await act(async () => { broadcastCb?.() })
 
-    // month+1로 이동 (이때 month+2 prefetch 발생)
+    // month+1로 이동
     fireEvent.click(screen.getByRole('button', { name: '다음 달' }))
     await act(async () => {})
 
-    const callsAfter = mockGetEventsByMonth.mock.calls.filter(
-      ([, ey, em]) => ey === farYear && em === farMonth
-    ).length
+    const callsAfter = mockGetEventsByRange.mock.calls.length
 
     // 캐시가 무효화됐으므로 broadcast 후 재탐색 시 새로 불러온 횟수가 증가해야 한다
     expect(callsAfter).toBeGreaterThan(callsBefore)
@@ -395,7 +385,7 @@ describe('CalendarTab — touch-action 스크롤 차단', () => {
   })
 
   it('초기 이벤트 로드 실패 시 전체 스피너 대신 오류 배너와 캘린더 그리드를 유지한다', async () => {
-    mockGetEventsByMonth.mockRejectedValue(new Error('load failed'))
+    mockGetEventsByRange.mockRejectedValue(new Error('load failed'))
 
     render(<CalendarTab {...defaultProps} />)
 
@@ -516,7 +506,7 @@ describe('CalendarTab — touch-action 스크롤 차단', () => {
   })
 
   it('재시도 버튼 클릭 시 캘린더 데이터를 다시 불러온다', async () => {
-    mockGetEventsByMonth
+    mockGetEventsByRange
       .mockRejectedValueOnce(new Error('load failed'))
       .mockResolvedValue([])
 
@@ -526,7 +516,7 @@ describe('CalendarTab — touch-action 스크롤 차단', () => {
     fireEvent.click(retryButton)
 
     await waitFor(() => expect(mockReloadCalendars).toHaveBeenCalled())
-    await waitFor(() => expect(mockGetEventsByMonth).toHaveBeenCalledTimes(4))
+    await waitFor(() => expect(mockGetEventsByRange).toHaveBeenCalledTimes(2))
     await waitFor(() => expect(screen.getByTestId('calendar-grid')).toBeInTheDocument())
   })
 
@@ -598,17 +588,12 @@ describe('CalendarTab — touch-action 스크롤 차단', () => {
     const initialMonth = today.getMonth()
     const nextYear = initialMonth === 11 ? initialYear + 1 : initialYear
     const nextMonth = initialMonth === 11 ? 0 : initialMonth + 1
-    const monthAfterNextYear = nextMonth === 11 ? nextYear + 1 : nextYear
-    const monthAfterNext = nextMonth === 11 ? 0 : nextMonth + 1
     let resolvePrefetch: ((value: []) => void) | null = null
-    mockGetEventsByMonth.mockImplementation(async (_familyId, year, month) => {
-      if (year === monthAfterNextYear && month === monthAfterNext) {
-        return new Promise((resolve) => {
-          resolvePrefetch = resolve as (value: []) => void
-        })
-      }
-      return []
-    })
+    mockGetEventsByRange
+      .mockResolvedValueOnce([])
+      .mockImplementation(() => new Promise((resolve) => {
+        resolvePrefetch = resolve as (value: []) => void
+      }))
 
     render(<CalendarTab {...defaultProps} />)
 
@@ -710,7 +695,7 @@ describe('CalendarTab — 캘린더 필터 localStorage 복원', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     localStorage.clear()
-    mockGetEventsByMonth.mockResolvedValue([])
+    mockGetEventsByRange.mockResolvedValue([])
     mockGetFamilyMembers.mockResolvedValue([])
     mockGetCalendarMembers.mockResolvedValue([])
   })
@@ -778,7 +763,7 @@ describe('CalendarTab — handleCalendarUpdate', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-    mockGetEventsByMonth.mockResolvedValue([])
+    mockGetEventsByRange.mockResolvedValue([])
     mockGetFamilyMembers.mockResolvedValue([])
     mockGetCalendarMembers.mockResolvedValue([])
     mockUpdateCalendar.mockResolvedValue(undefined)

--- a/src/__tests__/lib/calendar-grid.test.ts
+++ b/src/__tests__/lib/calendar-grid.test.ts
@@ -1,0 +1,26 @@
+import { buildCalendarGrid, getCalendarGridRange } from '@/lib/calendar-grid'
+
+describe('calendar grid range', () => {
+  it('5행 월의 전월·다음월 셀을 포함한 반개방 범위를 반환한다', () => {
+    const { start, endExclusive } = getCalendarGridRange(2026, 3)
+
+    expect([start.getFullYear(), start.getMonth(), start.getDate()]).toEqual([2026, 2, 29])
+    expect([endExclusive.getFullYear(), endExclusive.getMonth(), endExclusive.getDate()]).toEqual([2026, 4, 3])
+    expect(buildCalendarGrid(2026, 3)).toHaveLength(35)
+  })
+
+  it('6행 월의 마지막 주까지 범위에 포함한다', () => {
+    const { start, endExclusive } = getCalendarGridRange(2026, 4)
+
+    expect([start.getFullYear(), start.getMonth(), start.getDate()]).toEqual([2026, 3, 26])
+    expect([endExclusive.getFullYear(), endExclusive.getMonth(), endExclusive.getDate()]).toEqual([2026, 5, 7])
+    expect(buildCalendarGrid(2026, 4)).toHaveLength(42)
+  })
+
+  it('연도 경계의 인접 월 날짜를 보존한다', () => {
+    const { start, endExclusive } = getCalendarGridRange(2026, 0)
+
+    expect(start.getFullYear()).toBe(2025)
+    expect(endExclusive.getFullYear()).toBe(2026)
+  })
+})

--- a/src/__tests__/lib/calendar.test.ts
+++ b/src/__tests__/lib/calendar.test.ts
@@ -7,14 +7,14 @@ import {
   getCalendarMembersForCalendars,
   setCalendarMembers,
   getFamilyMembers,
-  getEventsByMonth,
+  getEventsByRange,
   getReminders,
 } from '@/lib/calendar'
 
 function makeChain(result: { data: unknown; error: unknown }) {
   const p = Promise.resolve(result)
   const chain: Record<string, unknown> = {}
-  ;['select', 'insert', 'update', 'delete', 'eq', 'neq', 'in', 'gte', 'lte', 'order'].forEach((m) => {
+  ;['select', 'insert', 'update', 'delete', 'eq', 'neq', 'in', 'gte', 'lte', 'lt', 'or', 'order'].forEach((m) => {
     chain[m] = jest.fn().mockReturnValue(chain)
   })
   chain.single = jest.fn().mockReturnValue(p)
@@ -217,25 +217,35 @@ describe('deleteCalendar', () => {
   })
 })
 
-// ── getEventsByMonth ──────────────────────────────────────
+// ── getEventsByRange ──────────────────────────────────────
 
-describe('getEventsByMonth', () => {
-  it('이벤트 목록을 반환한다', async () => {
+describe('getEventsByRange', () => {
+  const start = new Date(2026, 2, 29)
+  const endExclusive = new Date(2026, 4, 3)
+
+  it('표시 범위 이벤트 목록을 한 번의 overlap 쿼리로 반환한다', async () => {
     const mockData = [{ id: 'evt-1', title: '생일', start_at: '2026-03-15T00:00:00Z' }]
-    mockFrom.mockReturnValue(makeChain({ data: mockData, error: null }))
-    const result = await getEventsByMonth('fam-1', 2026, 2)
+    const chain = makeChain({ data: mockData, error: null })
+    mockFrom.mockReturnValue(chain)
+
+    const result = await getEventsByRange('fam-1', start, endExclusive)
+
     expect(result).toEqual(mockData)
     expect(mockFrom).toHaveBeenCalledWith('events')
+    expect(chain.lt).toHaveBeenCalledWith('start_at', endExclusive.toISOString())
+    expect(chain.or).toHaveBeenCalledWith(
+      `start_at.gte.${start.toISOString()},and(is_all_day.eq.true,end_at.gte.${start.toISOString()})`
+    )
   })
 
   it('data가 null이면 빈 배열을 반환한다', async () => {
     mockFrom.mockReturnValue(makeChain({ data: null, error: null }))
-    expect(await getEventsByMonth('fam-1', 2026, 2)).toEqual([])
+    expect(await getEventsByRange('fam-1', start, endExclusive)).toEqual([])
   })
 
   it('error가 있으면 throw한다', async () => {
     mockFrom.mockReturnValue(makeChain({ data: null, error: { message: 'fetch error' } }))
-    await expect(getEventsByMonth('fam-1', 2026, 2)).rejects.toEqual({ message: 'fetch error' })
+    await expect(getEventsByRange('fam-1', start, endExclusive)).rejects.toEqual({ message: 'fetch error' })
   })
 })
 
@@ -255,4 +265,3 @@ describe('getReminders', () => {
     expect(await getReminders('evt-1')).toEqual([])
   })
 })
-

--- a/src/components/calendar/CalendarGrid.tsx
+++ b/src/components/calendar/CalendarGrid.tsx
@@ -3,6 +3,7 @@
 import { type CSSProperties, useEffect, useMemo, useRef, useState } from 'react'
 import KoreanLunarCalendar from 'korean-lunar-calendar'
 import type { Calendar, CalendarEvent } from '@/lib/calendar'
+import { buildCalendarGrid, type CalendarDayCell as DayCell } from '@/lib/calendar-grid'
 import { toDisplayColor } from '@/lib/label-colors'
 import type { Holiday } from '@/types/holidays'
 
@@ -16,32 +17,7 @@ const CHIP_HEIGHT = 17        // text-[10px] leading-tight + py-0.5
 const CHIP_GAP = 2            // space-y-0.5
 const HOLIDAY_EVENT_GAP = 2
 
-interface DayCell {
-  date: Date
-  isCurrentMonth: boolean
-}
-
-export function buildGrid(year: number, month: number): DayCell[] {
-  const firstDay = new Date(year, month, 1)
-  const startDow = firstDay.getDay()
-  const daysInMonth = new Date(year, month + 1, 0).getDate()
-  const prevMonthLastDay = new Date(year, month, 0).getDate()
-  const rows = Math.ceil((startDow + daysInMonth) / 7)
-  const totalCells = rows * 7
-  const cells: DayCell[] = []
-
-  for (let i = startDow - 1; i >= 0; i--) {
-    cells.push({ date: new Date(year, month - 1, prevMonthLastDay - i), isCurrentMonth: false })
-  }
-  for (let d = 1; d <= daysInMonth; d++) {
-    cells.push({ date: new Date(year, month, d), isCurrentMonth: true })
-  }
-  const trailingDays = totalCells - cells.length
-  for (let d = 1; d <= trailingDays; d++) {
-    cells.push({ date: new Date(year, month + 1, d), isCurrentMonth: false })
-  }
-  return cells
-}
+export const buildGrid = buildCalendarGrid
 
 function isSameDay(a: Date, b: Date) {
   return (
@@ -331,7 +307,7 @@ export function CalendarGrid({
     height: 0,
     weekdayHeaderHeight: WEEKDAY_HEADER_HEIGHT,
   })
-  const cells = useMemo(() => buildGrid(year, month), [year, month])
+  const cells = useMemo(() => buildCalendarGrid(year, month), [year, month])
   const today = useMemo(() => new Date(), [])
   const calendarMap = useMemo(() => new Map(calendars.map((c) => [c.id, c])), [calendars])
 

--- a/src/components/tabs/CalendarTab.tsx
+++ b/src/components/tabs/CalendarTab.tsx
@@ -8,7 +8,7 @@ import { useHolidays } from '@/hooks/useHolidays'
 import type { UserPreferences } from '@/lib/preferences'
 import type { AuthState } from '@/types/tabs'
 import {
-  getEventsByMonth,
+  getEventsByRange,
   createCalendar,
   updateCalendar,
   deleteCalendar,
@@ -21,6 +21,7 @@ import {
   type FamilyMember,
   type SaveResult,
 } from '@/lib/calendar'
+import { getCalendarGridRange } from '@/lib/calendar-grid'
 import { CalendarFilter } from '@/components/calendar/CalendarFilter'
 import { CalendarGrid } from '@/components/calendar/CalendarGrid'
 import type { RecurrenceRule, RecurrenceScope } from '@/types/recurrence'
@@ -37,7 +38,7 @@ interface Props extends AuthState {
   reloadCalendars: () => Promise<unknown>
 }
 
-const MAX_MONTH_EVENT_CACHE = 12
+const MAX_EVENT_RANGE_CACHE = 12
 
 type FamilyMembersStatus = 'idle' | 'loading' | 'ready' | 'error'
 
@@ -45,6 +46,11 @@ interface FamilyMembersState {
   familyId: string | null
   members: FamilyMember[]
   status: FamilyMembersStatus
+}
+
+interface EventRangeRequest {
+  promise: Promise<CalendarEvent[]>
+  isCurrent: () => boolean
 }
 
 // Keep dynamic render loaders and idle preload loaders identical so first-open chunks are actually warmed.
@@ -112,8 +118,13 @@ function scheduleIdleWork(callback: () => void) {
   return () => window.clearTimeout(timeoutId)
 }
 
-function getMonthEventsKey(familyId: string, year: number, month: number) {
-  return `${familyId}:${year}:${month}`
+function getVisibleEventRange(familyId: string, year: number, month: number) {
+  const { start, endExclusive } = getCalendarGridRange(year, month)
+  return {
+    key: `${familyId}:${start.toISOString()}:${endExclusive.toISOString()}`,
+    start,
+    endExclusive,
+  }
 }
 
 function calendarFilterKey(familyId: string) {
@@ -136,18 +147,6 @@ function saveStoredFilter(familyId: string, ids: Set<string>) {
   try {
     localStorage.setItem(calendarFilterKey(familyId), JSON.stringify([...ids]))
   } catch {}
-}
-
-function getAdjacentMonth(year: number, month: number, delta: -1 | 1) {
-  if (delta === -1) {
-    return month === 0
-      ? { year: year - 1, month: 11 }
-      : { year, month: month - 1 }
-  }
-
-  return month === 11
-    ? { year: year + 1, month: 0 }
-    : { year, month: month + 1 }
 }
 
 function getLocalTimePart(isoString: string): string {
@@ -211,15 +210,18 @@ export function CalendarTab({
   }))
 
   const [events, setEvents] = useState<CalendarEvent[]>([])
-  const [adjacentMonthEvents, setAdjacentMonthEvents] = useState<CalendarEvent[]>([])
   const [eventsLoading, setEventsLoading] = useState(true)
   const [eventsError, setEventsError] = useState<unknown>(null)
-  const monthEventsCacheRef = useRef(new Map<string, CalendarEvent[]>())
-  const monthEventsRequestsRef = useRef(new Map<string, Promise<CalendarEvent[]>>())
+  const eventRangeCacheRef = useRef(new Map<string, CalendarEvent[]>())
+  const eventRangeRequestsRef = useRef(new Map<string, EventRangeRequest>())
+  const eventRangeRequestSeqRef = useRef(new Map<string, number>())
+  const familyEventGenerationRef = useRef(new Map<string, number>())
   const currentFamilyIdRef = useRef<string | null>(familyId ?? null)
   const calendarOpenRequestSeqRef = useRef(0)
   const previousFamilyIdRef = useRef<string | null>(familyId ?? null)
-  const visibleMonthKeyRef = useRef<string | null>(familyId ? getMonthEventsKey(familyId, year, month) : null)
+  const visibleEventRangeKeyRef = useRef<string | null>(
+    familyId ? getVisibleEventRange(familyId, year, month).key : null
+  )
   currentFamilyIdRef.current = familyId ?? null
 
   useEffect(() => {
@@ -341,91 +343,79 @@ export function CalendarTab({
   const familyMembersReady = !familyId ||
     (familyMembersState.familyId === familyId && familyMembersState.status === 'ready')
 
-  const storeMonthEvents = useCallback((key: string, nextEvents: CalendarEvent[]) => {
-    const cache = monthEventsCacheRef.current
+  const storeEventRange = useCallback((key: string, nextEvents: CalendarEvent[]) => {
+    const cache = eventRangeCacheRef.current
     if (cache.has(key)) cache.delete(key)
     cache.set(key, nextEvents)
 
-    while (cache.size > MAX_MONTH_EVENT_CACHE) {
+    while (cache.size > MAX_EVENT_RANGE_CACHE) {
       const oldestKey = cache.keys().next().value
       if (!oldestKey) break
       cache.delete(oldestKey)
     }
   }, [])
 
-  const clearFamilyMonthEventsCache = useCallback((targetFamilyId: string) => {
+  const clearFamilyEventRangeCache = useCallback((targetFamilyId: string) => {
     const prefix = `${targetFamilyId}:`
+    familyEventGenerationRef.current.set(
+      targetFamilyId,
+      (familyEventGenerationRef.current.get(targetFamilyId) ?? 0) + 1
+    )
 
-    for (const key of monthEventsCacheRef.current.keys()) {
-      if (key.startsWith(prefix)) monthEventsCacheRef.current.delete(key)
+    for (const key of eventRangeCacheRef.current.keys()) {
+      if (key.startsWith(prefix)) eventRangeCacheRef.current.delete(key)
     }
 
-    for (const key of monthEventsRequestsRef.current.keys()) {
-      if (key.startsWith(prefix)) monthEventsRequestsRef.current.delete(key)
+    for (const key of eventRangeRequestsRef.current.keys()) {
+      if (key.startsWith(prefix)) eventRangeRequestsRef.current.delete(key)
     }
   }, [])
 
-  const fetchMonthEvents = useCallback(async (
+  const getEventRangeRequest = useCallback((
     targetFamilyId: string,
     targetYear: number,
     targetMonth: number,
     options: { force?: boolean } = {}
-  ) => {
-    const key = getMonthEventsKey(targetFamilyId, targetYear, targetMonth)
+  ): EventRangeRequest => {
+    const { key, start, endExclusive } = getVisibleEventRange(
+      targetFamilyId,
+      targetYear,
+      targetMonth
+    )
 
     if (!options.force) {
-      const cached = monthEventsCacheRef.current.get(key)
-      if (cached) return cached
-
-      const inFlight = monthEventsRequestsRef.current.get(key)
+      const inFlight = eventRangeRequestsRef.current.get(key)
       if (inFlight) return inFlight
     }
 
-    const request = getEventsByMonth(targetFamilyId, targetYear, targetMonth)
+    const familyGeneration = familyEventGenerationRef.current.get(targetFamilyId) ?? 0
+    const requestSeq = (eventRangeRequestSeqRef.current.get(key) ?? 0) + 1
+    eventRangeRequestSeqRef.current.set(key, requestSeq)
+
+    const request: EventRangeRequest = {
+      promise: Promise.resolve([]),
+      isCurrent: () => (
+        (familyEventGenerationRef.current.get(targetFamilyId) ?? 0) === familyGeneration &&
+        eventRangeRequestSeqRef.current.get(key) === requestSeq
+      ),
+    }
+
+    request.promise = getEventsByRange(targetFamilyId, start, endExclusive)
       .then((nextEvents) => {
-        storeMonthEvents(key, nextEvents)
-        monthEventsRequestsRef.current.delete(key)
+        if (request.isCurrent()) storeEventRange(key, nextEvents)
         return nextEvents
       })
-      .catch((error) => {
-        monthEventsRequestsRef.current.delete(key)
-        throw error
+      .finally(() => {
+        if (eventRangeRequestsRef.current.get(key) === request) {
+          eventRangeRequestsRef.current.delete(key)
+        }
       })
 
-    monthEventsRequestsRef.current.set(key, request)
+    eventRangeRequestsRef.current.set(key, request)
     return request
-  }, [storeMonthEvents])
+  }, [storeEventRange])
 
-  const syncAdjacentFromCache = useCallback((
-    targetFamilyId: string, targetYear: number, targetMonth: number
-  ) => {
-    const expectedKey = getMonthEventsKey(targetFamilyId, targetYear, targetMonth)
-    if (visibleMonthKeyRef.current !== expectedKey) return
-
-    const prev = getAdjacentMonth(targetYear, targetMonth, -1)
-    const next = getAdjacentMonth(targetYear, targetMonth, 1)
-    const prevEvents = monthEventsCacheRef.current.get(
-      getMonthEventsKey(targetFamilyId, prev.year, prev.month)
-    ) ?? []
-    const nextEvents = monthEventsCacheRef.current.get(
-      getMonthEventsKey(targetFamilyId, next.year, next.month)
-    ) ?? []
-    setAdjacentMonthEvents([...prevEvents, ...nextEvents])
-  }, [])
-
-  const prefetchAdjacentMonths = useCallback((targetFamilyId: string, targetYear: number, targetMonth: number) => {
-    const prev = getAdjacentMonth(targetYear, targetMonth, -1)
-    const next = getAdjacentMonth(targetYear, targetMonth, 1)
-
-    void Promise.all([
-      fetchMonthEvents(targetFamilyId, prev.year, prev.month).catch(() => {}),
-      fetchMonthEvents(targetFamilyId, next.year, next.month).catch(() => {}),
-    ]).then(() => {
-      syncAdjacentFromCache(targetFamilyId, targetYear, targetMonth)
-    })
-  }, [fetchMonthEvents, syncAdjacentFromCache])
-
-  const loadMonthEvents = useCallback(async ({
+  const loadVisibleEvents = useCallback(async ({
     targetFamilyId,
     targetYear,
     targetMonth,
@@ -440,48 +430,44 @@ export function CalendarTab({
     silent?: boolean
     throwOnError?: boolean
   }) => {
-    const key = getMonthEventsKey(targetFamilyId, targetYear, targetMonth)
-    const cached = !force ? monthEventsCacheRef.current.get(key) : undefined
-    const isVisibleMonth = () => visibleMonthKeyRef.current === key
-    const applyMonthState = (nextEvents: CalendarEvent[], nextError: unknown = null) => {
-      if (!isVisibleMonth()) return
+    const { key } = getVisibleEventRange(targetFamilyId, targetYear, targetMonth)
+    const cached = !force ? eventRangeCacheRef.current.get(key) : undefined
+    const isVisibleRange = () => visibleEventRangeKeyRef.current === key
+    const applyRangeState = (nextEvents: CalendarEvent[], nextError: unknown = null) => {
+      if (!isVisibleRange()) return
       setEvents(nextEvents)
       setEventsError(nextError)
       setEventsLoading(false)
     }
 
     if (cached) {
-      applyMonthState(cached)
-      syncAdjacentFromCache(targetFamilyId, targetYear, targetMonth)
-      prefetchAdjacentMonths(targetFamilyId, targetYear, targetMonth)
+      applyRangeState(cached)
       return cached
     }
 
-    if (!silent && isVisibleMonth()) {
+    if (!silent && isVisibleRange()) {
       setEvents([])
-      setAdjacentMonthEvents([])
       setEventsLoading(true)
     }
-    if (isVisibleMonth()) setEventsError(null)
+    if (isVisibleRange()) setEventsError(null)
+
+    const request = getEventRangeRequest(targetFamilyId, targetYear, targetMonth, { force })
 
     try {
-      const nextEvents = await fetchMonthEvents(targetFamilyId, targetYear, targetMonth, { force })
-      applyMonthState(nextEvents)
-      syncAdjacentFromCache(targetFamilyId, targetYear, targetMonth)
-      prefetchAdjacentMonths(targetFamilyId, targetYear, targetMonth)
+      const nextEvents = await request.promise
+      if (request.isCurrent()) applyRangeState(nextEvents)
       return nextEvents
     } catch (error) {
       console.error('[CalendarTab] loadEvents failed:', error)
-      if (isVisibleMonth()) {
+      if (request.isCurrent() && isVisibleRange()) {
         setEvents([])
-        setAdjacentMonthEvents([])
         setEventsError(error)
         setEventsLoading(false)
       }
       if (throwOnError) throw error
       return []
     }
-  }, [fetchMonthEvents, prefetchAdjacentMonths, syncAdjacentFromCache])
+  }, [getEventRangeRequest])
 
   useEffect(() => {
     if (!familyId || calendars.length === 0) return
@@ -506,12 +492,13 @@ export function CalendarTab({
   }, [familyId, activeIds])
 
   useEffect(() => {
-    visibleMonthKeyRef.current = familyId ? getMonthEventsKey(familyId, year, month) : null
+    visibleEventRangeKeyRef.current = familyId
+      ? getVisibleEventRange(familyId, year, month).key
+      : null
 
     if (!familyId) {
       queueMicrotask(() => {
         setEvents([])
-        setAdjacentMonthEvents([])
         setEventsError(null)
         setEventsLoading(false)
       })
@@ -525,20 +512,19 @@ export function CalendarTab({
     if (familyChanged) {
       queueMicrotask(() => {
         setEvents([])
-        setAdjacentMonthEvents([])
         setEventsError(null)
         setEventsLoading(true)
       })
     }
 
     queueMicrotask(() => {
-      void loadMonthEvents({
+      void loadVisibleEvents({
         targetFamilyId: familyId,
         targetYear: year,
         targetMonth: month,
       })
     })
-  }, [familyId, year, month, loadMonthEvents])
+  }, [familyId, year, month, loadVisibleEvents])
 
   useEffect(() => {
     if (!familyId) return
@@ -549,45 +535,33 @@ export function CalendarTab({
     })
   }, [familyId, loadFamilyMembers])
 
-  const mergedEvents = useMemo(() => {
-    if (adjacentMonthEvents.length === 0) return events
-    const seen = new Set(events.map((e) => e.id))
-    return [...events, ...adjacentMonthEvents.filter((e) => !seen.has(e.id))]
-  }, [events, adjacentMonthEvents])
-
   const filteredEvents = useMemo(
-    () => mergedEvents.filter((e) => activeIds.size === 0 || !e.calendar_id || activeIds.has(e.calendar_id)),
-    [mergedEvents, activeIds]
+    () => events.filter((e) => activeIds.size === 0 || !e.calendar_id || activeIds.has(e.calendar_id)),
+    [events, activeIds]
   )
 
   const reloadEvents = useCallback(async () => {
     if (!familyId) return
-    await loadMonthEvents({
+    await loadVisibleEvents({
       targetFamilyId: familyId,
       targetYear: year,
       targetMonth: month,
       force: true,
       throwOnError: true,
     })
-  }, [familyId, year, month, loadMonthEvents])
+  }, [familyId, year, month, loadVisibleEvents])
 
   const refreshEvents = useCallback(async () => {
     if (!familyId) return
-    const prefix = `${familyId}:`
-    for (const key of monthEventsCacheRef.current.keys()) {
-      if (key.startsWith(prefix)) monthEventsCacheRef.current.delete(key)
-    }
-    for (const key of monthEventsRequestsRef.current.keys()) {
-      if (key.startsWith(prefix)) monthEventsRequestsRef.current.delete(key)
-    }
-    await loadMonthEvents({
+    clearFamilyEventRangeCache(familyId)
+    await loadVisibleEvents({
       targetFamilyId: familyId,
       targetYear: year,
       targetMonth: month,
       force: true,
       silent: true,
     })
-  }, [familyId, year, month, loadMonthEvents])
+  }, [clearFamilyEventRangeCache, familyId, year, month, loadVisibleEvents])
 
   const reloadCalendarContext = useCallback(async () => {
     await Promise.allSettled([
@@ -727,7 +701,7 @@ export function CalendarTab({
     setMutationError(null)
 
     try {
-      clearFamilyMonthEventsCache(familyId)
+      clearFamilyEventRangeCache(familyId)
       await deleteCalendar(calendarForm.calendar.id)
       setActiveIds((prev) => {
         const next = new Set(prev)
@@ -784,7 +758,7 @@ export function CalendarTab({
     setMutationError(null)
 
     try {
-      clearFamilyMonthEventsCache(familyId)
+      clearFamilyEventRangeCache(familyId)
       await deleteCalendar(calendarId)
       setActiveIds((prev) => {
         const next = new Set(prev)
@@ -818,7 +792,7 @@ export function CalendarTab({
     setMutationError(null)
 
     try {
-      clearFamilyMonthEventsCache(familyId)
+      clearFamilyEventRangeCache(familyId)
 
       const saveLastLabelColor = (color: string | null, prev: string | null = null) => {
         if (color !== null && color !== prev) {
@@ -905,7 +879,7 @@ export function CalendarTab({
     }
 
     try {
-      clearFamilyMonthEventsCache(familyId)
+      clearFamilyEventRangeCache(familyId)
 
       const url = targetEvent.series_id && scope
         ? `/api/events/${targetEvent.id}?scope=${scope}&anchorOccurrenceDate=${targetEvent.series_occurrence_date ?? ''}`
@@ -1078,7 +1052,7 @@ export function CalendarTab({
         <CalendarGrid
           year={year}
           month={month}
-          events={mergedEvents}
+          events={events}
           calendars={calendars}
           activeIds={activeIds}
           holidays={holidays}

--- a/src/lib/calendar-grid.ts
+++ b/src/lib/calendar-grid.ts
@@ -1,0 +1,36 @@
+export interface CalendarDayCell {
+  date: Date
+  isCurrentMonth: boolean
+}
+
+export function buildCalendarGrid(year: number, month: number): CalendarDayCell[] {
+  const firstDay = new Date(year, month, 1)
+  const startDow = firstDay.getDay()
+  const daysInMonth = new Date(year, month + 1, 0).getDate()
+  const prevMonthLastDay = new Date(year, month, 0).getDate()
+  const rows = Math.ceil((startDow + daysInMonth) / 7)
+  const totalCells = rows * 7
+  const cells: CalendarDayCell[] = []
+
+  for (let i = startDow - 1; i >= 0; i -= 1) {
+    cells.push({ date: new Date(year, month - 1, prevMonthLastDay - i), isCurrentMonth: false })
+  }
+  for (let day = 1; day <= daysInMonth; day += 1) {
+    cells.push({ date: new Date(year, month, day), isCurrentMonth: true })
+  }
+  const trailingDays = totalCells - cells.length
+  for (let day = 1; day <= trailingDays; day += 1) {
+    cells.push({ date: new Date(year, month + 1, day), isCurrentMonth: false })
+  }
+
+  return cells
+}
+
+export function getCalendarGridRange(year: number, month: number) {
+  const cells = buildCalendarGrid(year, month)
+  const start = cells[0].date
+  const last = cells[cells.length - 1].date
+  const endExclusive = new Date(last.getFullYear(), last.getMonth(), last.getDate() + 1)
+
+  return { start, endExclusive }
+}

--- a/src/lib/calendar.ts
+++ b/src/lib/calendar.ts
@@ -173,21 +173,21 @@ export async function setCalendarMembers(
 
 // ── Events ─────────────────────────────────────────────────
 
-export async function getEventsByMonth(
+export async function getEventsByRange(
   familyId: string,
-  year: number,
-  month: number // 0-indexed (0=January)
+  start: Date,
+  endExclusive: Date
 ): Promise<CalendarEvent[]> {
-  const start = new Date(year, month, 1).toISOString()
-  const end = new Date(year, month + 1, 0, 23, 59, 59, 999).toISOString()
+  const startIso = start.toISOString()
+  const endExclusiveIso = endExclusive.toISOString()
 
   const { data, error } = await supabase
     .from('events')
     .select('*')
     .eq('family_id', familyId)
     .eq('is_cancelled', false)
-    .gte('start_at', start)
-    .lte('start_at', end)
+    .lt('start_at', endExclusiveIso)
+    .or(`start_at.gte.${startIso},and(is_all_day.eq.true,end_at.gte.${startIso})`)
     .order('start_at', { ascending: true })
 
   if (error) throw error


### PR DESCRIPTION
## Summary
- 현재 월 조회 후 전월·다음월을 각각 prefetch하던 3회 요청을 캘린더 그리드의 실제 표시 범위 1회 조회로 통합했습니다.
- 5행·6행 월과 연도 경계를 동일한 그리드 범위 유틸리티로 계산해 렌더링과 데이터 조회가 같은 날짜 계약을 사용합니다.
- 범위 시작 전에 시작해 화면 안까지 이어지는 여러 날 종일 일정도 overlap 조건으로 조회합니다.
- 월별·인접 월 캐시를 유한 크기의 표시 범위 캐시로 단순화했습니다.
- Realtime 구독 성립 시 gap 보정 갱신은 유지해 첫 조회와 구독 사이 변경을 놓치지 않도록 했습니다. 초기 요청 수는 최대 6회에서 2회로 줄어듭니다.
- 강제 갱신과 기존 in-flight 요청이 경쟁해도 세대·요청 순서 guard가 오래된 결과와 오류의 commit을 막습니다.
- 프로젝트 문서의 이벤트 조회 계약을 새 표시 범위 방식으로 갱신했습니다.

## 사용자 관점 변화
- 기존: 현재 월 일정이 먼저 표시된 뒤 전월·다음월 셀의 일정이 추가 요청 완료 순서에 따라 뒤늦게 붙을 수 있습니다.
- 변경: 화면에 보이는 현재 월과 인접 월 셀의 일정이 한 응답으로 함께 표시됩니다.
- 월 이동 시 해당 화면 범위가 캐시에 있으면 즉시 표시되고, 없으면 캘린더 그리드를 유지한 채 새 범위 결과로 교체됩니다.
- Realtime 보정 갱신은 silent로 수행되어 이미 표시된 캘린더를 비우거나 별도 전체 로딩 화면을 띄우지 않습니다.

## Testing
- `npm run test -- --runInBand` (69 suites, 701 tests passed)
- `npx tsc --noEmit`
- `npm run lint`
- `git diff --check`
- 5행·6행·연도 경계 범위, 여러 날 종일 일정 overlap query, 단일 요청, 월 이동 stale 응답, Realtime 강제 갱신 stale commit 방어 테스트 추가