### PR TITLE
feat: convert regular events to recurring

### DIFF
--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -82,6 +82,8 @@ DB migration -> src/types/database.ts -> src/lib/* -> src/hooks/* -> src/app/* -
 - 이벤트 생성/수정은 클라이언트에서 테이블을 직접 건드리지 않고 `/api/events` 계열 route를 사용한다.
 - 이벤트 생성/수정 시 reminder도 함께 저장한다. event와 reminder를 분리 저장하지 않는다.
 - reminder 원자 저장은 `create_event_with_reminders`, `update_event_with_reminders` RPC에 맡긴다.
+- 일반 일정을 반복 일정으로 전환할 때는 `convert_event_to_recurring_series_authorized`로 rule/series/occurrence/reminder를 한 트랜잭션에서 만들고 원본 event ID를 유지한다.
+- 일반 일정의 반복 전환은 오늘 이후의 단일 날짜 일정만 허용하며, 주간 사용자 지정 반복은 원본 일정의 시작 요일을 포함해야 한다.
 - 이 RPC들은 service role route에서만 호출한다. 클라이언트 실행 권한을 다시 열지 않는다.
 - 이벤트 저장 후에는 현재 가족 월 cache를 비우고 refresh + broadcast 순서로 정합성을 맞춘다.
 - 캘린더 메인 화면은 `height: 100dvh`와 `touchAction` 제어를 사용한다.

--- a/docs/PROJECT_MAP.md
+++ b/docs/PROJECT_MAP.md
@@ -142,7 +142,8 @@ Current behavior:
 - 월 이벤트 캐시는 최대 12개월까지 유지된다.
 - 가족 전체 일정과 캘린더 전용 일정을 함께 지원한다.
 - 캘린더 생성/수정/삭제와 멤버 관리가 가능하다.
-- 이벤트 생성/수정은 API route 뒤의 `create_event_with_reminders`, `update_event_with_reminders` RPC로 원자 저장한다.
+- 이벤트 생성/수정은 API route 뒤의 authorized RPC로 이벤트와 reminder를 원자 저장한다.
+- 오늘 이후의 단일 날짜 일반 일정은 기존 event ID를 유지한 채 반복 일정으로 전환할 수 있다. 과거/여러 날 일정 전환과 반복 해제는 아직 지원하지 않는다.
 - 이벤트 삭제는 API route에서 권한 검증 후 수행한다.
 - 이벤트 생성/수정/삭제 시 관련 멤버에게 push notification을 보낼 수 있다.
 - holiday overlay, lunar display, year-month picker, swipe month navigation을 제공한다.

--- a/src/__tests__/api/events/recurring.test.ts
+++ b/src/__tests__/api/events/recurring.test.ts
@@ -142,6 +142,118 @@ describe('POST /api/events (recurring)', () => {
   })
 })
 
+// ── PATCH: regular event conversion ──────────────────────────
+
+describe('PATCH /api/events/[id] (regular -> recurring)', () => {
+  const conversionBody = {
+    calendarId: null,
+    title: '주간 회의',
+    description: '회의 메모',
+    startAt: '2099-04-17T09:00:00.000Z',
+    endAt: '2099-04-17T10:00:00.000Z',
+    localStartDate: '2099-04-17',
+    localEndDate: '2099-04-17',
+    isAllDay: false,
+    reminderMinutes: [10],
+    labelColor: null,
+    recurrence: { freq: 'weekly', interval: 1 },
+  }
+
+  it('scope 없는 recurrence 객체는 원자 전환 RPC를 호출한다', async () => {
+    mockRpc.mockResolvedValue({
+      data: {
+        is_changed: true,
+        family_id: FAMILY_ID,
+        new_calendar_id: null,
+        new_title: '주간 회의',
+        new_start_at: '2099-04-17T09:00:00.000Z',
+        series_id: SERIES_ID,
+        event_count: 53,
+      },
+      error: null,
+    })
+
+    const res = await PATCH(
+      makeRequest('PATCH', `http://localhost/api/events/${EVENT_ID}`, conversionBody),
+      makeParams(EVENT_ID)
+    )
+
+    expect(res.status).toBe(204)
+    expect(mockRpc).toHaveBeenCalledWith(
+      'convert_event_to_recurring_series_authorized',
+      expect.objectContaining({
+        p_actor_user_id: ACTOR_USER_ID,
+        p_event_id: EVENT_ID,
+        p_local_start_date: '2099-04-17',
+        p_local_end_date: '2099-04-17',
+        p_freq: 'weekly',
+        p_interval: 1,
+        p_days_of_week: [],
+        p_today: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+      })
+    )
+    expect(mockSendEventNotification).toHaveBeenCalledTimes(1)
+    expect(mockSendEventNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'updated', eventTitle: '주간 회의' })
+    )
+  })
+
+  it('이미 반복 전환된 stale 요청은 409를 반환한다', async () => {
+    mockRpc.mockResolvedValue({ data: null, error: { message: 'already_recurring' } })
+
+    const res = await PATCH(
+      makeRequest('PATCH', `http://localhost/api/events/${EVENT_ID}`, conversionBody),
+      makeParams(EVENT_ID)
+    )
+
+    expect(res.status).toBe(409)
+    expect(mockSendEventNotification).not.toHaveBeenCalled()
+  })
+
+  it('여러 날 일정 전환은 RPC 호출 전에 400을 반환한다', async () => {
+    const res = await PATCH(
+      makeRequest('PATCH', `http://localhost/api/events/${EVENT_ID}`, {
+        ...conversionBody,
+        localEndDate: '2099-04-18',
+        endAt: '2099-04-18T10:00:00.000Z',
+      }),
+      makeParams(EVENT_ID)
+    )
+
+    expect(res.status).toBe(400)
+    expect(mockRpc).not.toHaveBeenCalled()
+  })
+
+  it('timestamp와 local date가 다르면 RPC 호출 전에 400을 반환한다', async () => {
+    const res = await PATCH(
+      makeRequest('PATCH', `http://localhost/api/events/${EVENT_ID}`, {
+        ...conversionBody,
+        localStartDate: '2099-04-18',
+        localEndDate: '2099-04-18',
+      }),
+      makeParams(EVENT_ID)
+    )
+
+    expect(res.status).toBe(400)
+    expect(mockRpc).not.toHaveBeenCalled()
+  })
+
+  it('주간 반복 요일에 시작 요일이 없으면 400을 반환한다', async () => {
+    const startDay = new Date(`${conversionBody.localStartDate}T00:00:00Z`).getUTCDay()
+    const otherDay = (startDay + 1) % 7
+    const res = await PATCH(
+      makeRequest('PATCH', `http://localhost/api/events/${EVENT_ID}`, {
+        ...conversionBody,
+        recurrence: { freq: 'weekly', interval: 1, daysOfWeek: [otherDay] },
+      }),
+      makeParams(EVENT_ID)
+    )
+
+    expect(res.status).toBe(400)
+    expect(mockRpc).not.toHaveBeenCalled()
+  })
+})
+
 // ── PATCH: series scope ───────────────────────────────────────
 
 describe('PATCH /api/events/[id] (series scope)', () => {

--- a/src/__tests__/components/CalendarTab.test.tsx
+++ b/src/__tests__/components/CalendarTab.test.tsx
@@ -104,6 +104,28 @@ jest.mock('@/components/calendar/DayEventsSheet', () => ({
       >
         event
       </button>
+      <button
+        data-testid="select-regular-event"
+        onClick={() => onSelectEvent({
+          id: 'evt-regular-1',
+          family_id: 'fam-1',
+          calendar_id: 'cal-1',
+          title: '일반 일정',
+          description: null,
+          start_at: '2026-04-17T09:00:00.000Z',
+          end_at: '2026-04-17T10:00:00.000Z',
+          is_all_day: false,
+          created_by: 'user-1',
+          created_at: '',
+          updated_at: '',
+          series_id: null,
+          series_occurrence_date: null,
+          is_cancelled: false,
+          label_color: null,
+        })}
+      >
+        regular event
+      </button>
     </div>
   ),
 }))
@@ -179,6 +201,24 @@ jest.mock('@/components/calendar/EventFormModal', () => ({
       })}
     >
       save following recurrence
+    </button>
+    <button
+      data-testid="event-form-save-convert-recurrence"
+      onClick={() => onSave({
+        calendarId: 'cal-1',
+        title: '일반 일정',
+        description: null,
+        startAt: '2026-09-02T01:00:00.000Z',
+        endAt: '2026-09-02T02:00:00.000Z',
+        localStartDate: '2026-09-02',
+        localEndDate: '2026-09-02',
+        isAllDay: false,
+        reminderMinutes: [10],
+        recurrence: { freq: 'weekly', interval: 1 },
+        labelColor: '#f97316',
+      })}
+    >
+      convert recurrence
     </button>
     </>
   ),
@@ -678,6 +718,33 @@ describe('CalendarTab — touch-action 스크롤 차단', () => {
         })
       )
     })
+  })
+
+  it('일반 일정 반복 전환은 scope 없이 recurrence와 local date를 PATCH한다', async () => {
+    render(<CalendarTab {...defaultProps} />)
+    await act(async () => {})
+
+    fireEvent.click(screen.getByTestId('select-date'))
+    fireEvent.click(await screen.findByTestId('select-regular-event'))
+    fireEvent.click(await screen.findByTestId('detail-edit'))
+    fireEvent.click(await screen.findByTestId('event-form-save-convert-recurrence'))
+
+    await waitFor(() => {
+      expect(mockPatchJsonWithAuth).toHaveBeenCalledWith(
+        '/api/events/evt-regular-1',
+        expect.objectContaining({
+          startAt: '2026-09-02T01:00:00.000Z',
+          endAt: '2026-09-02T02:00:00.000Z',
+          localStartDate: '2026-09-02',
+          localEndDate: '2026-09-02',
+          recurrence: { freq: 'weekly', interval: 1 },
+        })
+      )
+    })
+
+    const payload = mockPatchJsonWithAuth.mock.calls.at(-1)?.[1] as Record<string, unknown>
+    expect(payload).not.toHaveProperty('scope')
+    expect(payload).not.toHaveProperty('anchorOccurrenceDate')
   })
 })
 

--- a/src/__tests__/components/EventFormModal.test.tsx
+++ b/src/__tests__/components/EventFormModal.test.tsx
@@ -672,6 +672,140 @@ describe('EventFormModal', () => {
     )
   })
 
+  it('일반 일정 편집에서 반복 규칙을 선택하면 확인 후 전환 저장한다', async () => {
+    jest.setSystemTime(new Date('2026-08-20T00:00:00Z'))
+    const onSave = jest.fn().mockResolvedValue(undefined)
+    const initial: import('@/lib/calendar').CalendarEvent = {
+      id: 'evt-regular-1',
+      family_id: 'fam-1',
+      calendar_id: 'cal-1',
+      created_by: 'user-1',
+      title: '일반 일정',
+      description: '메모',
+      start_at: '2026-09-02T01:00:00.000Z',
+      end_at: '2026-09-02T02:00:00.000Z',
+      is_all_day: false,
+      is_cancelled: false,
+      label_color: null,
+      series_id: null,
+      series_occurrence_date: null,
+      created_at: '',
+      updated_at: '',
+    }
+
+    render(<EventFormModal {...defaultProps} initial={initial} onSave={onSave} />)
+
+    fireEvent.click(screen.getByText('안 함'))
+    fireEvent.click(screen.getByText('매주'))
+    await act(async () => {
+      fireEvent.click(screen.getByText('저장'))
+    })
+
+    expect(onSave).not.toHaveBeenCalled()
+    expect(screen.getByTestId('recurrence-conversion-confirm')).toBeInTheDocument()
+    expect(screen.getByText('반복 해제는 아직 지원하지 않아요.', { exact: false })).toBeInTheDocument()
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('반복으로 전환'))
+    })
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: '일반 일정',
+        localStartDate: '2026-09-02',
+        localEndDate: '2026-09-02',
+        recurrence: { freq: 'weekly', interval: 1 },
+      })
+    )
+  })
+
+  it('일반 일정의 반복 전환 확인을 취소하면 저장하지 않는다', async () => {
+    jest.setSystemTime(new Date('2026-08-20T00:00:00Z'))
+    const onSave = jest.fn().mockResolvedValue(undefined)
+    const initial: import('@/lib/calendar').CalendarEvent = {
+      id: 'evt-regular-1',
+      family_id: 'fam-1',
+      calendar_id: 'cal-1',
+      created_by: 'user-1',
+      title: '일반 일정',
+      description: null,
+      start_at: '2026-09-02T01:00:00.000Z',
+      end_at: '2026-09-02T02:00:00.000Z',
+      is_all_day: false,
+      is_cancelled: false,
+      label_color: null,
+      series_id: null,
+      series_occurrence_date: null,
+      created_at: '',
+      updated_at: '',
+    }
+
+    render(<EventFormModal {...defaultProps} initial={initial} onSave={onSave} />)
+    fireEvent.click(screen.getByText('안 함'))
+    fireEvent.click(screen.getByText('매일'))
+    fireEvent.click(screen.getByText('저장'))
+    fireEvent.click(screen.getByText('취소'))
+
+    expect(onSave).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('recurrence-conversion-confirm')).not.toBeInTheDocument()
+  })
+
+  it('과거 일반 일정은 반복 일정으로 전환할 수 없다', () => {
+    jest.setSystemTime(new Date('2026-08-20T00:00:00Z'))
+    const initial: import('@/lib/calendar').CalendarEvent = {
+      id: 'evt-past',
+      family_id: 'fam-1',
+      calendar_id: 'cal-1',
+      created_by: 'user-1',
+      title: '과거 일정',
+      description: null,
+      start_at: '2026-08-18T01:00:00.000Z',
+      end_at: '2026-08-18T02:00:00.000Z',
+      is_all_day: false,
+      is_cancelled: false,
+      label_color: null,
+      series_id: null,
+      series_occurrence_date: null,
+      created_at: '',
+      updated_at: '',
+    }
+
+    render(<EventFormModal {...defaultProps} initial={initial} />)
+    fireEvent.click(screen.getByText('안 함'))
+    fireEvent.click(screen.getByText('매일'))
+
+    expect(screen.getByText('과거 일정은 반복 일정으로 전환할 수 없어요.')).toBeInTheDocument()
+    expect(screen.getByText('저장')).toBeDisabled()
+  })
+
+  it('여러 날에 걸친 일반 일정은 반복 일정으로 전환할 수 없다', () => {
+    jest.setSystemTime(new Date('2026-08-20T00:00:00Z'))
+    const initial: import('@/lib/calendar').CalendarEvent = {
+      id: 'evt-multi-day',
+      family_id: 'fam-1',
+      calendar_id: 'cal-1',
+      created_by: 'user-1',
+      title: '여러 날 일정',
+      description: null,
+      start_at: '2026-09-02T01:00:00.000Z',
+      end_at: '2026-09-03T02:00:00.000Z',
+      is_all_day: false,
+      is_cancelled: false,
+      label_color: null,
+      series_id: null,
+      series_occurrence_date: null,
+      created_at: '',
+      updated_at: '',
+    }
+
+    render(<EventFormModal {...defaultProps} initial={initial} />)
+    fireEvent.click(screen.getByText('안 함'))
+    fireEvent.click(screen.getByText('매일'))
+
+    expect(screen.getByText('여러 날에 걸친 일정은 아직 반복 일정으로 전환할 수 없어요.')).toBeInTheDocument()
+    expect(screen.getByText('저장')).toBeDisabled()
+  })
+
   it('following 반복 일정은 기존 반복 규칙을 표시하고 변경된 규칙을 저장한다', async () => {
     const initial: import('@/lib/calendar').CalendarEvent = {
       id: 'evt-1',

--- a/src/__tests__/lib/convert-event-recurrence-sql.test.ts
+++ b/src/__tests__/lib/convert-event-recurrence-sql.test.ts
@@ -1,0 +1,42 @@
+import fs from 'fs'
+import path from 'path'
+
+const migrationPath = path.join(
+  process.cwd(),
+  'supabase/migrations/20260820000000_convert_event_to_recurring_series.sql'
+)
+const sql = fs.readFileSync(migrationPath, 'utf8')
+
+describe('convert_event_to_recurring_series_authorized migration', () => {
+  it('기존 event를 잠그고 이미 반복 전환된 요청을 거부한다', () => {
+    expect(sql).toContain('FOR UPDATE')
+    expect(sql).toContain("RAISE EXCEPTION 'already_recurring'")
+  })
+
+  it('기존 event id를 유지한 채 첫 occurrence로 연결한다', () => {
+    expect(sql).toContain('WHERE id = p_event_id')
+    expect(sql).toContain('series_id = v_series_id')
+    expect(sql).toContain('series_occurrence_date = p_local_start_date')
+    expect(sql).not.toContain('DELETE FROM events')
+  })
+
+  it('같은 transaction에서 rule, series, reminder, occurrence를 생성한다', () => {
+    expect(sql).toContain('INSERT INTO recurrence_rules')
+    expect(sql).toContain('INSERT INTO recurrence_series')
+    expect(sql).toContain('DELETE FROM event_reminders WHERE event_id = p_event_id')
+    expect(sql).toContain('PERFORM insert_series_event_instance')
+  })
+
+  it('과거·여러 날·시작 요일 불일치 전환을 방어한다', () => {
+    expect(sql).toContain("RAISE EXCEPTION 'past_event'")
+    expect(sql).toContain("RAISE EXCEPTION 'multi_day_event'")
+    expect(sql).toContain("RAISE EXCEPTION 'invalid_local_date'")
+    expect(sql).toContain("AT TIME ZONE 'Asia/Tokyo'")
+    expect(sql).toContain("RAISE EXCEPTION 'start_day_not_selected'")
+  })
+
+  it('클라이언트 실행 권한을 닫고 service role만 허용한다', () => {
+    expect(sql).toContain('FROM public, anon, authenticated')
+    expect(sql).toContain('TO service_role')
+  })
+})

--- a/src/app/api/events/[id]/route.ts
+++ b/src/app/api/events/[id]/route.ts
@@ -5,6 +5,7 @@ import { sendEventNotification } from '@/lib/push-utils'
 import type { RecurrenceScope } from '@/types/recurrence'
 import { VALID_SCOPES } from '@/types/recurrence'
 import { ALLOWED_LABEL_COLORS } from '@/lib/label-colors'
+import { REMINDER_TIME_ZONE } from '@/lib/reminders'
 
 interface RecurrenceInput {
   freq: 'daily' | 'weekly' | 'monthly' | 'yearly'
@@ -56,6 +57,107 @@ function getIsoDatePart(value: string): string {
   return new Date(value).toISOString().slice(0, 10)
 }
 
+function getDateInReminderTimeZone(date: Date): string {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: REMINDER_TIME_ZONE,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(date)
+  const year = parts.find((part) => part.type === 'year')?.value
+  const month = parts.find((part) => part.type === 'month')?.value
+  const day = parts.find((part) => part.type === 'day')?.value
+  return `${year}-${month}-${day}`
+}
+
+function getTodayInReminderTimeZone(): string {
+  return getDateInReminderTimeZone(new Date())
+}
+
+function isDateString(value: unknown): value is string {
+  if (typeof value !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return false
+  const parsed = new Date(`${value}T00:00:00Z`)
+  return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value
+}
+
+function addYears(date: string, years: number): string {
+  const value = new Date(`${date}T00:00:00Z`)
+  value.setUTCFullYear(value.getUTCFullYear() + years)
+  return value.toISOString().slice(0, 10)
+}
+
+function getRegularConversionError(body: UpdateEventRequest): string | null {
+  const recurrence = body.recurrence
+  if (!recurrence || !body.title?.trim() || !body.startAt || !body.endAt
+      || !isDateString(body.localStartDate) || !isDateString(body.localEndDate)
+      || typeof body.isAllDay !== 'boolean' || !Array.isArray(body.reminderMinutes)) {
+    return 'Invalid recurrence conversion request'
+  }
+  if (body.localStartDate < getTodayInReminderTimeZone()) {
+    return 'Past events cannot be converted to recurring events'
+  }
+  if (body.localStartDate !== body.localEndDate) {
+    return 'Multi-day events cannot be converted to recurring events'
+  }
+
+  const startAt = new Date(body.startAt)
+  const endAt = new Date(body.endAt)
+  if (Number.isNaN(startAt.getTime()) || Number.isNaN(endAt.getTime()) || endAt < startAt) {
+    return 'Invalid event range'
+  }
+  if (
+    getDateInReminderTimeZone(startAt) !== body.localStartDate
+    || getDateInReminderTimeZone(endAt) !== body.localEndDate
+  ) {
+    return 'Invalid local event date'
+  }
+  if (!['daily', 'weekly', 'monthly', 'yearly'].includes(recurrence.freq)) {
+    return 'Invalid recurrence frequency'
+  }
+  if (!Number.isInteger(recurrence.interval) || recurrence.interval < 1) {
+    return 'Invalid recurrence interval'
+  }
+
+  if (recurrence.freq === 'weekly' && recurrence.daysOfWeek?.length) {
+    const uniqueDays = new Set(recurrence.daysOfWeek)
+    if (
+      uniqueDays.size !== recurrence.daysOfWeek.length
+      || recurrence.daysOfWeek.some((day) => !Number.isInteger(day) || day < 0 || day > 6)
+    ) {
+      return 'Invalid recurrence days'
+    }
+
+    const startDay = new Date(`${body.localStartDate}T00:00:00Z`).getUTCDay()
+    if (!uniqueDays.has(startDay)) {
+      return 'The recurrence days must include the event start day'
+    }
+  }
+
+  if (
+    recurrence.freq === 'monthly'
+    && recurrence.dayOfMonth !== undefined
+    && recurrence.dayOfMonth !== null
+    && (!Number.isInteger(recurrence.dayOfMonth) || recurrence.dayOfMonth < 1 || recurrence.dayOfMonth > 31)
+  ) {
+    return 'Invalid recurrence day of month'
+  }
+
+  if (
+    recurrence.endDate !== undefined
+    && recurrence.endDate !== null
+    && (!isDateString(recurrence.endDate)
+      || recurrence.endDate < body.localStartDate
+      || recurrence.endDate > addYears(body.localStartDate, 2))
+  ) {
+    return 'Invalid recurrence end date'
+  }
+
+  if (body.reminderMinutes.some((minutes) => !Number.isInteger(minutes) || minutes <= 0)) {
+    return 'Invalid reminder minutes'
+  }
+  return null
+}
+
 export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const actorUserId = await getAuthenticatedUserId(req)
   if (!actorUserId) {
@@ -96,6 +198,62 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
       { error: 'Changing occurrence date is only supported for following scope' },
       { status: 400 }
     )
+  }
+
+  // ── Regular event -> recurring series ─────────────────────
+  if (!scope && body.recurrence) {
+    const validationError = getRegularConversionError(body)
+    if (validationError) {
+      return NextResponse.json({ error: validationError }, { status: 400 })
+    }
+
+    const { data: result, error } = await supabaseAdmin.rpc(
+      'convert_event_to_recurring_series_authorized',
+      {
+        p_actor_user_id:    actorUserId,
+        p_event_id:         eventId,
+        p_calendar_id:      body.calendarId ?? null,
+        p_title:            body.title!,
+        p_description:      body.description ?? null,
+        p_start_at:         body.startAt!,
+        p_end_at:           body.endAt!,
+        p_local_start_date: body.localStartDate!,
+        p_local_end_date:   body.localEndDate!,
+        p_is_all_day:       body.isAllDay!,
+        p_reminder_minutes: body.reminderMinutes!,
+        p_freq:             body.recurrence.freq,
+        p_interval:         body.recurrence.interval,
+        p_days_of_week:     body.recurrence.daysOfWeek ?? [],
+        p_day_of_month:     body.recurrence.dayOfMonth ?? null,
+        p_end_date:         body.recurrence.endDate ?? null,
+        p_label_color:      body.labelColor ?? null,
+        p_today:            getTodayInReminderTimeZone(),
+      }
+    )
+
+    if (error) {
+      if (error.message === 'not_found') return NextResponse.json({ error: 'Event not found' }, { status: 404 })
+      if (error.message === 'already_recurring') return NextResponse.json({ error: 'Event is already recurring' }, { status: 409 })
+      if (error.message === 'forbidden') return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+      if (error.message === 'past_event') return NextResponse.json({ error: 'Past events cannot be converted to recurring events' }, { status: 400 })
+      if (error.message === 'multi_day_event') return NextResponse.json({ error: 'Multi-day events cannot be converted to recurring events' }, { status: 400 })
+      if (error.message === 'start_day_not_selected') return NextResponse.json({ error: 'The recurrence days must include the event start day' }, { status: 400 })
+      if (error.message.startsWith('invalid_')) return NextResponse.json({ error: 'Invalid recurrence conversion request' }, { status: 400 })
+      return NextResponse.json({ error: 'Failed to convert event to recurring series' }, { status: 500 })
+    }
+
+    const { family_id, new_calendar_id, new_title, new_start_at } = result as UpdateResult
+    after(async () => {
+      await sendEventNotification({
+        familyId: family_id,
+        calendarId: new_calendar_id,
+        actorUserId,
+        action: 'updated',
+        eventTitle: new_title,
+        eventStartAt: new_start_at,
+      })
+    })
+    return new NextResponse(null, { status: 204 })
   }
 
   // ── Series update ────────────────────────────────────────

--- a/src/components/calendar/EventFormModal.tsx
+++ b/src/components/calendar/EventFormModal.tsx
@@ -8,6 +8,7 @@ import { TimeWheelPicker } from './TimeWheelPicker'
 import { RecurrencePickerSheet } from './RecurrencePickerSheet'
 import { RecurrenceCustomModal } from './RecurrenceCustomModal'
 import { buildRecurrenceLabel, type RecurrenceRule, type RecurrenceScope } from '@/types/recurrence'
+import { REMINDER_TIME_ZONE } from '@/lib/reminders'
 
 const DOW_KR = ['일', '월', '화', '수', '목', '금', '토']
 
@@ -51,6 +52,19 @@ function buildISO(date: string, time: string): string {
 
 function buildAllDayISO(date: string): string {
   return new Date(date + 'T00:00:00').toISOString()
+}
+
+function getTodayInReminderTimeZone(): string {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: REMINDER_TIME_ZONE,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(new Date())
+  const year = parts.find((part) => part.type === 'year')?.value
+  const month = parts.find((part) => part.type === 'month')?.value
+  const day = parts.find((part) => part.type === 'day')?.value
+  return `${year}-${month}-${day}`
 }
 
 function isSameRecurrenceRule(a: RecurrenceRule | null, b: RecurrenceRule | null): boolean {
@@ -149,8 +163,10 @@ export function EventFormModal({
   const [saving, setSaving] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
   const [dateError, setDateError] = useState<string | null>(null)
+  const [showConversionConfirm, setShowConversionConfirm] = useState(false)
 
   const isNewEvent = !initial
+  const isRegularEventEdit = Boolean(initial && !initial.series_id)
   const followingAnchorDate = initial?.series_id && recurrenceScope === 'following'
     ? initial.series_occurrence_date
     : null
@@ -165,6 +181,17 @@ export function EventFormModal({
   const isAllSeriesEdit = Boolean(initial?.series_id && recurrenceScope === 'all')
   const canEditStartDate = !isAllSeriesEdit
   const canEditEndDate = !isAllSeriesEdit && !isFollowingSeriesEdit
+  const regularConversionError = isRegularEventEdit && recurrence
+    ? startDate < getTodayInReminderTimeZone()
+      ? '과거 일정은 반복 일정으로 전환할 수 없어요.'
+      : startDate !== endDate
+        ? '여러 날에 걸친 일정은 아직 반복 일정으로 전환할 수 없어요.'
+        : recurrence.freq === 'weekly'
+          && recurrence.daysOfWeek?.length
+          && !recurrence.daysOfWeek.includes(new Date(`${startDate}T00:00:00Z`).getUTCDay())
+          ? '반복 요일에 일정 시작 요일을 포함해주세요.'
+          : null
+    : null
 
   const titleInputRef = useRef<HTMLInputElement>(null)
   const startDateInputRef = useRef<HTMLInputElement>(null)
@@ -300,9 +327,9 @@ export function EventFormModal({
     })
   }
 
-  const handleSave = async () => {
+  const persistEvent = async () => {
     if (!title.trim() || !startDate) return
-    if (dateError) return
+    if (dateError || regularConversionError) return
     if (followingAnchorDate && startDate < followingAnchorDate) {
       setDateError('이후 일정은 선택한 일정 날짜 이후로만 이동할 수 있어요.')
       return
@@ -326,7 +353,9 @@ export function EventFormModal({
         localEndDate: endDate,
         isAllDay,
         reminderMinutes: Array.from(reminderMinutes),
-        recurrence: isNewEvent || (isFollowingSeriesEdit && !isSameRecurrenceRule(recurrence, initialRecurrence))
+        recurrence: isNewEvent
+          || isRegularEventEdit
+          || (isFollowingSeriesEdit && !isSameRecurrenceRule(recurrence, initialRecurrence))
           ? recurrence
           : null,
         labelColor,
@@ -338,6 +367,15 @@ export function EventFormModal({
     } finally {
       setSaving(false)
     }
+  }
+
+  const handleSave = async () => {
+    if (dateError || regularConversionError) return
+    if (isRegularEventEdit && recurrence) {
+      setShowConversionConfirm(true)
+      return
+    }
+    await persistEvent()
   }
 
   const timeBtnCls = (active: boolean) =>
@@ -374,7 +412,7 @@ export function EventFormModal({
         </button>
         <button
           onClick={handleSave}
-          disabled={!title.trim() || !startDate || saving || Boolean(dateError)}
+          disabled={!title.trim() || !startDate || saving || Boolean(dateError || regularConversionError)}
           className="rounded-full border border-stone-200 bg-stone-50 px-7 py-2 text-sm font-bold text-stone-800 transition-colors hover:bg-stone-100 disabled:opacity-40 dark:border-stone-800 dark:bg-stone-950 dark:text-stone-100 dark:hover:bg-stone-900 sm:px-8 sm:py-2.5"
         >
           저장
@@ -394,8 +432,8 @@ export function EventFormModal({
           />
         </div>
 
-        {(dateError ?? saveError) && (
-          <p className="mx-6 mb-3 rounded-2xl bg-red-50 px-4 py-3 text-sm text-red-500 dark:bg-red-950/30 dark:text-red-300">{dateError ?? saveError}</p>
+        {(dateError ?? regularConversionError ?? saveError) && (
+          <p className="mx-6 mb-3 rounded-2xl bg-red-50 px-4 py-3 text-sm text-red-500 dark:bg-red-950/30 dark:text-red-300">{dateError ?? regularConversionError ?? saveError}</p>
         )}
 
         <div className="border-y border-stone-200/70 dark:border-stone-900">
@@ -658,7 +696,7 @@ export function EventFormModal({
           </div>
 
           {/* 반복 */}
-          {(isNewEvent || isFollowingSeriesEdit) && (
+          {(isNewEvent || isRegularEventEdit || isFollowingSeriesEdit) && (
             <button
               type="button"
               onClick={() => setRecurrenceModal('picker')}
@@ -684,7 +722,7 @@ export function EventFormModal({
           onSelect={(rule) => { setRecurrence(rule); setRecurrenceModal(null) }}
           onCustomize={() => setRecurrenceModal('custom')}
           onClose={() => setRecurrenceModal(null)}
-          allowNone={isNewEvent}
+          allowNone={isNewEvent || isRegularEventEdit}
         />
       )}
 
@@ -695,6 +733,46 @@ export function EventFormModal({
           onSave={(rule) => { setCustomRule(rule); setRecurrence(rule); setRecurrenceModal(null) }}
           onBack={() => setRecurrenceModal('picker')}
         />
+      )}
+
+      {showConversionConfirm && (
+        <div
+          className="fixed inset-0 z-[100] flex items-center justify-center bg-black/55 px-5"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="recurrence-conversion-title"
+          data-testid="recurrence-conversion-confirm"
+        >
+          <div className="w-full max-w-sm rounded-2xl bg-white p-5 shadow-2xl dark:bg-stone-900">
+            <h2 id="recurrence-conversion-title" className="text-lg font-bold text-stone-900 dark:text-stone-100">
+              반복 일정으로 전환할까요?
+            </h2>
+            <p className="mt-2 text-sm leading-6 text-stone-500 dark:text-stone-400">
+              현재 일정이 반복 일정의 첫 일정이 됩니다. 반복 해제는 아직 지원하지 않아요.
+            </p>
+            <div className="mt-5 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setShowConversionConfirm(false)}
+                disabled={saving}
+                className="rounded-xl px-4 py-2 text-sm font-semibold text-stone-500 transition-colors hover:bg-stone-100 disabled:opacity-50 dark:text-stone-400 dark:hover:bg-stone-800"
+              >
+                취소
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setShowConversionConfirm(false)
+                  void persistEvent()
+                }}
+                disabled={saving}
+                className="rounded-xl bg-accent-400 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-accent-500 disabled:opacity-50"
+              >
+                반복으로 전환
+              </button>
+            </div>
+          </div>
+        </div>
       )}
       </div>
     </div>

--- a/src/components/tabs/CalendarTab.tsx
+++ b/src/components/tabs/CalendarTab.tsx
@@ -805,6 +805,9 @@ export function CalendarTab({
           scope === 'following' &&
           params.recurrence
         )
+        const isRegularRecurrenceConversion = Boolean(
+          !editingEvent.event.series_id && params.recurrence
+        )
         const shouldSplitFollowingSeries = isFollowingDateChange || isFollowingRecurrenceChange
         await Promise.all([
           patchJsonWithAuth(`/api/events/${editingEvent.event.id}`, {
@@ -818,7 +821,9 @@ export function CalendarTab({
             isAllDay: params.isAllDay,
             reminderMinutes: params.reminderMinutes,
             labelColor: params.labelColor,
-            ...(isFollowingRecurrenceChange ? { recurrence: params.recurrence } : {}),
+            ...(isFollowingRecurrenceChange || isRegularRecurrenceConversion
+              ? { recurrence: params.recurrence }
+              : {}),
             ...(isScopedSeriesEdit && !params.isAllDay ? {
               startTime: getLocalTimePart(params.startAt),
               endTime: params.endAt ? getLocalTimePart(params.endAt) : null,

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -910,6 +910,29 @@ export type Database = {
         }
         Returns: { series_id: string; event_count: number }[]
       }
+      convert_event_to_recurring_series_authorized: {
+        Args: {
+          p_actor_user_id: string
+          p_event_id: string
+          p_calendar_id: string | null
+          p_title: string
+          p_description: string | null
+          p_start_at: string
+          p_end_at: string
+          p_local_start_date: string
+          p_local_end_date: string
+          p_is_all_day: boolean
+          p_reminder_minutes: number[]
+          p_freq: string
+          p_interval: number
+          p_days_of_week: number[]
+          p_day_of_month: number | null
+          p_end_date: string | null
+          p_label_color: string | null
+          p_today: string
+        }
+        Returns: Json
+      }
       delete_series_authorized: {
         Args: {
           p_actor_user_id: string

--- a/supabase/migrations/20260820000000_convert_event_to_recurring_series.sql
+++ b/supabase/migrations/20260820000000_convert_event_to_recurring_series.sql
@@ -1,0 +1,276 @@
+-- Convert an existing same-day event into a recurring series without replacing
+-- the original event row. This preserves its id and dependent records while
+-- creating the recurrence rule, series, and future occurrences atomically.
+
+CREATE OR REPLACE FUNCTION convert_event_to_recurring_series_authorized(
+  p_actor_user_id    uuid,
+  p_event_id         uuid,
+  p_calendar_id      uuid,
+  p_title            text,
+  p_description      text,
+  p_start_at         timestamptz,
+  p_end_at           timestamptz,
+  p_local_start_date date,
+  p_local_end_date   date,
+  p_is_all_day       boolean,
+  p_reminder_minutes integer[],
+  p_freq             text,
+  p_interval         integer,
+  p_days_of_week     integer[],
+  p_day_of_month     integer,
+  p_end_date         date,
+  p_label_color      text,
+  p_today            date
+)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_event          events%rowtype;
+  v_has_access     boolean;
+  v_rule_id        uuid;
+  v_series_id      uuid;
+  v_horizon        date;
+  v_start_time     time;
+  v_end_time       time;
+  v_days_of_week   integer[];
+  v_day_of_month   integer;
+  v_current_date   date;
+  v_week_start     date;
+  v_occurrence     date;
+  v_day            integer;
+  v_count          integer := 0;
+BEGIN
+  IF p_actor_user_id IS NULL OR p_today IS NULL THEN
+    RAISE EXCEPTION 'invalid_request';
+  END IF;
+
+  SELECT * INTO v_event
+  FROM events
+  WHERE id = p_event_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN RAISE EXCEPTION 'not_found'; END IF;
+  IF v_event.series_id IS NOT NULL THEN RAISE EXCEPTION 'already_recurring'; END IF;
+
+  IF v_event.calendar_id IS NOT NULL THEN
+    SELECT (
+      EXISTS(
+        SELECT 1 FROM calendars
+        WHERE id = v_event.calendar_id AND family_id = v_event.family_id
+      )
+      AND EXISTS(
+        SELECT 1 FROM calendar_members
+        WHERE calendar_id = v_event.calendar_id AND user_id = p_actor_user_id
+      )
+    ) INTO v_has_access;
+  ELSE
+    SELECT EXISTS(
+      SELECT 1 FROM family_members
+      WHERE family_id = v_event.family_id AND user_id = p_actor_user_id
+    ) INTO v_has_access;
+  END IF;
+
+  IF NOT v_has_access THEN RAISE EXCEPTION 'forbidden'; END IF;
+
+  IF p_calendar_id IS NOT NULL THEN
+    SELECT (
+      EXISTS(
+        SELECT 1 FROM calendars
+        WHERE id = p_calendar_id AND family_id = v_event.family_id
+      )
+      AND EXISTS(
+        SELECT 1 FROM calendar_members
+        WHERE calendar_id = p_calendar_id AND user_id = p_actor_user_id
+      )
+    ) INTO v_has_access;
+
+    IF NOT v_has_access THEN RAISE EXCEPTION 'forbidden'; END IF;
+  END IF;
+
+  IF p_title IS NULL OR btrim(p_title) = '' OR p_start_at IS NULL OR p_end_at IS NULL
+     OR p_local_start_date IS NULL OR p_local_end_date IS NULL
+     OR p_is_all_day IS NULL OR p_reminder_minutes IS NULL
+  THEN
+    RAISE EXCEPTION 'invalid_request';
+  END IF;
+
+  IF p_local_start_date < p_today THEN RAISE EXCEPTION 'past_event'; END IF;
+  IF p_local_start_date <> p_local_end_date THEN RAISE EXCEPTION 'multi_day_event'; END IF;
+  IF p_end_at < p_start_at THEN RAISE EXCEPTION 'invalid_event_range'; END IF;
+  IF (p_start_at AT TIME ZONE 'Asia/Tokyo')::date <> p_local_start_date
+     OR (p_end_at AT TIME ZONE 'Asia/Tokyo')::date <> p_local_end_date
+  THEN
+    RAISE EXCEPTION 'invalid_local_date';
+  END IF;
+
+  IF p_freq NOT IN ('daily', 'weekly', 'monthly', 'yearly') THEN
+    RAISE EXCEPTION 'invalid_frequency';
+  END IF;
+  IF p_interval IS NULL OR p_interval < 1 THEN RAISE EXCEPTION 'invalid_interval'; END IF;
+
+  IF p_freq = 'weekly' THEN
+    v_days_of_week := CASE
+      WHEN cardinality(p_days_of_week) > 0 THEN p_days_of_week
+      ELSE ARRAY[EXTRACT(DOW FROM p_local_start_date)::integer]
+    END;
+
+    IF EXISTS (
+      SELECT 1 FROM unnest(v_days_of_week) AS selected_day
+      WHERE selected_day < 0 OR selected_day > 6
+    ) OR cardinality(v_days_of_week) <> (
+      SELECT count(DISTINCT selected_day)::integer FROM unnest(v_days_of_week) AS selected_day
+    ) THEN
+      RAISE EXCEPTION 'invalid_days_of_week';
+    END IF;
+
+    IF NOT (EXTRACT(DOW FROM p_local_start_date)::integer = ANY(v_days_of_week)) THEN
+      RAISE EXCEPTION 'start_day_not_selected';
+    END IF;
+  ELSE
+    v_days_of_week := NULL;
+  END IF;
+
+  IF p_freq = 'monthly' THEN
+    v_day_of_month := COALESCE(p_day_of_month, EXTRACT(DAY FROM p_local_start_date)::integer);
+    IF v_day_of_month < 1 OR v_day_of_month > 31 THEN
+      RAISE EXCEPTION 'invalid_day_of_month';
+    END IF;
+  ELSE
+    v_day_of_month := NULL;
+  END IF;
+
+  IF p_end_date IS NOT NULL AND (
+    p_end_date < p_local_start_date
+    OR p_end_date > (p_local_start_date + INTERVAL '2 years')::date
+  ) THEN
+    RAISE EXCEPTION 'invalid_end_date';
+  END IF;
+
+  v_horizon := LEAST(
+    COALESCE(p_end_date, (p_local_start_date + INTERVAL '1 year')::date),
+    (p_local_start_date + INTERVAL '2 years')::date
+  );
+
+  IF NOT p_is_all_day THEN
+    v_start_time := p_start_at::time;
+    v_end_time := p_end_at::time;
+  END IF;
+
+  INSERT INTO recurrence_rules (freq, interval, days_of_week, day_of_month, end_date)
+  VALUES (p_freq, p_interval, v_days_of_week, v_day_of_month, p_end_date)
+  RETURNING id INTO v_rule_id;
+
+  INSERT INTO recurrence_series (
+    family_id, calendar_id, title, description, is_all_day,
+    start_time, end_time, reminder_minutes, rule_id, created_by
+  ) VALUES (
+    v_event.family_id, p_calendar_id, p_title, p_description, p_is_all_day,
+    v_start_time, v_end_time, p_reminder_minutes, v_rule_id, v_event.created_by
+  )
+  RETURNING id INTO v_series_id;
+
+  UPDATE events SET
+    calendar_id = p_calendar_id,
+    title = p_title,
+    description = p_description,
+    start_at = p_start_at,
+    end_at = p_end_at,
+    is_all_day = p_is_all_day,
+    label_color = p_label_color,
+    series_id = v_series_id,
+    series_occurrence_date = p_local_start_date,
+    is_cancelled = false,
+    updated_at = now()
+  WHERE id = p_event_id;
+
+  DELETE FROM event_reminders WHERE event_id = p_event_id;
+  IF cardinality(p_reminder_minutes) > 0 THEN
+    INSERT INTO event_reminders (event_id, remind_minutes_before)
+    SELECT p_event_id, unnest(p_reminder_minutes);
+  END IF;
+
+  IF p_freq = 'daily' THEN
+    v_current_date := p_local_start_date;
+    WHILE v_current_date <= v_horizon LOOP
+      PERFORM insert_series_event_instance(
+        v_series_id, v_event.family_id, v_event.created_by, p_calendar_id,
+        p_title, p_description, p_is_all_day,
+        v_start_time, v_end_time, v_current_date, p_reminder_minutes, p_label_color
+      );
+      v_count := v_count + 1;
+      v_current_date := v_current_date + (p_interval || ' days')::interval;
+    END LOOP;
+  ELSIF p_freq = 'weekly' THEN
+    v_week_start := p_local_start_date - EXTRACT(DOW FROM p_local_start_date)::integer;
+    WHILE v_week_start <= v_horizon LOOP
+      FOREACH v_day IN ARRAY v_days_of_week LOOP
+        v_current_date := v_week_start + v_day;
+        IF v_current_date >= p_local_start_date AND v_current_date <= v_horizon THEN
+          PERFORM insert_series_event_instance(
+            v_series_id, v_event.family_id, v_event.created_by, p_calendar_id,
+            p_title, p_description, p_is_all_day,
+            v_start_time, v_end_time, v_current_date, p_reminder_minutes, p_label_color
+          );
+          v_count := v_count + 1;
+        END IF;
+      END LOOP;
+      v_week_start := v_week_start + (p_interval * 7 || ' days')::interval;
+    END LOOP;
+  ELSIF p_freq = 'monthly' THEN
+    v_current_date := p_local_start_date;
+    WHILE date_trunc('month', v_current_date)::date <= date_trunc('month', v_horizon)::date LOOP
+      v_occurrence := (
+        date_trunc('month', v_current_date) + (v_day_of_month - 1) * interval '1 day'
+      )::date;
+      IF EXTRACT(MONTH FROM v_occurrence) = EXTRACT(MONTH FROM date_trunc('month', v_current_date))
+         AND v_occurrence >= p_local_start_date
+         AND v_occurrence <= v_horizon
+      THEN
+        PERFORM insert_series_event_instance(
+          v_series_id, v_event.family_id, v_event.created_by, p_calendar_id,
+          p_title, p_description, p_is_all_day,
+          v_start_time, v_end_time, v_occurrence, p_reminder_minutes, p_label_color
+        );
+        v_count := v_count + 1;
+      END IF;
+      v_current_date := (
+        date_trunc('month', v_current_date) + (p_interval || ' months')::interval
+      )::date;
+    END LOOP;
+  ELSE
+    v_current_date := p_local_start_date;
+    WHILE v_current_date <= v_horizon LOOP
+      PERFORM insert_series_event_instance(
+        v_series_id, v_event.family_id, v_event.created_by, p_calendar_id,
+        p_title, p_description, p_is_all_day,
+        v_start_time, v_end_time, v_current_date, p_reminder_minutes, p_label_color
+      );
+      v_count := v_count + 1;
+      v_current_date := (v_current_date + (p_interval || ' years')::interval)::date;
+    END LOOP;
+  END IF;
+
+  RETURN json_build_object(
+    'is_changed', true,
+    'family_id', v_event.family_id,
+    'new_calendar_id', p_calendar_id,
+    'new_title', p_title,
+    'new_start_at', p_start_at,
+    'series_id', v_series_id,
+    'event_count', v_count
+  );
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION convert_event_to_recurring_series_authorized(
+  uuid, uuid, uuid, text, text, timestamptz, timestamptz, date, date,
+  boolean, integer[], text, integer, integer[], integer, date, text, date
+) FROM public, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION convert_event_to_recurring_series_authorized(
+  uuid, uuid, uuid, text, text, timestamptz, timestamptz, date, date,
+  boolean, integer[], text, integer, integer[], integer, date, text, date
+) TO service_role;


### PR DESCRIPTION
## Summary

- 일반 일정 수정 화면에서 반복 옵션을 선택할 수 있게 합니다.
- 기존 event ID를 유지하면서 반복 규칙, series, 미래 occurrence, reminder를 원자적으로 생성합니다.
- 과거 일정, 여러 날 일정, 시작 요일이 빠진 주간 반복 전환을 차단합니다.
- 반복 전환 전 확인창을 표시하고 반복 해제는 이번 범위에서 제외합니다.

## Testing

- [x] `npm run test -- --runInBand` (71 suites, 721 tests)
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] 테스트 환경 변수로 `npm run build`
- [x] 브라우저에서 반복 선택, 취소, 확인, payload, 과거/여러 날 제한 확인
- [x] 390x844 모바일 화면과 브라우저 console 오류 확인
- [ ] 운영 Supabase migration 적용 및 본방 smoke test