### PR TITLE
fix: restore iOS PWA calendar height

### DIFF
--- a/docs/CHALLENGES.md
+++ b/docs/CHALLENGES.md
@@ -244,13 +244,14 @@ JS `preventDefault()` 대신 CSS `touch-action: none`을 사용했다.
 
 ### 해결
 
-- `TabsShell`은 viewport 단위 높이 대신 `position: fixed; inset: 0`으로 화면을 점유한다.
+- `position: fixed; inset: 0`은 일부 iOS PWA에서 작은 containing viewport에 고정되어 하단 빈 공간을 만들므로 사용하지 않는다.
+- `TabsShell`은 동적 viewport가 순간적으로 작아져도 화면 비율을 유지하도록 `height: 100lvh`로 화면을 점유한다.
 - 탭 내부 로딩/빈/오류 화면은 `100vh`를 계산하지 않고 부모 셸의 높이를 사용한다.
 - 전체 화면 리마인더 상세 오버레이가 상단과 하단 safe area를 직접 적용한다.
 
 ### 남은 규칙
 
-- 탭 셸 또는 전체 화면 오버레이에 `100vh`/`100dvh`를 높이의 유일한 기준으로 다시 도입하지 않는다.
+- 탭 셸에 `position: fixed; inset: 0`이나 `100dvh`를 높이의 유일한 기준으로 다시 도입하지 않는다.
 - fixed 전체 화면 오버레이는 셸의 safe area를 상속한다고 가정하지 않는다.
 
 ---

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -86,7 +86,7 @@ DB migration -> src/types/database.ts -> src/lib/* -> src/hooks/* -> src/app/* -
 - 일반 일정의 반복 전환은 오늘 이후의 단일 날짜 일정만 허용하며, 주간 사용자 지정 반복은 원본 일정의 시작 요일을 포함해야 한다.
 - 이 RPC들은 service role route에서만 호출한다. 클라이언트 실행 권한을 다시 열지 않는다.
 - 이벤트 저장 후에는 현재 가족 월 cache를 비우고 refresh + broadcast 순서로 정합성을 맞춘다.
-- 앱 탭 셸은 iOS PWA의 동적 viewport 재계산에 의존하지 않도록 `position: fixed; inset: 0`으로 화면을 점유한다.
+- 앱 탭 셸은 iOS PWA의 작은 fixed containing viewport나 동적 viewport 재계산에 의존하지 않도록 `height: 100lvh`로 화면을 점유한다.
 - 탭 콘텐츠는 `100vh`/`100dvh` 대신 셸이 제공하는 `h-full`/`min-h-full` 높이를 사용하고, 전체 화면 오버레이는 자체적으로 safe area를 적용한다.
 - 캘린더 메인 화면은 셸이 제공한 높이 안에서 `touchAction` 제어를 사용한다.
 - 세로 스크롤 차단이 필요하면 JS `preventDefault()`보다 CSS `touch-action`을 우선한다.

--- a/src/__tests__/TabsShell.test.tsx
+++ b/src/__tests__/TabsShell.test.tsx
@@ -122,12 +122,13 @@ describe('TabsShell', () => {
     expect(screen.getByTestId('bottom-nav')).toBeInTheDocument()
   })
 
-  it('viewport 단위 높이 없이 fixed app shell로 화면을 점유한다', () => {
+  it('fixed containing viewport 대신 안정적인 large viewport 높이를 사용한다', () => {
     render(<TabsShell />)
 
     const shell = screen.getByTestId('tabs-shell')
-    expect(shell).toHaveClass('fixed', 'inset-0', 'overflow-hidden')
-    expect(shell.style.height).toBe('')
+    expect(shell).toHaveClass('overflow-hidden')
+    expect(shell).not.toHaveClass('fixed', 'inset-0')
+    expect(shell).toHaveStyle({ height: '100lvh' })
     expect(shell).toHaveStyle({ paddingTop: 'env(safe-area-inset-top, 0px)' })
   })
 

--- a/src/components/TabsShell.tsx
+++ b/src/components/TabsShell.tsx
@@ -163,8 +163,12 @@ export function TabsShell() {
   return (
     <div
       data-testid="tabs-shell"
-      className="fixed inset-0 flex flex-col overflow-hidden"
-      style={{ boxSizing: 'border-box', paddingTop: 'env(safe-area-inset-top, 0px)' }}
+      className="flex flex-col overflow-hidden"
+      style={{
+        height: '100lvh',
+        boxSizing: 'border-box',
+        paddingTop: 'env(safe-area-inset-top, 0px)',
+      }}
     >
       <div className="flex-1 min-h-0 relative">
         <div className={`absolute inset-0 flex flex-col min-h-0 overflow-hidden${activeTab !== 'calendar' ? ' hidden' : ''}`}>


### PR DESCRIPTION
## Summary
- iOS 설치형 PWA에서 앱 셸이 작은 fixed containing viewport에 고정되던 `fixed inset-0` 구조를 제거했습니다.
- 동적 viewport가 순간적으로 작아져도 기존 캘린더 비율을 유지하도록 앱 셸 높이를 `100lvh`로 변경했습니다.
- 앞선 수정의 리마인더 safe area와 탭 내부 부모 높이 규칙은 유지했습니다.
- iOS PWA 셸 높이 계약을 테스트와 프로젝트 문서에 반영했습니다.

## Testing
- `npm run test -- --runInBand` (73 suites, 729 tests passed)
- `npx tsc --noEmit`
- `npm run lint`
- [ ] 운영 배포 후 실제 iPhone PWA에서 캘린더 하단 빈 공간과 행 비율 확인