### PR TITLE
fix: preload reminder tab chunk

### DIFF
--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -114,6 +114,7 @@ DB migration -> src/types/database.ts -> src/lib/* -> src/hooks/* -> src/app/* -
 ## 9. Background Warmup
 
 - 사용자 입력과 무관한 chunk/data warmup은 `src/lib/idle-work.ts`의 공유 queue를 사용한다.
+- 첫 탭 전환에 필요한 리마인더 코드 청크는 셸 준비 직후 요청하되, 실제 탭 마운트와 데이터 effect는 idle queue에서 시작한다.
 - 한 idle slot에서는 한 작업만 실행하고, 사용자 접근 가능성이 높은 작업부터 `high`, `normal`, `low` 우선순위를 부여한다.
 - 예약된 작업은 컴포넌트 cleanup에서 취소하며, 사용자 진입 경로는 idle warmup 완료를 전제로 하지 않는다.
 

--- a/src/__tests__/TabsShell.test.tsx
+++ b/src/__tests__/TabsShell.test.tsx
@@ -13,6 +13,8 @@ let mockFamilyError: Error | null = null
 let mockCalendarsError: Error | null = null
 const mockReloadFamily = jest.fn().mockResolvedValue(undefined)
 const mockReloadCalendars = jest.fn().mockResolvedValue(undefined)
+const mockLoadReminderTab = jest.fn()
+const mockLoadSettingsTab = jest.fn()
 
 jest.mock('next/navigation', () => ({
   useRouter: () => ({ replace: mockReplace, push: jest.fn() }),
@@ -52,6 +54,11 @@ jest.mock('@/lib/supabase', () => ({
 
 jest.mock('@/lib/push', () => ({
   registerPushSubscription: jest.fn().mockResolvedValue(undefined),
+}))
+
+jest.mock('@/components/tab-loaders', () => ({
+  loadReminderTab: () => mockLoadReminderTab(),
+  loadSettingsTab: () => mockLoadSettingsTab(),
 }))
 
 jest.mock('@/components/AppSplash', () => ({
@@ -104,6 +111,10 @@ describe('TabsShell', () => {
     mockFamilyError = null
     mockCalendarsError = null
     mockAuthUser = { id: 'user-1' }
+    mockLoadReminderTab.mockReset()
+    mockLoadReminderTab.mockResolvedValue(() => <div data-testid="reminder-tab" />)
+    mockLoadSettingsTab.mockReset()
+    mockLoadSettingsTab.mockResolvedValue(() => <div data-testid="settings-tab" />)
     jest.useRealTimers()
   })
 
@@ -231,6 +242,31 @@ describe('TabsShell', () => {
     })
 
     expect(screen.getByTestId('settings-tab').parentElement).toHaveClass('hidden')
+  })
+
+  it('셸 준비 직후 리마인더 코드는 예열하지만 탭 데이터 effect는 idle 전까지 시작하지 않는다', () => {
+    render(<TabsShell />)
+
+    expect(mockLoadReminderTab).toHaveBeenCalledTimes(1)
+    expect(screen.queryByTestId('reminder-tab')).not.toBeInTheDocument()
+  })
+
+  it('리마인더 코드 예열 실패가 캘린더 셸을 다시 splash로 돌리지 않는다', async () => {
+    const preloadError = new Error('chunk failed')
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    mockLoadReminderTab.mockRejectedValueOnce(preloadError)
+
+    render(<TabsShell />)
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(screen.queryByTestId('app-splash')).not.toBeInTheDocument()
+    expect(screen.getByTestId('calendar-tab')).toBeInTheDocument()
+    expect(warn).toHaveBeenCalledWith(
+      '[TabsShell] reminder tab chunk preload failed:',
+      preloadError
+    )
   })
 
   it('초기 진입 시 자동으로 푸시 구독을 요청하지 않는다', () => {

--- a/src/components/TabsShell.tsx
+++ b/src/components/TabsShell.tsx
@@ -12,16 +12,17 @@ import { useUserPreferences } from '@/hooks/useUserPreferences'
 import { type Tab, TABS } from '@/types/tabs'
 import { AppSplash } from '@/components/AppSplash'
 import { scheduleIdleWork } from '@/lib/idle-work'
+import { loadReminderTab, loadSettingsTab } from '@/components/tab-loaders'
 
 const IDLE_PRELOAD_TABS: Tab[] = ['reminders', 'settings']
 
 const ReminderTab = dynamic(
-  () => import('@/components/tabs/ReminderTab').then((mod) => mod.ReminderTab),
+  loadReminderTab,
   { loading: () => <TabChunkFallback /> }
 )
 
 const SettingsTab = dynamic(
-  () => import('@/components/tabs/SettingsTab').then((mod) => mod.SettingsTab),
+  loadSettingsTab,
   { loading: () => <TabChunkFallback /> }
 )
 
@@ -95,6 +96,11 @@ export function TabsShell() {
 
   useEffect(() => {
     if (isInitializing || startupError || !user || needsFamilyOnboarding) return
+
+    // Warm the first likely tab transition without mounting it or starting its data effects.
+    void loadReminderTab().catch((error) => {
+      console.warn('[TabsShell] reminder tab chunk preload failed:', error)
+    })
 
     // Let the calendar paint first, then hidden-mount one secondary tab per idle slot.
     const cancelPreloads = IDLE_PRELOAD_TABS.map((tab) => scheduleIdleWork(() => {

--- a/src/components/tab-loaders.ts
+++ b/src/components/tab-loaders.ts
@@ -1,0 +1,7 @@
+export function loadReminderTab() {
+  return import('@/components/tabs/ReminderTab').then((mod) => mod.ReminderTab)
+}
+
+export function loadSettingsTab() {
+  return import('@/components/tabs/SettingsTab').then((mod) => mod.SettingsTab)
+}


### PR DESCRIPTION
## Summary
- 캘린더 셸 준비 직후 리마인더 코드 청크를 백그라운드에서 먼저 요청합니다.
- 리마인더 탭의 실제 마운트와 데이터 조회는 기존 idle preload 순서를 유지합니다.
- 청크 사전 로드 실패를 처리해 캘린더 셸이나 시작 스플래시로 오류가 번지지 않도록 합니다.
- 탭 청크 loader를 공유해 사전 요청과 `next/dynamic`이 동일한 import 경로를 사용하도록 합니다.

## Testing
- [x] `npm run test -- --runInBand` (74 suites, 739 tests)
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run build` 컴파일 및 TypeScript 단계 통과
- [ ] 로컬 빌드의 page data 수집은 운영 Supabase/VAPID 환경 변수가 없어 기존 `/api/cron/cleanup-reminders`에서 중단됨
- [ ] 배포 후 iPhone PWA를 새로 실행하고 캘린더가 열린 직후 리마인더 탭 전환 확인