### PR TITLE
fix: fill standalone PWA viewport

### DIFF
--- a/docs/CHALLENGES.md
+++ b/docs/CHALLENGES.md
@@ -245,13 +245,15 @@ JS `preventDefault()` 대신 CSS `touch-action: none`을 사용했다.
 ### 해결
 
 - 캘린더 메타데이터가 준비될 때까지 splash를 유지하고, 로딩 완료 또는 실패가 확정된 뒤 `TabsShell`을 마운트한다.
-- 기존에 안정적으로 동작하던 `height: 100dvh` 셸을 유지하고, 작은 containing viewport를 잡는 `position: fixed; inset: 0`은 사용하지 않는다.
+- 일반 브라우저에서는 `100dvh`를 유지하되, 설치형 PWA에서는 브라우저 UI용 작은 viewport를 피하도록 `100vh` fallback과 `100lvh`를 사용한다.
+- 작은 containing viewport를 잡는 `position: fixed; inset: 0`은 사용하지 않는다.
 - 탭 내부 로딩/빈/오류 화면은 `100vh`를 계산하지 않고 부모 셸의 높이를 사용한다.
 - 전체 화면 리마인더 상세 오버레이가 상단과 하단 safe area를 직접 적용한다.
 
 ### 남은 규칙
 
 - 캘린더 메타데이터 로딩 중 `TabsShell`을 다시 조기 마운트하지 않는다.
+- 설치형 PWA 셸을 `100dvh`만으로 채우지 않는다.
 - 탭 셸에 `position: fixed; inset: 0`을 사용하지 않는다.
 - fixed 전체 화면 오버레이는 셸의 safe area를 상속한다고 가정하지 않는다.
 

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -86,7 +86,7 @@ DB migration -> src/types/database.ts -> src/lib/* -> src/hooks/* -> src/app/* -
 - 일반 일정의 반복 전환은 오늘 이후의 단일 날짜 일정만 허용하며, 주간 사용자 지정 반복은 원본 일정의 시작 요일을 포함해야 한다.
 - 이 RPC들은 service role route에서만 호출한다. 클라이언트 실행 권한을 다시 열지 않는다.
 - 이벤트 저장 후에는 현재 가족 월 cache를 비우고 refresh + broadcast 순서로 정합성을 맞춘다.
-- 앱 탭 셸은 캘린더 메타데이터 로딩이 끝나 viewport가 안정된 뒤 마운트하며, `height: 100dvh`와 `border-box`로 화면을 점유한다.
+- 앱 탭 셸은 캘린더 메타데이터 로딩이 끝난 뒤 마운트한다. 일반 브라우저는 `100dvh`, 설치형 PWA는 `100vh` fallback과 `100lvh`로 화면을 점유한다.
 - 탭 콘텐츠는 `100vh`/`100dvh` 대신 셸이 제공하는 `h-full`/`min-h-full` 높이를 사용하고, 전체 화면 오버레이는 자체적으로 safe area를 적용한다.
 - 캘린더 메인 화면은 셸이 제공한 높이 안에서 `touchAction` 제어를 사용한다.
 - 세로 스크롤 차단이 필요하면 JS `preventDefault()`보다 CSS `touch-action`을 우선한다.

--- a/src/__tests__/TabsShell.test.tsx
+++ b/src/__tests__/TabsShell.test.tsx
@@ -134,13 +134,13 @@ describe('TabsShell', () => {
     expect(screen.getByTestId('bottom-nav')).toBeInTheDocument()
   })
 
-  it('viewport가 안정된 뒤 기존 dynamic viewport 셸을 마운트한다', () => {
+  it('브라우저 모드에 맞는 viewport CSS 변수로 셸을 채운다', () => {
     render(<TabsShell />)
 
     const shell = screen.getByTestId('tabs-shell')
     expect(shell).toHaveClass('overflow-hidden')
     expect(shell).not.toHaveClass('fixed', 'inset-0')
-    expect(shell).toHaveStyle({ height: '100dvh' })
+    expect(shell).toHaveStyle({ height: 'var(--app-viewport-height)' })
     expect(shell).toHaveStyle({ paddingTop: 'env(safe-area-inset-top, 0px)' })
   })
 

--- a/src/__tests__/app/AppViewportCss.test.ts
+++ b/src/__tests__/app/AppViewportCss.test.ts
@@ -1,0 +1,18 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+const css = fs.readFileSync(path.join(process.cwd(), 'src/app/globals.css'), 'utf8')
+
+describe('app viewport height CSS', () => {
+  it('일반 브라우저는 dynamic viewport 높이를 사용한다', () => {
+    expect(css).toContain('--app-viewport-height: 100dvh;')
+  })
+
+  it('standalone PWA는 large viewport 높이와 fallback을 사용한다', () => {
+    const standaloneRules = css.match(
+      /@media \(display-mode: standalone\) \{[\s\S]*?--app-viewport-height: 100vh;[\s\S]*?@supports \(height: 100lvh\) \{[\s\S]*?--app-viewport-height: 100lvh;/
+    )
+
+    expect(standaloneRules).not.toBeNull()
+  })
+})

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,6 +7,7 @@
   --foreground: #1c1917;
   --surface-overlay: rgba(245, 245, 244, 0.8);
   --surface-ring: rgba(0, 0, 0, 0.05);
+  --app-viewport-height: 100dvh;
 
   /* Default theme: tangerine (orange) */
   --accent-50: #fff7ed;
@@ -18,6 +19,18 @@
   --accent-600: #ea580c;
   --accent-700: #c2410c;
   --accent-950: #431407;
+}
+
+@media (display-mode: standalone) {
+  :root {
+    --app-viewport-height: 100vh;
+  }
+
+  @supports (height: 100lvh) {
+    :root {
+      --app-viewport-height: 100lvh;
+    }
+  }
 }
 
 .dark {

--- a/src/components/TabsShell.tsx
+++ b/src/components/TabsShell.tsx
@@ -166,7 +166,7 @@ export function TabsShell() {
       data-testid="tabs-shell"
       className="flex flex-col overflow-hidden"
       style={{
-        height: '100dvh',
+        height: 'var(--app-viewport-height)',
         boxSizing: 'border-box',
         paddingTop: 'env(safe-area-inset-top, 0px)',
       }}


### PR DESCRIPTION
## Summary
- 실제 iPhone 캡처에서 화면 높이 약 844px와 `100dvh` 셸 높이 약 720px의 차이가 하단 공백과 일치하는 것을 확인했습니다.
- 일반 Safari는 기존 `100dvh`를 유지하고, 설치형 PWA에서만 `100vh` fallback과 `100lvh`를 사용하도록 viewport 높이를 분리했습니다.
- 캘린더 그리드, 일정 데이터, 탭 마운트, 하단 내비게이션 높이는 변경하지 않았습니다.
- standalone viewport CSS 계약을 테스트와 프로젝트 문서에 반영했습니다.

## Testing
- `npm run test -- --runInBand` (74 suites, 732 tests passed)
- `npx tsc --noEmit`
- `npm run lint`
- 일회성 더미 Supabase/VAPID 환경값을 사용한 `npm run build`
- 빌드 CSS에서 기본 `100dvh`, standalone `100vh`/`100lvh` 규칙 생성 확인
- [ ] 운영 배포 후 실제 iPhone PWA를 완전히 종료·재실행하여 하단 공백과 일정 칩 표시량 확인