### PR TITLE
fix: restore calendar grid space

### DIFF
--- a/docs/CHALLENGES.md
+++ b/docs/CHALLENGES.md
@@ -247,6 +247,7 @@ JS `preventDefault()` 대신 CSS `touch-action: none`을 사용했다.
 - 캘린더 메타데이터가 준비될 때까지 splash를 유지하고, 로딩 완료 또는 실패가 확정된 뒤 `TabsShell`을 마운트한다.
 - 일반 브라우저에서는 `100dvh`를 유지하되, 설치형 PWA에서는 브라우저 UI용 작은 viewport를 피하도록 `100vh` fallback과 `100lvh`를 사용한다.
 - 작은 containing viewport를 잡는 `position: fixed; inset: 0`은 사용하지 않는다.
+- 하단 내비게이션의 별도 safe-area 패딩은 제거해 6주 달력의 각 행에 일정 3개를 표시할 높이를 돌려준다.
 - 탭 내부 로딩/빈/오류 화면은 `100vh`를 계산하지 않고 부모 셸의 높이를 사용한다.
 - 전체 화면 리마인더 상세 오버레이가 상단과 하단 safe area를 직접 적용한다.
 

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -87,6 +87,7 @@ DB migration -> src/types/database.ts -> src/lib/* -> src/hooks/* -> src/app/* -
 - 이 RPC들은 service role route에서만 호출한다. 클라이언트 실행 권한을 다시 열지 않는다.
 - 이벤트 저장 후에는 현재 가족 월 cache를 비우고 refresh + broadcast 순서로 정합성을 맞춘다.
 - 앱 탭 셸은 캘린더 메타데이터 로딩이 끝난 뒤 마운트한다. 일반 브라우저는 `100dvh`, 설치형 PWA는 `100vh` fallback과 `100lvh`로 화면을 점유한다.
+- 하단 내비게이션은 캘린더 셸 안에서 별도 safe-area 패딩을 예약하지 않는다. 추가 패딩은 6주 달력의 일정 칩 표시 공간을 줄인다.
 - 탭 콘텐츠는 `100vh`/`100dvh` 대신 셸이 제공하는 `h-full`/`min-h-full` 높이를 사용하고, 전체 화면 오버레이는 자체적으로 safe area를 적용한다.
 - 캘린더 메인 화면은 셸이 제공한 높이 안에서 `touchAction` 제어를 사용한다.
 - 세로 스크롤 차단이 필요하면 JS `preventDefault()`보다 CSS `touch-action`을 우선한다.

--- a/src/__tests__/components/BottomNav.test.tsx
+++ b/src/__tests__/components/BottomNav.test.tsx
@@ -9,13 +9,11 @@ import { usePathname } from 'next/navigation'
 const mockUsePathname = usePathname as jest.Mock
 
 describe('BottomNav', () => {
-  it('하단 safe area를 실제 CSS 환경값으로 확보한다', () => {
+  it('캘린더 높이를 줄이는 별도 하단 패딩을 예약하지 않는다', () => {
     mockUsePathname.mockReturnValue('/')
     const { container } = render(<BottomNav />)
 
-    expect(container.querySelector('nav')).toHaveStyle({
-      paddingBottom: 'env(safe-area-inset-bottom, 0px)',
-    })
+    expect((container.querySelector('nav') as HTMLElement).style.paddingBottom).toBe('')
   })
 
   it('리마인더와 설정 탭이 렌더링된다', () => {

--- a/src/__tests__/components/CalendarGrid.test.tsx
+++ b/src/__tests__/components/CalendarGrid.test.tsx
@@ -466,6 +466,14 @@ describe('getSingleEventDisplayBudget', () => {
     })).toEqual({ visibleCount: 2, showOverflow: true })
   })
 
+  it('하단 내비게이션 여백을 회수한 6주 셀에서는 일정 3개를 모두 표시한다', () => {
+    expect(getSingleEventDisplayBudget({
+      ...base,
+      rowHeight: 93,
+      singleEventCount: 3,
+    })).toEqual({ visibleCount: 3, showOverflow: false })
+  })
+
   it('단일 일정 영역이 0줄이면 +N도 표시하지 않는다', () => {
     expect(getSingleEventDisplayBudget({
       rowHeight: 60,

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -21,10 +21,7 @@ export function BottomNav({ activeTab, onTabChange }: Props) {
   const tabMode = !!onTabChange
 
   return (
-    <nav
-      className="shrink-0 bg-white dark:bg-stone-950 border-t border-stone-100 dark:border-stone-800"
-      style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
-    >
+    <nav className="shrink-0 bg-white dark:bg-stone-950 border-t border-stone-100 dark:border-stone-800">
       <div className="max-w-lg mx-auto flex">
         {navItems.map(({ href, icon: Icon, label }) => {
           const tabId = href.slice(1) // '/calendar' → 'calendar'


### PR DESCRIPTION
## Summary
- PR #197에서 추가된 하단 내비게이션의 별도 safe-area 패딩을 제거해 초기 로딩 개선 전 내비게이션 높이로 복원했습니다.
- 회수되는 약 34px를 6주 캘린더 행에 돌려줘 일정 3개가 `일정1 +2`로 접히지 않고 모두 표시될 높이를 확보했습니다.
- 캘린더 그리드, 일정 데이터, standalone viewport 분기는 변경하지 않았습니다.
- 6주 셀의 일정 3개 표시 경계값을 회귀 테스트로 고정했습니다.

## Testing
- `npm run test -- --runInBand` (74 suites, 733 tests passed)
- `npx tsc --noEmit`
- `npm run lint`
- [ ] 운영 배포 후 실제 iPhone PWA에서 하단 메뉴 아래 여백과 일정 3개 표시 확인