### PR TITLE
fix: prevent tab navigation remounts

### DIFF
--- a/docs/CHALLENGES.md
+++ b/docs/CHALLENGES.md
@@ -173,6 +173,7 @@ setItems((prev) =>
 ### 남은 규칙
 
 - 탭을 다시 개별 route page로 쪼개지 않는다.
+- 셸 내부 탭 변경에는 `router.replace()`를 사용하지 않는다. search param은 History API로 갱신해 `TabsShell` 재마운트와 시작 splash 재노출을 막는다.
 - 첫 마운트 전에는 보조 탭 내부 effect가 실행되지 않으므로 선행 초기화가 필요한 작업은 공유 idle warmup에 명시한다.
 - 독립 route가 필요하면 bridge 또는 외부 링크 호환 목적이 분명해야 한다.
 

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -23,6 +23,7 @@ DB migration -> src/types/database.ts -> src/lib/* -> src/hooks/* -> src/app/* -
 - `/calendar`가 가족 앱의 단일 live entry point다.
 - `/reminders`, `/settings`는 독립 화면이 아니라 `/calendar` 탭 셸로 리다이렉트한다.
 - 실제 탭 상태는 route path가 아니라 `/calendar?tab=reminders` 같은 search param으로 제어한다.
+- 셸 내부 탭 전환은 `window.history.replaceState()`로 URL만 갱신한다. `router.replace()`를 사용하면 같은 page segment가 다시 마운트되어 초기 splash와 데이터 요청이 반복될 수 있다.
 - `TabsShell`은 활성 탭을 즉시 마운트하고, 리마인더와 설정은 `scheduleIdleWork()`로 순서대로 준비한 뒤 keep-alive한다.
 - 탭 상태 유지가 목적이므로 탭별 개별 route로 다시 분리하지 않는다.
 - 리마인더 상세도 메인 흐름에서는 `/calendar?tab=reminders&list=<id>` search param으로 연다.

--- a/src/__tests__/TabsShell.test.tsx
+++ b/src/__tests__/TabsShell.test.tsx
@@ -80,11 +80,20 @@ jest.mock('@/components/tabs/SettingsTab', () => ({
 }))
 
 jest.mock('@/components/BottomNav', () => ({
-  BottomNav: () => <div data-testid="bottom-nav" />,
+  BottomNav: ({ onTabChange }: {
+    onTabChange: (tab: 'calendar' | 'reminders' | 'settings') => void
+  }) => (
+    <div data-testid="bottom-nav">
+      <button onClick={() => onTabChange('calendar')}>캘린더 탭</button>
+      <button onClick={() => onTabChange('reminders')}>리마인더 탭</button>
+      <button onClick={() => onTabChange('settings')}>설정 탭</button>
+    </div>
+  ),
 }))
 
 describe('TabsShell', () => {
   beforeEach(() => {
+    window.history.replaceState(null, '', '/calendar')
     mockReplace.mockClear()
     mockReloadFamily.mockClear()
     mockReloadCalendars.mockClear()
@@ -96,6 +105,10 @@ describe('TabsShell', () => {
     mockCalendarsError = null
     mockAuthUser = { id: 'user-1' }
     jest.useRealTimers()
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
   })
 
   it('인증 로딩 중에는 AppSplash를 표시한다', () => {
@@ -168,6 +181,29 @@ describe('TabsShell', () => {
     render(<TabsShell />)
     expect(screen.getByTestId('calendar-tab').parentElement).not.toHaveClass('hidden')
     expect(screen.queryByTestId('reminder-tab')).not.toBeInTheDocument()
+  })
+
+  it('탭 전환은 셸을 다시 탐색하지 않고 URL만 교체한다', async () => {
+    const replaceState = jest.spyOn(window.history, 'replaceState')
+    const user = userEvent.setup()
+
+    render(<TabsShell />)
+    await user.click(screen.getByRole('button', { name: '리마인더 탭' }))
+
+    expect(replaceState).toHaveBeenCalledWith(null, '', '/calendar?tab=reminders')
+    expect(mockReplace).not.toHaveBeenCalled()
+    replaceState.mockRestore()
+  })
+
+  it('다른 탭으로 전환하면 리마인더 상세 파라미터를 제거한다', async () => {
+    window.history.replaceState(null, '', '/calendar?tab=reminders&list=list-1')
+    const user = userEvent.setup()
+
+    render(<TabsShell />)
+    await user.click(screen.getByRole('button', { name: '설정 탭' }))
+
+    expect(window.location.pathname).toBe('/calendar')
+    expect(window.location.search).toBe('?tab=settings')
   })
 
   it('캘린더 진입 후 idle 시점에 리마인더와 설정 탭을 hidden 상태로 예열한다', async () => {

--- a/src/components/TabsShell.tsx
+++ b/src/components/TabsShell.tsx
@@ -158,7 +158,8 @@ export function TabsShell() {
   if (needsFamilyOnboarding) return null
 
   const handleTabChange = (tab: Tab) => {
-    router.replace(tab === 'calendar' ? '/calendar' : `/calendar?tab=${tab}`)
+    const href = tab === 'calendar' ? '/calendar' : `/calendar?tab=${tab}`
+    window.history.replaceState(null, '', href)
   }
 
   return (


### PR DESCRIPTION
## Summary
- 탭 전환 시 `router.replace()` 대신 Next.js가 지원하는 History API로 URL만 갱신합니다.
- `TabsShell` 재마운트로 인증·가족·캘린더 초기화와 시작 로고가 반복되는 경로를 제거합니다.
- 다른 탭으로 이동할 때 리마인더 상세 `list` 파라미터가 제거되는 기존 URL 동작을 유지합니다.
- 탭 셸 라우팅 계약을 문서화하고 회귀 테스트를 추가합니다.

## Testing
- [x] `npm run test -- --runInBand src/__tests__/TabsShell.test.tsx src/__tests__/components/BottomNav.test.tsx`
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [ ] 설치형 iOS PWA를 콜드 스타트한 직후 리마인더 탭을 눌러 로고 화면이 다시 나타나지 않는지 수동 확인