### PR TITLE
polish: remove splash logo background

### DIFF
--- a/src/__tests__/components/Splash.test.tsx
+++ b/src/__tests__/components/Splash.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react'
+import { AppSplash } from '@/components/AppSplash'
+import { PreHydrationSplash } from '@/components/PreHydrationSplash'
+
+describe('splash logo presentation', () => {
+  it('renders the app splash logo directly without a background wrapper', () => {
+    render(<AppSplash animateLogo />)
+
+    const splash = screen.getByRole('status', { name: '앱을 불러오는 중' })
+    const logo = splash.querySelector('img')
+
+    expect(splash.children).toHaveLength(1)
+    expect(logo).toBe(splash.firstElementChild)
+    expect(logo).toHaveClass('splash-logo-fade-in')
+  })
+
+  it('renders the pre-hydration logo directly without a background wrapper', () => {
+    const { container } = render(<PreHydrationSplash />)
+
+    const splash = container.querySelector('#koko-pre-splash')
+    const logo = splash?.querySelector('img')
+
+    expect(splash?.children).toHaveLength(1)
+    expect(logo).toBe(splash?.firstElementChild)
+    expect(container.querySelector('#koko-pre-splash-logo')).not.toBeInTheDocument()
+  })
+})

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -52,7 +52,7 @@ export default function RootLayout({
           href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard-jp.min.css"
         />
         <link rel="preload" href="/logo.webp" as="image" />
-        <style dangerouslySetInnerHTML={{ __html: `#koko-pre-splash{background:#fafaf9}@media(prefers-color-scheme:dark){#koko-pre-splash{background:#0f0e0d}}.dark #koko-pre-splash{background:#0f0e0d}#koko-pre-splash-logo{background:rgba(245,245,244,0.8)}@media(prefers-color-scheme:dark){#koko-pre-splash-logo{background:rgba(255,255,255,0.1)}}.dark #koko-pre-splash-logo{background:rgba(255,255,255,0.1)}` }} />
+        <style dangerouslySetInnerHTML={{ __html: `#koko-pre-splash{background:#fafaf9}@media(prefers-color-scheme:dark){#koko-pre-splash{background:#0f0e0d}}.dark #koko-pre-splash{background:#0f0e0d}` }} />
       </head>
       <body className="min-h-full flex flex-col bg-[var(--background)] text-[var(--foreground)]">
         <PreHydrationSplash />

--- a/src/components/AppSplash.tsx
+++ b/src/components/AppSplash.tsx
@@ -7,15 +7,14 @@ interface Props {
 export function AppSplash({ animateLogo = false }: Props) {
   return (
     <div role="status" aria-label="앱을 불러오는 중" className="fixed inset-0 flex items-center justify-center bg-[var(--background)]">
-      <div className={`${animateLogo ? 'splash-logo-fade-in ' : ''}rounded-full bg-[var(--surface-overlay)] ring-1 ring-[var(--surface-ring)] p-6`}>
-        <Image
-          src="/logo.webp"
-          alt=""
-          width={96}
-          height={96}
-          priority
-        />
-      </div>
+      <Image
+        src="/logo.webp"
+        alt=""
+        width={96}
+        height={96}
+        priority
+        className={animateLogo ? 'splash-logo-fade-in' : undefined}
+      />
     </div>
   )
 }

--- a/src/components/PreHydrationSplash.tsx
+++ b/src/components/PreHydrationSplash.tsx
@@ -25,14 +25,9 @@ export function PreHydrationSplash() {
         justifyContent: 'center',
       }}
     >
-      <div
-        id="koko-pre-splash-logo"
-        style={{ borderRadius: '9999px', padding: '24px', boxShadow: '0 0 0 1px rgba(0,0,0,0.05)' }}
-      >
-        {/* next/image requires hydration; this splash must render before hydration */}
-        {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img src="/logo.webp" alt="" width={96} height={96} />
-      </div>
+      {/* next/image requires hydration; this splash must render before hydration */}
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img src="/logo.webp" alt="" width={96} height={96} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- React 스플래시에서 로고를 감싸던 회색 원형 배경, 패딩, 테두리를 제거했습니다.
- hydration 이전 스플래시에서도 같은 wrapper와 인라인 배경 스타일을 제거했습니다.
- 기존 fade-in 애니메이션은 로고 이미지 자체에 유지했습니다.
- 두 로딩 경로에서 로고가 직접 렌더링되는 회귀 테스트를 추가했습니다.

## Testing
- `npm run test -- --runInBand` (73 suites, 726 tests passed)
- `npm run test -- --runInBand src/__tests__/components/Splash.test.tsx` (2 tests passed)
- `npm run lint`
- `npx tsc --noEmit`
- [x] 390×844 모바일 다크 화면에서 회색 원 없이 96px 로고만 중앙에 표시되는지 확인
- [x] 로고 잘림, 비율 왜곡, 배경 깜빡임이 없는지 확인