### PR TITLE
perf: defer background warmups

### DIFF
--- a/docs/CHALLENGES.md
+++ b/docs/CHALLENGES.md
@@ -167,12 +167,13 @@ setItems((prev) =>
 ### 해결
 
 - `/calendar`를 단일 live entry로 고정했다.
-- `TabsShell`이 세 탭을 모두 마운트한 상태로 유지하고 `display`만 전환한다.
+- `TabsShell`이 활성 탭을 즉시 마운트하고, 보조 탭은 idle 시점에 마운트한 뒤 `display`만 전환한다.
 - 리마인더 상세도 메인 흐름에서는 search param 기반으로 유지한다.
 
 ### 남은 규칙
 
 - 탭을 다시 개별 route page로 쪼개지 않는다.
+- 첫 마운트 전에는 보조 탭 내부 effect가 실행되지 않으므로 선행 초기화가 필요한 작업은 공유 idle warmup에 명시한다.
 - 독립 route가 필요하면 bridge 또는 외부 링크 호환 목적이 분명해야 한다.
 
 ---

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -23,7 +23,7 @@ DB migration -> src/types/database.ts -> src/lib/* -> src/hooks/* -> src/app/* -
 - `/calendar`가 가족 앱의 단일 live entry point다.
 - `/reminders`, `/settings`는 독립 화면이 아니라 `/calendar` 탭 셸로 리다이렉트한다.
 - 실제 탭 상태는 route path가 아니라 `/calendar?tab=reminders` 같은 search param으로 제어한다.
-- `TabsShell`은 `CalendarTab`, `ReminderTab`, `SettingsTab`를 항상 마운트하고 `display`만 바꾼다.
+- `TabsShell`은 활성 탭을 즉시 마운트하고, 리마인더와 설정은 `scheduleIdleWork()`로 순서대로 준비한 뒤 keep-alive한다.
 - 탭 상태 유지가 목적이므로 탭별 개별 route로 다시 분리하지 않는다.
 - 리마인더 상세도 메인 흐름에서는 `/calendar?tab=reminders&list=<id>` search param으로 연다.
 - `src/app/reminders/[id]/page.tsx`는 리마인더 상세 링크용 bridge route다.
@@ -102,10 +102,16 @@ DB migration -> src/types/database.ts -> src/lib/* -> src/hooks/* -> src/app/* -
 - 사용자 설정은 `user_preferences` 한 테이블로 모은다.
 - 테마는 DB와 클라이언트 저장소를 함께 사용한다.
 - `persistTheme()`는 `localStorage`와 cookie를 같이 갱신해야 한다.
-- SSR 첫 페인트 전 테마 적용은 `src/app/layout.tsx`의 inline head script가 담당한다.
-- 클라이언트에서만 테마를 바꾸고 SSR fallback을 빼면 FOUC가 다시 생긴다.
+- 첫 페인트 전 테마 적용은 `src/app/layout.tsx`의 inline head script가 localStorage와 cookie fallback을 읽어 담당한다.
+- layout에서 동적 cookie API를 다시 사용하지 않는다. head script의 cookie fallback을 빼면 FOUC가 다시 생길 수 있다.
 
-## 9. Push And Notification Pattern
+## 9. Background Warmup
+
+- 사용자 입력과 무관한 chunk/data warmup은 `src/lib/idle-work.ts`의 공유 queue를 사용한다.
+- 한 idle slot에서는 한 작업만 실행하고, 사용자 접근 가능성이 높은 작업부터 `high`, `normal`, `low` 우선순위를 부여한다.
+- 예약된 작업은 컴포넌트 cleanup에서 취소하며, 사용자 진입 경로는 idle warmup 완료를 전제로 하지 않는다.
+
+## 10. Push And Notification Pattern
 
 - push subscription 등록은 API route를 통해 저장한다.
 - reminder 발송과 이벤트 변경 알림은 서로 다른 목적이다.
@@ -114,7 +120,7 @@ DB migration -> src/types/database.ts -> src/lib/* -> src/hooks/* -> src/app/* -
 - actor 본인에게는 이벤트 변경 push를 보내지 않는다.
 - 404/410으로 만료된 구독은 발송 시점에 정리한다.
 
-## 10. Modal And Mobile Layout Rules
+## 11. Modal And Mobile Layout Rules
 
 - 하단 네비게이션이 있는 일반 모달 컨테이너에는 `pb-16 sm:pb-0`를 넣는다.
 - 이 패딩이 없으면 PWA 모바일에서 CTA가 하단 탭 바 뒤로 가려질 수 있다.
@@ -127,7 +133,7 @@ DB migration -> src/types/database.ts -> src/lib/* -> src/hooks/* -> src/app/* -
 | 삭제 확인 다이얼로그 | `z-[60]` |
 | 최상위 모달 또는 중첩 시트 | `z-[70]` |
 
-## 11. Testing Expectations
+## 12. Testing Expectations
 
 - 코드 변경 시 관련 테스트를 같이 갱신한다.
 - 우선 위치는 `src/__tests__/lib`, `src/__tests__/hooks`, `src/__tests__/api`, `src/__tests__/components`, `src/__tests__/reminders`, `src/__tests__/settings`다.
@@ -135,7 +141,7 @@ DB migration -> src/types/database.ts -> src/lib/* -> src/hooks/* -> src/app/* -
 - 회귀 위험이 큰 변경은 "lib 테스트 + 화면/훅 테스트"를 함께 추가하는 쪽을 우선한다.
 - 코드 작업 마무리 전 `npx tsc --noEmit`를 실행한다.
 
-## 12. Forbidden Patterns
+## 13. Forbidden Patterns
 
 | Forbidden | Why |
 | --- | --- |
@@ -150,7 +156,7 @@ DB migration -> src/types/database.ts -> src/lib/* -> src/hooks/* -> src/app/* -
 | 탭을 다시 개별 route page로 분리 | 탭 전환 시 상태 손실과 스피너 회귀 |
 | 수동 테마 저장 시 cookie 갱신 생략 | SSR 초기 렌더와 hydration 사이 FOUC 재발 |
 
-## 13. When To Read Challenges
+## 14. When To Read Challenges
 
 - realtime 흐름을 수정할 때
 - RLS 정책이나 migration을 수정할 때

--- a/docs/PROJECT_MAP.md
+++ b/docs/PROJECT_MAP.md
@@ -35,13 +35,13 @@ Koko는 가족 단위로 일정을 공유하고 리마인더와 설정을 함께
 ### Top-Level Runtime Shape
 
 - `src/app/layout.tsx`
-  - 글로벌 메타데이터, 폰트, SSR-safe theme bootstrap
+  - 글로벌 메타데이터, 외부 subset 폰트, 정적 head theme bootstrap
 - `src/app/page.tsx`
   - `/calendar`로 리다이렉트
 - `src/app/calendar/page.tsx`
   - 가족 앱의 단일 live entry point
 - `src/components/TabsShell.tsx`
-  - auth/family/preferences/calendars 초기화 후 탭을 keep-alive 상태로 렌더링
+  - auth/family 확인 후 캘린더를 즉시 렌더링하고 보조 탭은 idle 시점에 keep-alive로 준비
 
 ### Auxiliary Routes
 
@@ -328,8 +328,8 @@ Important notes:
 
 1. `useAuth()`가 현재 세션을 확인한다.
 2. `useFamily()`가 `/api/family/me`를 호출해 `familyId`와 `appRole`을 가져온다.
-3. `useCalendars()`가 가족 캘린더를 읽는다.
-4. `TabsShell`이 세 탭을 keep-alive 상태로 렌더링한다.
+3. `TabsShell`이 캘린더 셸을 렌더링하고 `useCalendars()`와 일정 조회가 병렬로 진행된다.
+4. 리마인더와 설정 탭은 공유 idle queue에서 순서대로 마운트되어 keep-alive 상태가 된다.
 5. 가족이 없으면 `/onboarding`으로 리다이렉트한다.
 
 ### Login And Access Decision

--- a/src/__tests__/TabsShell.test.tsx
+++ b/src/__tests__/TabsShell.test.tsx
@@ -158,12 +158,20 @@ describe('TabsShell', () => {
     expect(screen.queryByTestId('settings-tab')).not.toBeInTheDocument()
 
     await act(async () => {
-      jest.advanceTimersByTime(1200)
+      jest.advanceTimersByTime(1300)
       await Promise.resolve()
       await Promise.resolve()
     })
 
     expect(screen.getByTestId('reminder-tab').parentElement).toHaveClass('hidden')
+    expect(screen.queryByTestId('settings-tab')).not.toBeInTheDocument()
+
+    await act(async () => {
+      jest.advanceTimersByTime(1300)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
     expect(screen.getByTestId('settings-tab').parentElement).toHaveClass('hidden')
   })
 

--- a/src/__tests__/app/LayoutMetadata.test.tsx
+++ b/src/__tests__/app/LayoutMetadata.test.tsx
@@ -1,16 +1,8 @@
-jest.mock('next/headers', () => ({
-  cookies: jest.fn(),
-}))
-
 jest.mock('next-themes', () => ({
   ThemeProvider: ({ children }: { children: React.ReactNode }) => children,
 }))
 
-jest.mock('@/lib/preferences', () => ({
-  THEME_STORAGE_KEY: 'koko_theme',
-}))
-
-import { metadata, viewport } from '@/app/layout'
+import RootLayout, { metadata, viewport } from '@/app/layout'
 
 describe('RootLayout metadata', () => {
   it('상단 시스템 바 색을 라이트/다크 배경색으로 분리한다', () => {
@@ -32,5 +24,24 @@ describe('RootLayout metadata', () => {
     expect(metadata.other).toEqual({
       'mobile-web-app-capable': 'yes',
     })
+  })
+
+  it('루트 layout은 동적 cookie 조회 없이 동기적으로 렌더링된다', () => {
+    const layout = RootLayout({ children: null })
+
+    expect(layout).not.toBeInstanceOf(Promise)
+    expect(layout.props['data-theme']).toBeUndefined()
+  })
+
+  it('첫 paint 전 theme script가 localStorage와 cookie fallback을 유지한다', () => {
+    const layout = RootLayout({ children: null })
+    const head = layout.props.children[0]
+    const script = head.props.children[0]
+    const scriptBody = script.props.dangerouslySetInnerHTML.__html as string
+
+    expect(scriptBody).toContain("var k='koko_theme'")
+    expect(scriptBody).toContain('localStorage.getItem(k)')
+    expect(scriptBody).toContain('try{ls=localStorage.getItem(k);}catch(e){}')
+    expect(scriptBody).toContain('document.cookie.match')
   })
 })

--- a/src/__tests__/components/CalendarTab.test.tsx
+++ b/src/__tests__/components/CalendarTab.test.tsx
@@ -490,7 +490,7 @@ describe('CalendarTab — touch-action 스크롤 차단', () => {
     await act(async () => {})
 
     act(() => {
-      jest.advanceTimersByTime(700)
+      jest.advanceTimersByTime(1800)
     })
     expect(mockGetFamilyMembers).toHaveBeenCalledTimes(1)
 

--- a/src/__tests__/lib/idle-work.test.ts
+++ b/src/__tests__/lib/idle-work.test.ts
@@ -1,0 +1,81 @@
+import { clearIdleWorkQueue, scheduleIdleWork } from '@/lib/idle-work'
+
+type IdleWindow = {
+  requestIdleCallback?: (callback: () => void, options?: { timeout: number }) => number
+  cancelIdleCallback?: (handle: number) => void
+}
+
+const idleWindow = window as unknown as IdleWindow
+const originalRequestIdleCallback = idleWindow.requestIdleCallback
+const originalCancelIdleCallback = idleWindow.cancelIdleCallback
+const originalRequestAnimationFrame = window.requestAnimationFrame
+const originalCancelAnimationFrame = window.cancelAnimationFrame
+
+beforeEach(() => {
+  jest.useFakeTimers()
+  clearIdleWorkQueue()
+  delete idleWindow.requestIdleCallback
+  delete idleWindow.cancelIdleCallback
+  window.requestAnimationFrame = (callback) => window.setTimeout(callback, 16)
+  window.cancelAnimationFrame = (handle) => window.clearTimeout(handle)
+})
+
+afterEach(() => {
+  clearIdleWorkQueue()
+  jest.useRealTimers()
+  idleWindow.requestIdleCallback = originalRequestIdleCallback
+  idleWindow.cancelIdleCallback = originalCancelIdleCallback
+  window.requestAnimationFrame = originalRequestAnimationFrame
+  window.cancelAnimationFrame = originalCancelAnimationFrame
+})
+
+describe('scheduleIdleWork', () => {
+  it('fallback에서는 우선순위 순서로 한 번에 하나씩 실행한다', () => {
+    const order: string[] = []
+    scheduleIdleWork(() => order.push('low'), 'low')
+    scheduleIdleWork(() => order.push('normal'), 'normal')
+    scheduleIdleWork(() => order.push('high'), 'high')
+
+    jest.advanceTimersByTime(800)
+    expect(order).toEqual(['high'])
+
+    jest.advanceTimersByTime(1000)
+    expect(order).toEqual(['high', 'normal'])
+
+    jest.advanceTimersByTime(1300)
+    expect(order).toEqual(['high', 'normal', 'low'])
+  })
+
+  it('취소된 작업은 실행하지 않는다', () => {
+    const callback = jest.fn()
+    const cancel = scheduleIdleWork(callback, 'high')
+
+    cancel()
+    jest.runAllTimers()
+
+    expect(callback).not.toHaveBeenCalled()
+  })
+
+  it('requestIdleCallback 환경에서도 idle slot 하나당 작업 하나만 실행한다', () => {
+    const idleCallbacks: Array<() => void> = []
+    idleWindow.requestIdleCallback = jest.fn((callback: () => void) => {
+      idleCallbacks.push(callback)
+      return idleCallbacks.length
+    })
+    idleWindow.cancelIdleCallback = jest.fn()
+    const first = jest.fn()
+    const second = jest.fn()
+
+    scheduleIdleWork(first, 'normal')
+    scheduleIdleWork(second, 'normal')
+    expect(idleCallbacks).toHaveLength(1)
+
+    idleCallbacks.shift()?.()
+    expect(first).toHaveBeenCalledTimes(1)
+    expect(second).not.toHaveBeenCalled()
+    expect(idleCallbacks).toHaveLength(1)
+
+    idleCallbacks.shift()?.()
+    expect(second).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,5 @@
 import type { Metadata, Viewport } from 'next'
 import { ThemeProvider } from 'next-themes'
-import { cookies } from 'next/headers'
-import { THEME_STORAGE_KEY } from '@/lib/preferences'
 import { PreHydrationSplash } from '@/components/PreHydrationSplash'
 import './globals.css'
 
@@ -29,22 +27,18 @@ export const viewport: Viewport = {
 
 // Applies accent theme and dark class before first paint to prevent FOUC.
 // next-themes stores dark/light preference under 'theme' key in localStorage.
-const HEAD_SCRIPT = `(function(){var de=document.documentElement;var k='koko_theme';var ls=localStorage.getItem(k);if(ls){de.setAttribute('data-theme',ls);}else{var m=document.cookie.match('(?:^|;)\\s*'+k+'=([^;]+)');if(m)de.setAttribute('data-theme',m[1]);}var t=localStorage.getItem('theme');var dark=(t==='dark')||(t!=='light'&&window.matchMedia('(prefers-color-scheme:dark)').matches);if(dark)de.classList.add('dark');})();`
+const HEAD_SCRIPT = `(function(){var de=document.documentElement;var k='koko_theme';var ls=null;try{ls=localStorage.getItem(k);}catch(e){}if(ls){de.setAttribute('data-theme',ls);}else{var m=document.cookie.match('(?:^|;)\\s*'+k+'=([^;]+)');if(m)de.setAttribute('data-theme',m[1]);}var t=null;try{t=localStorage.getItem('theme');}catch(e){}var dark=(t==='dark')||(t!=='light'&&window.matchMedia('(prefers-color-scheme:dark)').matches);if(dark)de.classList.add('dark');})();`
 
-export default async function RootLayout({
+export default function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode
 }>) {
-  const cookieStore = await cookies()
-  const theme = cookieStore.get(THEME_STORAGE_KEY)?.value
-
   return (
     <html
       lang="ko"
       className="h-full antialiased"
       suppressHydrationWarning
-      data-theme={theme || undefined}
     >
       <head>
         <script dangerouslySetInnerHTML={{ __html: HEAD_SCRIPT }} />

--- a/src/components/TabsShell.tsx
+++ b/src/components/TabsShell.tsx
@@ -11,11 +11,9 @@ import { useCalendars } from '@/hooks/useCalendars'
 import { useUserPreferences } from '@/hooks/useUserPreferences'
 import { type Tab, TABS } from '@/types/tabs'
 import { AppSplash } from '@/components/AppSplash'
+import { scheduleIdleWork } from '@/lib/idle-work'
 
 const IDLE_PRELOAD_TABS: Tab[] = ['reminders', 'settings']
-
-type RequestIdleCallback = (callback: () => void, options?: { timeout?: number }) => number
-type CancelIdleCallback = (handle: number) => void
 
 const ReminderTab = dynamic(
   () => import('@/components/tabs/ReminderTab').then((mod) => mod.ReminderTab),
@@ -33,23 +31,6 @@ function TabChunkFallback() {
       <div className="w-8 h-8 rounded-full border-2 border-accent-300 border-t-accent-500 animate-spin" />
     </div>
   )
-}
-
-function scheduleIdlePreload(callback: () => void) {
-  if (typeof window === 'undefined') return () => {}
-
-  const idleWindow = window as Window & {
-    requestIdleCallback?: RequestIdleCallback
-    cancelIdleCallback?: CancelIdleCallback
-  }
-
-  if (idleWindow.requestIdleCallback && idleWindow.cancelIdleCallback) {
-    const handle = idleWindow.requestIdleCallback(callback, { timeout: 2000 })
-    return () => idleWindow.cancelIdleCallback?.(handle)
-  }
-
-  const handle = window.setTimeout(callback, 1200)
-  return () => window.clearTimeout(handle)
 }
 
 export function TabsShell() {
@@ -114,15 +95,17 @@ export function TabsShell() {
   useEffect(() => {
     if (isInitializing || startupError || !user || needsFamilyOnboarding) return
 
-    // Let the calendar paint first, then hidden-mount secondary tabs to warm their data.
-    return scheduleIdlePreload(() => {
+    // Let the calendar paint first, then hidden-mount one secondary tab per idle slot.
+    const cancelPreloads = IDLE_PRELOAD_TABS.map((tab) => scheduleIdleWork(() => {
       setMountedTabs((prev) => {
-        if (IDLE_PRELOAD_TABS.every((tab) => prev.has(tab))) return prev
+        if (prev.has(tab)) return prev
         const next = new Set(prev)
-        IDLE_PRELOAD_TABS.forEach((tab) => next.add(tab))
+        next.add(tab)
         return next
       })
-    })
+    }, 'low'))
+
+    return () => cancelPreloads.forEach((cancel) => cancel())
   }, [isInitializing, needsFamilyOnboarding, startupError, user])
 
   const handleStartupRetry = async () => {

--- a/src/components/tabs/CalendarTab.tsx
+++ b/src/components/tabs/CalendarTab.tsx
@@ -28,6 +28,7 @@ import type { RecurrenceRule, RecurrenceScope } from '@/types/recurrence'
 import { useRealtimeSync } from '@/hooks/useRealtimeSync'
 import { postJsonWithAuth, patchJsonWithAuth, deleteWithAuth } from '@/lib/api-client'
 import type { Calendar } from '@/lib/calendar'
+import { scheduleIdleWork } from '@/lib/idle-work'
 
 interface Props extends AuthState {
   preferences: UserPreferences | null
@@ -99,24 +100,6 @@ const calendarOverlayLoaders = [
   loadYearMonthPickerSheet,
   loadRecurrenceScopeSheet,
 ]
-
-type WindowWithIdleCallback = Window & typeof globalThis & {
-  requestIdleCallback?: (callback: () => void, options?: { timeout: number }) => number
-  cancelIdleCallback?: (handle: number) => void
-}
-
-function scheduleIdleWork(callback: () => void) {
-  if (typeof window === 'undefined') return () => {}
-
-  const idleWindow = window as WindowWithIdleCallback
-  if (idleWindow.requestIdleCallback) {
-    const handle = idleWindow.requestIdleCallback(callback, { timeout: 2500 })
-    return () => idleWindow.cancelIdleCallback?.(handle)
-  }
-
-  const timeoutId = window.setTimeout(callback, 700)
-  return () => window.clearTimeout(timeoutId)
-}
 
 function getVisibleEventRange(familyId: string, year: number, month: number) {
   const { start, endExclusive } = getCalendarGridRange(year, month)
@@ -529,10 +512,17 @@ export function CalendarTab({
   useEffect(() => {
     if (!familyId) return
 
-    return scheduleIdleWork(() => {
+    const cancelOverlayPreload = scheduleIdleWork(() => {
       void Promise.allSettled(calendarOverlayLoaders.map((loadOverlay) => loadOverlay()))
+    }, 'high')
+    const cancelMemberPreload = scheduleIdleWork(() => {
       void loadFamilyMembers({ silent: true }).catch(() => {})
     })
+
+    return () => {
+      cancelOverlayPreload()
+      cancelMemberPreload()
+    }
   }, [familyId, loadFamilyMembers])
 
   const filteredEvents = useMemo(

--- a/src/lib/idle-work.ts
+++ b/src/lib/idle-work.ts
@@ -1,0 +1,124 @@
+export type IdleWorkPriority = 'high' | 'normal' | 'low'
+
+interface IdleWorkTask {
+  id: number
+  priority: IdleWorkPriority
+  callback: () => void
+}
+
+interface ScheduledWork {
+  priority: IdleWorkPriority
+  cancel: () => void
+}
+
+const PRIORITY_ORDER: Record<IdleWorkPriority, number> = {
+  high: 0,
+  normal: 1,
+  low: 2,
+}
+
+const PRIORITY_TIMING: Record<IdleWorkPriority, { timeout: number; fallbackDelay: number }> = {
+  high: { timeout: 1500, fallbackDelay: 700 },
+  normal: { timeout: 2500, fallbackDelay: 900 },
+  low: { timeout: 4000, fallbackDelay: 1200 },
+}
+
+type IdleWindow = Window & {
+  requestIdleCallback?: (callback: () => void, options?: { timeout: number }) => number
+  cancelIdleCallback?: (handle: number) => void
+}
+
+let nextTaskId = 1
+let tasks: IdleWorkTask[] = []
+let scheduledWork: ScheduledWork | null = null
+
+function getNextTaskIndex() {
+  let nextIndex = 0
+  for (let index = 1; index < tasks.length; index += 1) {
+    if (PRIORITY_ORDER[tasks[index].priority] < PRIORITY_ORDER[tasks[nextIndex].priority]) {
+      nextIndex = index
+    }
+  }
+  return nextIndex
+}
+
+function runNextTask() {
+  scheduledWork = null
+  if (tasks.length === 0) return
+
+  const [task] = tasks.splice(getNextTaskIndex(), 1)
+  try {
+    task.callback()
+  } finally {
+    scheduleNextTask()
+  }
+}
+
+function scheduleNextTask() {
+  if (scheduledWork || tasks.length === 0 || typeof window === 'undefined') return
+
+  const priority = tasks[getNextTaskIndex()].priority
+  const timing = PRIORITY_TIMING[priority]
+  const idleWindow = window as IdleWindow
+
+  if (idleWindow.requestIdleCallback && idleWindow.cancelIdleCallback) {
+    const handle = idleWindow.requestIdleCallback(runNextTask, { timeout: timing.timeout })
+    scheduledWork = {
+      priority,
+      cancel: () => idleWindow.cancelIdleCallback?.(handle),
+    }
+    return
+  }
+
+  let animationFrame: number | null = null
+  const timeout = window.setTimeout(() => {
+    const run = () => runNextTask()
+    if (typeof window.requestAnimationFrame === 'function') {
+      animationFrame = window.requestAnimationFrame(run)
+    } else {
+      run()
+    }
+  }, timing.fallbackDelay)
+
+  scheduledWork = {
+    priority,
+    cancel: () => {
+      window.clearTimeout(timeout)
+      if (animationFrame !== null) window.cancelAnimationFrame(animationFrame)
+    },
+  }
+}
+
+export function scheduleIdleWork(
+  callback: () => void,
+  priority: IdleWorkPriority = 'normal'
+) {
+  if (typeof window === 'undefined') return () => {}
+
+  const task: IdleWorkTask = { id: nextTaskId, priority, callback }
+  nextTaskId += 1
+  tasks.push(task)
+
+  if (
+    scheduledWork &&
+    PRIORITY_ORDER[priority] < PRIORITY_ORDER[scheduledWork.priority]
+  ) {
+    scheduledWork.cancel()
+    scheduledWork = null
+  }
+  scheduleNextTask()
+
+  return () => {
+    tasks = tasks.filter((queuedTask) => queuedTask.id !== task.id)
+    if (tasks.length === 0 && scheduledWork) {
+      scheduledWork.cancel()
+      scheduledWork = null
+    }
+  }
+}
+
+export function clearIdleWorkQueue() {
+  scheduledWork?.cancel()
+  scheduledWork = null
+  tasks = []
+}


### PR DESCRIPTION
## Summary
- 캘린더 첫 화면과 경쟁하던 백그라운드 준비 작업을 공유 idle queue로 통합했습니다.
- 캘린더 오버레이 청크는 높은 우선순위, 가족 멤버 데이터는 보통 우선순위, 리마인더와 설정 탭은 각각 별도의 낮은 우선순위 작업으로 순차 준비합니다.
- 브라우저가 `requestIdleCallback`을 지원하지 않는 경우 타이머와 animation frame을 조합해 한 번에 하나씩 실행하며, 언마운트 시 대기 작업을 취소합니다.
- 사용자가 준비 완료 전에 탭이나 기능을 열어도 기존 직접 로딩 경로가 즉시 동작하도록 유지했습니다.
- 루트 레이아웃의 서버 cookie 조회를 제거해 `/calendar`가 정적으로 생성되도록 했고, 첫 paint 전 theme script의 localStorage 및 cookie fallback은 유지했습니다.
- Pretendard는 현재 CDN unicode-range 동적 서브셋이 초기 전송량에 유리해 변경하지 않았습니다. 단일 CJK 폰트 self-hosting으로 인한 초기 전송량 증가와 글꼴 회귀를 피하기 위한 결정입니다.

## 사용자 관점 변화
- 캘린더가 표시된 직후 오버레이, 가족 멤버, 리마인더, 설정 준비 작업이 한꺼번에 경쟁하지 않고 순서대로 진행됩니다.
- 리마인더와 설정은 백그라운드에서 차례로 준비되며, 준비 전에 직접 탭을 열면 해당 탭 로딩이 즉시 시작되고 기존 fallback이 잠깐 보일 수 있습니다.
- 테마와 폰트의 보이는 결과는 이전과 동일합니다.
- 새로운 전면 로딩 화면이나 기능 접근 제한은 추가되지 않습니다.

## Testing
- `npm run test` (70 suites, 706 tests passed)
- `npm run test -- --runInBand` (70 suites, 706 tests passed)
- `npm run test -- --runInBand src/__tests__/reminders/ReminderDetailView.test.tsx` (32 tests passed)
- `npx tsc --noEmit`
- `npm run lint`
- `git diff --check`
- `npm run build` with non-secret placeholder environment values (`/calendar` static prerender 확인)
- `npx next experimental-analyze --output`