### PR TITLE
fix: repair push subscription lifecycle

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,13 +1,26 @@
+self.addEventListener('install', (event) => {
+  event.waitUntil(self.skipWaiting())
+})
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(clients.claim())
+})
+
 self.addEventListener('push', (event) => {
   const data = event.data?.json() ?? {}
+  const options = {
+    body: data.body ?? '',
+    icon: '/icons/icon-192.png?v=2',
+    badge: '/icons/icon-192.png?v=2',
+    data: { url: data.url ?? '/' },
+  }
+
+  if (typeof data.tag === 'string' && data.tag) {
+    options.tag = data.tag
+  }
+
   event.waitUntil(
-    self.registration.showNotification(data.title ?? 'Koko', {
-      body: data.body ?? '',
-      icon: '/icons/icon-192.png?v=2',
-      badge: '/icons/icon-192.png?v=2',
-      tag: data.tag ?? 'koko-reminder',
-      data: { url: data.url ?? '/' },
-    })
+    self.registration.showNotification(data.title ?? 'Koko', options)
   )
 })
 

--- a/src/__tests__/TabsShell.test.tsx
+++ b/src/__tests__/TabsShell.test.tsx
@@ -1,7 +1,7 @@
 import { act, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { TabsShell } from '@/components/TabsShell'
-import { registerPushSubscription } from '@/lib/push'
+import { registerPushSubscription, syncPushSubscriptionIfGranted } from '@/lib/push'
 
 const mockReplace = jest.fn()
 let mockTabParam: string | null = null
@@ -54,6 +54,7 @@ jest.mock('@/lib/supabase', () => ({
 
 jest.mock('@/lib/push', () => ({
   registerPushSubscription: jest.fn().mockResolvedValue(undefined),
+  syncPushSubscriptionIfGranted: jest.fn().mockResolvedValue('connected'),
 }))
 
 jest.mock('@/components/tab-loaders', () => ({
@@ -104,6 +105,8 @@ describe('TabsShell', () => {
     mockReplace.mockClear()
     mockReloadFamily.mockClear()
     mockReloadCalendars.mockClear()
+    ;(registerPushSubscription as jest.Mock).mockClear()
+    ;(syncPushSubscriptionIfGranted as jest.Mock).mockClear()
     mockTabParam = null
     mockAuthLoading = false
     mockFamilyLoading = false
@@ -223,6 +226,16 @@ describe('TabsShell', () => {
     render(<TabsShell />)
 
     expect(screen.getByTestId('calendar-tab').parentElement).not.toHaveClass('hidden')
+    expect(screen.queryByTestId('reminder-tab')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('settings-tab')).not.toBeInTheDocument()
+
+    await act(async () => {
+      jest.advanceTimersByTime(1300)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(syncPushSubscriptionIfGranted).toHaveBeenCalledTimes(1)
     expect(screen.queryByTestId('reminder-tab')).not.toBeInTheDocument()
     expect(screen.queryByTestId('settings-tab')).not.toBeInTheDocument()
 

--- a/src/__tests__/api/push/subscribe.test.ts
+++ b/src/__tests__/api/push/subscribe.test.ts
@@ -5,7 +5,10 @@ import { POST } from '@/app/api/push/subscribe/route'
 import { NextRequest } from 'next/server'
 
 const mockUpsert: jest.Mock = jest.fn()
-const mockFrom: jest.Mock = jest.fn(() => ({ upsert: mockUpsert }))
+const mockDeleteFinalEq: jest.Mock = jest.fn()
+const mockDeleteFirstEq: jest.Mock = jest.fn(() => ({ eq: mockDeleteFinalEq }))
+const mockDelete: jest.Mock = jest.fn(() => ({ eq: mockDeleteFirstEq }))
+const mockFrom: jest.Mock = jest.fn(() => ({ upsert: mockUpsert, delete: mockDelete }))
 const mockGetAuthenticatedUserId = jest.fn()
 
 jest.mock('@/lib/supabase-admin', () => ({
@@ -27,6 +30,7 @@ function makeRequest(body: object = {}) {
 beforeEach(() => {
   jest.clearAllMocks()
   mockGetAuthenticatedUserId.mockResolvedValue('u1')
+  mockDeleteFinalEq.mockResolvedValue({ error: null })
   process.env.NEXT_PUBLIC_SUPABASE_URL = 'http://localhost'
   process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key'
 })
@@ -56,6 +60,43 @@ describe('POST /api/push/subscribe', () => {
       { user_id: 'u1', endpoint: 'https://ep', p256dh: 'key', auth: 'auth' },
       { onConflict: 'endpoint' }
     )
+    expect(mockDelete).not.toHaveBeenCalled()
+  })
+
+  it('새 구독 저장 후 현재 사용자의 이전 endpoint를 정리한다', async () => {
+    mockUpsert.mockResolvedValue({ error: null })
+    const res = await POST(
+      makeRequest({
+        endpoint: 'https://new-ep',
+        p256dh: 'key',
+        auth: 'auth',
+        previousEndpoint: 'https://old-ep',
+      })
+    )
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ ok: true, cleanupPending: false })
+    expect(mockDeleteFirstEq).toHaveBeenCalledWith('user_id', 'u1')
+    expect(mockDeleteFinalEq).toHaveBeenCalledWith('endpoint', 'https://old-ep')
+  })
+
+  it('이전 endpoint 정리 실패는 새 구독 성공을 되돌리지 않는다', async () => {
+    mockUpsert.mockResolvedValue({ error: null })
+    mockDeleteFinalEq.mockResolvedValue({ error: { message: 'cleanup failed' } })
+    const error = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    const res = await POST(
+      makeRequest({
+        endpoint: 'https://new-ep',
+        p256dh: 'key',
+        auth: 'auth',
+        previousEndpoint: 'https://old-ep',
+      })
+    )
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ ok: true, cleanupPending: true })
+    expect(error).toHaveBeenCalled()
   })
 
   it('DB 에러 발생 시 500을 반환한다', async () => {

--- a/src/__tests__/components/SettingsTab.notification.test.tsx
+++ b/src/__tests__/components/SettingsTab.notification.test.tsx
@@ -1,7 +1,11 @@
 import { render, screen, fireEvent, act, within } from '@testing-library/react'
 import { SettingsTab } from '@/components/tabs/SettingsTab'
 import { getFamilyInfo, getFamilyMembers } from '@/lib/family'
-import { registerPushSubscription } from '@/lib/push'
+import {
+  registerPushSubscription,
+  repairPushSubscription,
+  syncPushSubscriptionIfGranted,
+} from '@/lib/push'
 import { supabase } from '@/lib/supabase'
 import { DEFAULT_THEME } from '@/lib/preferences'
 import type { User } from '@supabase/supabase-js'
@@ -18,7 +22,9 @@ jest.mock('@/lib/family', () => ({
   updateMyDisplayName: jest.fn(),
 }))
 jest.mock('@/lib/push', () => ({
-  registerPushSubscription: jest.fn().mockResolvedValue(undefined),
+  registerPushSubscription: jest.fn().mockResolvedValue('connected'),
+  repairPushSubscription: jest.fn().mockResolvedValue('connected'),
+  syncPushSubscriptionIfGranted: jest.fn().mockResolvedValue('connected'),
 }))
 jest.mock('next/navigation', () => ({ useRouter: () => ({ replace: jest.fn() }) }))
 
@@ -55,6 +61,9 @@ describe('SettingsTab 메인 화면', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     ;(getFamilyInfo as jest.Mock).mockResolvedValue({ name: '우리 가족', invite_code: 'ABC123' })
+    ;(registerPushSubscription as jest.Mock).mockResolvedValue('connected')
+    ;(repairPushSubscription as jest.Mock).mockResolvedValue('connected')
+    ;(syncPushSubscriptionIfGranted as jest.Mock).mockResolvedValue('connected')
   })
 
   it('4개 카테고리 메뉴가 표시된다', async () => {
@@ -129,6 +138,9 @@ describe('SettingsTab 앱 서브뷰 — 알림', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     ;(getFamilyInfo as jest.Mock).mockResolvedValue({ name: '우리 가족', invite_code: 'ABC123' })
+    ;(registerPushSubscription as jest.Mock).mockResolvedValue('connected')
+    ;(repairPushSubscription as jest.Mock).mockResolvedValue('connected')
+    ;(syncPushSubscriptionIfGranted as jest.Mock).mockResolvedValue('connected')
   })
 
   it('권한이 default일 때 "알림 허용하기" 버튼이 표시된다', async () => {
@@ -144,13 +156,15 @@ describe('SettingsTab 앱 서브뷰 — 알림', () => {
     expect(container.className).not.toContain('py-8')
   })
 
-  it('권한이 granted일 때 허용 상태 메시지가 표시된다', async () => {
+  it('권한이 granted일 때 실제 구독을 동기화하고 연결 상태를 표시한다', async () => {
     Object.defineProperty(window, 'Notification', {
       value: { permission: 'granted' },
       configurable: true,
     })
     await navigateToApp()
-    expect(screen.getByText('알림이 허용되어 있습니다')).toBeInTheDocument()
+    expect(await screen.findByText('알림이 연결되어 있습니다')).toBeInTheDocument()
+    expect(syncPushSubscriptionIfGranted).toHaveBeenCalledTimes(1)
+    expect(screen.getByRole('button', { name: '알림 다시 연결' })).toBeInTheDocument()
   })
 
   it('권한이 denied일 때 차단 안내 메시지가 표시된다', async () => {
@@ -170,6 +184,40 @@ describe('SettingsTab 앱 서브뷰 — 알림', () => {
     await navigateToApp()
     await act(async () => { fireEvent.click(screen.getByText('알림 허용하기')) })
     expect(registerPushSubscription).toHaveBeenCalled()
+  })
+
+  it('"알림 다시 연결" 클릭 시 기존 구독 복구를 실행한다', async () => {
+    Object.defineProperty(window, 'Notification', {
+      value: { permission: 'granted' },
+      configurable: true,
+    })
+    await navigateToApp()
+    await screen.findByText('알림이 연결되어 있습니다')
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: '알림 다시 연결' }))
+    })
+
+    expect(repairPushSubscription).toHaveBeenCalledTimes(1)
+    expect(screen.getByText('알림이 연결되어 있습니다')).toBeInTheDocument()
+  })
+
+  it('구독 복구 실패 시 연결 오류 상태를 유지한다', async () => {
+    Object.defineProperty(window, 'Notification', {
+      value: { permission: 'granted' },
+      configurable: true,
+    })
+    ;(repairPushSubscription as jest.Mock).mockRejectedValueOnce(new Error('repair failed'))
+    const error = jest.spyOn(console, 'error').mockImplementation(() => {})
+    await navigateToApp()
+    await screen.findByText('알림이 연결되어 있습니다')
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: '알림 다시 연결' }))
+    })
+
+    expect(screen.getByText('알림 연결을 확인하지 못했습니다')).toBeInTheDocument()
+    expect(error).toHaveBeenCalled()
   })
 
   it('Notification 미지원 환경에서는 알림 섹션이 표시되지 않는다', async () => {

--- a/src/__tests__/lib/push.test.ts
+++ b/src/__tests__/lib/push.test.ts
@@ -1,7 +1,11 @@
 /**
  * @jest-environment jsdom
  */
-import { registerPushSubscription } from '@/lib/push'
+import {
+  registerPushSubscription,
+  repairPushSubscription,
+  syncPushSubscriptionIfGranted,
+} from '@/lib/push'
 
 const mockPostJsonWithAuth = jest.fn()
 
@@ -12,6 +16,7 @@ jest.mock('@/lib/api-client', () => ({
 const mockGetSubscription = jest.fn()
 const mockSubscribe = jest.fn()
 const mockRegister = jest.fn()
+const mockUnsubscribe = jest.fn()
 
 const mockSubscriptionJSON = {
   endpoint: 'https://push.example.com/sub',
@@ -30,6 +35,7 @@ const mockRegistration = {
 beforeEach(() => {
   jest.clearAllMocks()
   mockPostJsonWithAuth.mockResolvedValue(undefined)
+  mockUnsubscribe.mockResolvedValue(true)
 
   process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY =
     'BDiltY7dC3CnNxamlejehgdculV7iorzypDSV1a2GDFc2d2FQoYyXcl_6J76J3HT-kTqQ7zB5hSNoKeTHxw_KvY'
@@ -125,5 +131,114 @@ describe('registerPushSubscription', () => {
     await registerPushSubscription()
 
     expect(mockRegister).not.toHaveBeenCalled()
+  })
+})
+
+describe('syncPushSubscriptionIfGranted', () => {
+  it('권한이 default이면 권한 요청이나 서비스 워커 등록을 하지 않는다', async () => {
+    const status = await syncPushSubscriptionIfGranted()
+
+    expect(status).toBe('permission-required')
+    expect(Notification.requestPermission).not.toHaveBeenCalled()
+    expect(mockRegister).not.toHaveBeenCalled()
+  })
+
+  it('허용된 기존 구독을 현재 로그인 계정에 다시 저장한다', async () => {
+    Object.defineProperty(window, 'Notification', {
+      value: { permission: 'granted', requestPermission: jest.fn() },
+      configurable: true,
+    })
+    mockGetSubscription.mockResolvedValue({ toJSON: () => mockSubscriptionJSON })
+
+    const status = await syncPushSubscriptionIfGranted()
+
+    expect(status).toBe('connected')
+    expect(mockSubscribe).not.toHaveBeenCalled()
+    expect(mockPostJsonWithAuth).toHaveBeenCalledWith(
+      '/api/push/subscribe',
+      expect.objectContaining({ endpoint: mockSubscriptionJSON.endpoint })
+    )
+  })
+
+  it('권한은 허용됐지만 구독이 없으면 새 구독을 만든다', async () => {
+    Object.defineProperty(window, 'Notification', {
+      value: { permission: 'granted', requestPermission: jest.fn() },
+      configurable: true,
+    })
+    mockGetSubscription.mockResolvedValue(null)
+    mockSubscribe.mockResolvedValue({ toJSON: () => mockSubscriptionJSON })
+
+    expect(await syncPushSubscriptionIfGranted()).toBe('connected')
+    expect(mockSubscribe).toHaveBeenCalledTimes(1)
+    expect(mockPostJsonWithAuth).toHaveBeenCalledTimes(1)
+  })
+
+  it('동시에 시작된 동기화는 하나의 구독 요청을 공유한다', async () => {
+    Object.defineProperty(window, 'Notification', {
+      value: { permission: 'granted', requestPermission: jest.fn() },
+      configurable: true,
+    })
+    let resolveSubscription!: (subscription: { toJSON: () => typeof mockSubscriptionJSON }) => void
+    mockGetSubscription.mockReturnValue(new Promise((resolve) => {
+      resolveSubscription = resolve
+    }))
+
+    const first = syncPushSubscriptionIfGranted()
+    const second = syncPushSubscriptionIfGranted()
+    resolveSubscription({ toJSON: () => mockSubscriptionJSON })
+
+    await expect(Promise.all([first, second])).resolves.toEqual(['connected', 'connected'])
+    expect(mockRegister).toHaveBeenCalledTimes(1)
+    expect(mockGetSubscription).toHaveBeenCalledTimes(1)
+    expect(mockPostJsonWithAuth).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('repairPushSubscription', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'Notification', {
+      value: { permission: 'granted', requestPermission: jest.fn() },
+      configurable: true,
+    })
+  })
+
+  it('기존 구독을 해제한 뒤 새 endpoint를 저장한다', async () => {
+    const existing = {
+      endpoint: mockSubscriptionJSON.endpoint,
+      toJSON: () => mockSubscriptionJSON,
+      unsubscribe: mockUnsubscribe,
+    }
+    const replacementJSON = {
+      endpoint: 'https://push.example.com/replacement',
+      keys: { p256dh: 'new-p256dh', auth: 'new-auth' },
+    }
+    mockGetSubscription.mockResolvedValue(existing)
+    mockSubscribe.mockResolvedValue({ toJSON: () => replacementJSON })
+
+    expect(await repairPushSubscription()).toBe('connected')
+    expect(mockUnsubscribe).toHaveBeenCalledTimes(1)
+    expect(mockSubscribe).toHaveBeenCalledTimes(1)
+    expect(mockPostJsonWithAuth).toHaveBeenCalledWith(
+      '/api/push/subscribe',
+      expect.objectContaining({
+        endpoint: replacementJSON.endpoint,
+        previousEndpoint: mockSubscriptionJSON.endpoint,
+      })
+    )
+  })
+
+  it('기존 구독 해제 실패 시 새 구독을 만들지 않는다', async () => {
+    mockUnsubscribe.mockResolvedValue(false)
+    mockGetSubscription.mockResolvedValue({
+      endpoint: mockSubscriptionJSON.endpoint,
+      toJSON: () => mockSubscriptionJSON,
+      unsubscribe: mockUnsubscribe,
+    })
+
+    await expect(repairPushSubscription()).rejects.toThrow(
+      'Failed to unsubscribe stale push subscription'
+    )
+    expect(mockSubscribe).not.toHaveBeenCalled()
+    expect(mockPostJsonWithAuth).not.toHaveBeenCalled()
   })
 })

--- a/src/__tests__/lib/push.test.ts
+++ b/src/__tests__/lib/push.test.ts
@@ -241,4 +241,69 @@ describe('repairPushSubscription', () => {
     expect(mockSubscribe).not.toHaveBeenCalled()
     expect(mockPostJsonWithAuth).not.toHaveBeenCalled()
   })
+
+  it('새 구독 생성이 일시적으로 실패하면 한 번 다시 생성한다', async () => {
+    const existing = {
+      endpoint: mockSubscriptionJSON.endpoint,
+      toJSON: () => mockSubscriptionJSON,
+      unsubscribe: mockUnsubscribe,
+    }
+    const replacementJSON = {
+      endpoint: 'https://push.example.com/replacement',
+      keys: { p256dh: 'new-p256dh', auth: 'new-auth' },
+    }
+    mockGetSubscription
+      .mockResolvedValueOnce(existing)
+      .mockResolvedValueOnce(existing)
+    mockSubscribe
+      .mockRejectedValueOnce(new Error('temporary subscribe failure'))
+      .mockResolvedValueOnce({ toJSON: () => replacementJSON })
+
+    await expect(repairPushSubscription()).resolves.toBe('connected')
+    expect(mockSubscribe).toHaveBeenCalledTimes(2)
+    expect(mockPostJsonWithAuth).toHaveBeenCalledTimes(1)
+  })
+
+  it('새 구독 저장이 일시적으로 실패하면 생성된 구독의 저장만 재시도한다', async () => {
+    const existing = {
+      endpoint: mockSubscriptionJSON.endpoint,
+      toJSON: () => mockSubscriptionJSON,
+      unsubscribe: mockUnsubscribe,
+    }
+    const replacementJSON = {
+      endpoint: 'https://push.example.com/replacement',
+      keys: { p256dh: 'new-p256dh', auth: 'new-auth' },
+    }
+    const replacement = {
+      endpoint: replacementJSON.endpoint,
+      toJSON: () => replacementJSON,
+    }
+    mockGetSubscription
+      .mockResolvedValueOnce(existing)
+      .mockResolvedValueOnce(replacement)
+    mockSubscribe.mockResolvedValueOnce(replacement)
+    mockPostJsonWithAuth
+      .mockRejectedValueOnce(new Error('temporary persistence failure'))
+      .mockResolvedValueOnce(undefined)
+
+    await expect(repairPushSubscription()).resolves.toBe('connected')
+    expect(mockSubscribe).toHaveBeenCalledTimes(1)
+    expect(mockPostJsonWithAuth).toHaveBeenCalledTimes(2)
+  })
+
+  it('복구 재시도도 실패하면 오류를 반환하고 추가 반복은 하지 않는다', async () => {
+    const existing = {
+      endpoint: mockSubscriptionJSON.endpoint,
+      toJSON: () => mockSubscriptionJSON,
+      unsubscribe: mockUnsubscribe,
+    }
+    mockGetSubscription
+      .mockResolvedValueOnce(existing)
+      .mockResolvedValueOnce(null)
+    mockSubscribe.mockRejectedValue(new Error('subscribe unavailable'))
+
+    await expect(repairPushSubscription()).rejects.toThrow('subscribe unavailable')
+    expect(mockSubscribe).toHaveBeenCalledTimes(2)
+    expect(mockPostJsonWithAuth).not.toHaveBeenCalled()
+  })
 })

--- a/src/__tests__/service-worker.test.ts
+++ b/src/__tests__/service-worker.test.ts
@@ -1,0 +1,81 @@
+/**
+ * @jest-environment node
+ */
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+type WorkerEvent = {
+  data?: { json: () => Record<string, unknown> }
+  waitUntil: (promise: Promise<unknown>) => void
+}
+
+describe('push service worker', () => {
+  const listeners: Record<string, (event: WorkerEvent) => void> = {}
+  const showNotification = jest.fn().mockResolvedValue(undefined)
+  const skipWaiting = jest.fn().mockResolvedValue(undefined)
+  const claim = jest.fn().mockResolvedValue(undefined)
+
+  beforeAll(() => {
+    const source = readFileSync(join(process.cwd(), 'public/sw.js'), 'utf8')
+    const workerSelf = {
+      addEventListener: (type: string, listener: (event: WorkerEvent) => void) => {
+        listeners[type] = listener
+      },
+      skipWaiting,
+      registration: { showNotification },
+      location: { origin: 'https://koko.example.com' },
+    }
+    const workerClients = {
+      claim,
+      matchAll: jest.fn().mockResolvedValue([]),
+      openWindow: jest.fn().mockResolvedValue(undefined),
+    }
+
+    new Function('self', 'clients', source)(workerSelf, workerClients)
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('새 서비스 워커를 즉시 활성화한다', async () => {
+    let installWork: Promise<unknown> = Promise.resolve()
+    listeners.install({ waitUntil: (promise) => { installWork = promise } })
+    await installWork
+
+    let activateWork: Promise<unknown> = Promise.resolve()
+    listeners.activate({ waitUntil: (promise) => { activateWork = promise } })
+    await activateWork
+
+    expect(skipWaiting).toHaveBeenCalledTimes(1)
+    expect(claim).toHaveBeenCalledTimes(1)
+  })
+
+  it('tag가 없는 일정 알림은 기존 알림을 덮어쓰지 않는다', async () => {
+    let pushWork: Promise<unknown> = Promise.resolve()
+    listeners.push({
+      data: { json: () => ({ title: '새 일정', body: '일정 내용', url: '/' }) },
+      waitUntil: (promise) => { pushWork = promise },
+    })
+    await pushWork
+
+    expect(showNotification).toHaveBeenCalledWith(
+      '새 일정',
+      expect.not.objectContaining({ tag: expect.anything() })
+    )
+  })
+
+  it('명시한 tag는 일일 요약처럼 교체가 필요한 알림에 유지한다', async () => {
+    let pushWork: Promise<unknown> = Promise.resolve()
+    listeners.push({
+      data: { json: () => ({ title: '오늘의 일정', tag: 'koko-daily-digest' }) },
+      waitUntil: (promise) => { pushWork = promise },
+    })
+    await pushWork
+
+    expect(showNotification).toHaveBeenCalledWith(
+      '오늘의 일정',
+      expect.objectContaining({ tag: 'koko-daily-digest' })
+    )
+  })
+})

--- a/src/app/api/push/subscribe/route.ts
+++ b/src/app/api/push/subscribe/route.ts
@@ -8,7 +8,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  const { endpoint, p256dh, auth } = await req.json()
+  const { endpoint, p256dh, auth, previousEndpoint } = await req.json()
 
   if (!endpoint || !p256dh || !auth) {
     return NextResponse.json({ error: 'Missing required fields' }, { status: 400 })
@@ -23,5 +23,19 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Failed to save subscription' }, { status: 500 })
   }
 
-  return NextResponse.json({ ok: true })
+  let cleanupPending = false
+  if (typeof previousEndpoint === 'string' && previousEndpoint && previousEndpoint !== endpoint) {
+    const { error: cleanupError } = await supabaseAdmin
+      .from('push_subscriptions')
+      .delete()
+      .eq('user_id', userId)
+      .eq('endpoint', previousEndpoint)
+
+    if (cleanupError) {
+      cleanupPending = true
+      console.error('[push/subscribe] previous endpoint cleanup failed:', cleanupError)
+    }
+  }
+
+  return NextResponse.json({ ok: true, cleanupPending })
 }

--- a/src/components/TabsShell.tsx
+++ b/src/components/TabsShell.tsx
@@ -13,6 +13,7 @@ import { type Tab, TABS } from '@/types/tabs'
 import { AppSplash } from '@/components/AppSplash'
 import { scheduleIdleWork } from '@/lib/idle-work'
 import { loadReminderTab, loadSettingsTab } from '@/components/tab-loaders'
+import { syncPushSubscriptionIfGranted } from '@/lib/push'
 
 const IDLE_PRELOAD_TABS: Tab[] = ['reminders', 'settings']
 
@@ -102,6 +103,13 @@ export function TabsShell() {
       console.warn('[TabsShell] reminder tab chunk preload failed:', error)
     })
 
+    // Existing notification permission needs no prompt; refresh and rebind after first paint.
+    const cancelPushSync = scheduleIdleWork(() => {
+      void syncPushSubscriptionIfGranted().catch((error) => {
+        console.warn('[TabsShell] push subscription sync failed:', error)
+      })
+    }, 'normal')
+
     // Let the calendar paint first, then hidden-mount one secondary tab per idle slot.
     const cancelPreloads = IDLE_PRELOAD_TABS.map((tab) => scheduleIdleWork(() => {
       setMountedTabs((prev) => {
@@ -112,7 +120,10 @@ export function TabsShell() {
       })
     }, 'low'))
 
-    return () => cancelPreloads.forEach((cancel) => cancel())
+    return () => {
+      cancelPushSync()
+      cancelPreloads.forEach((cancel) => cancel())
+    }
   }, [isInitializing, needsFamilyOnboarding, startupError, user])
 
   const handleStartupRetry = async () => {

--- a/src/components/tabs/SettingsTab.tsx
+++ b/src/components/tabs/SettingsTab.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation'
 import {
   LogOut, Share2, Check, Users, Pencil, X,
   Bell, BellOff, ChevronLeft, ChevronRight, UserPlus,
-  UserRound, CalendarDays, Smartphone,
+  UserRound, CalendarDays, Smartphone, RefreshCw,
   type LucideIcon,
 } from 'lucide-react'
 import { supabase } from '@/lib/supabase'
@@ -17,7 +17,12 @@ import {
   updateFamilyName,
   type FamilyMember,
 } from '@/lib/family'
-import { registerPushSubscription } from '@/lib/push'
+import {
+  registerPushSubscription,
+  repairPushSubscription,
+  syncPushSubscriptionIfGranted,
+  type PushConnectionStatus,
+} from '@/lib/push'
 import { ApiClientError, postJsonWithAuth } from '@/lib/api-client'
 import { APP_THEMES, DEFAULT_THEME } from '@/lib/preferences'
 import type { UserPreferences } from '@/lib/preferences'
@@ -25,6 +30,7 @@ import type { AuthState, Tab } from '@/types/tabs'
 
 type SettingsView = 'main' | 'account' | 'family' | 'calendar' | 'app'
 type FamilyMembersStatus = 'idle' | 'loading' | 'ready' | 'error'
+type NotificationConnectionState = PushConnectionStatus | 'checking' | 'error'
 
 interface FamilyMembersState {
   familyId: string | null
@@ -120,6 +126,30 @@ export function SettingsTab({ onNavigateToTab, preferences, updatePreferences, u
     () => (typeof window !== 'undefined' && 'Notification' in window ? Notification.permission : 'unsupported')
   )
   const [enablingNotif, setEnablingNotif] = useState(false)
+  const [repairingNotif, setRepairingNotif] = useState(false)
+  const [notifConnection, setNotifConnection] = useState<NotificationConnectionState>(
+    notifPermission === 'unsupported' ? 'unsupported' : 'checking'
+  )
+
+  useEffect(() => {
+    if (view !== 'app' || notifPermission !== 'granted') return
+
+    let cancelled = false
+    setNotifConnection('checking')
+    syncPushSubscriptionIfGranted()
+      .then((status) => {
+        if (!cancelled) setNotifConnection(status)
+      })
+      .catch((error) => {
+        if (cancelled) return
+        console.error('[SettingsTab] push subscription sync failed:', error)
+        setNotifConnection('error')
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [notifPermission, view])
 
   useEffect(() => {
     if (!familyId) return
@@ -165,10 +195,28 @@ export function SettingsTab({ onNavigateToTab, preferences, updatePreferences, u
     if (!user) return
     setEnablingNotif(true)
     try {
-      await registerPushSubscription()
+      const status = await registerPushSubscription()
       setNotifPermission(Notification.permission)
+      setNotifConnection(status)
+    } catch (error) {
+      console.error('[SettingsTab] registerPushSubscription failed:', error)
+      setNotifConnection('error')
     } finally {
       setEnablingNotif(false)
+    }
+  }
+
+  const handleRepairNotifications = async () => {
+    setRepairingNotif(true)
+    setNotifConnection('checking')
+    try {
+      const status = await repairPushSubscription()
+      setNotifConnection(status)
+    } catch (error) {
+      console.error('[SettingsTab] repairPushSubscription failed:', error)
+      setNotifConnection('error')
+    } finally {
+      setRepairingNotif(false)
     }
   }
 
@@ -704,9 +752,27 @@ export function SettingsTab({ onNavigateToTab, preferences, updatePreferences, u
           <div className="rounded-2xl bg-white dark:bg-stone-900 border border-stone-100 dark:border-stone-800 p-4 mb-4">
             <p className="text-xs font-semibold text-stone-400 dark:text-stone-500 uppercase tracking-wide mb-3">알림</p>
             {notifPermission === 'granted' && (
-              <div className="flex items-center gap-2 text-sm text-stone-600 dark:text-stone-400">
-                <Bell size={15} className="text-accent-400" />
-                알림이 허용되어 있습니다
+              <div className="space-y-3">
+                <div className="flex items-center gap-2 text-sm text-stone-600 dark:text-stone-400">
+                  {notifConnection === 'connected' ? (
+                    <Bell size={15} className="text-accent-400" />
+                  ) : (
+                    <BellOff size={15} />
+                  )}
+                  {notifConnection === 'checking' && '알림 연결을 확인하고 있습니다'}
+                  {notifConnection === 'connected' && '알림이 연결되어 있습니다'}
+                  {notifConnection === 'error' && '알림 연결을 확인하지 못했습니다'}
+                  {['permission-required', 'blocked', 'unsupported'].includes(notifConnection) &&
+                    '알림 연결이 필요합니다'}
+                </div>
+                <button
+                  onClick={() => void handleRepairNotifications()}
+                  disabled={repairingNotif || notifConnection === 'checking'}
+                  className="flex min-h-[44px] items-center gap-2 rounded-xl border border-stone-200 px-4 py-2.5 text-sm font-semibold text-stone-700 transition-colors hover:bg-stone-50 disabled:opacity-50 dark:border-stone-700 dark:text-stone-200 dark:hover:bg-stone-800"
+                >
+                  <RefreshCw size={15} className={repairingNotif ? 'animate-spin' : undefined} />
+                  {repairingNotif ? '다시 연결 중...' : '알림 다시 연결'}
+                </button>
               </div>
             )}
             {notifPermission === 'denied' && (

--- a/src/lib/push.ts
+++ b/src/lib/push.ts
@@ -75,6 +75,23 @@ async function ensurePushSubscription(): Promise<PushConnectionStatus> {
   return 'connected'
 }
 
+async function createAndPersistReplacement(
+  registration: ServiceWorkerRegistration,
+  previousEndpoint?: string
+): Promise<void> {
+  try {
+    const subscription = await createPushSubscription(registration)
+    await persistPushSubscription(subscription, previousEndpoint)
+  } catch {
+    // subscribe() may have succeeded before persistence failed; reuse it when possible.
+    const current = await registration.pushManager.getSubscription()
+    const retrySubscription = current && current.endpoint !== previousEndpoint
+      ? current
+      : await createPushSubscription(registration)
+    await persistPushSubscription(retrySubscription, previousEndpoint)
+  }
+}
+
 function ensurePushSubscriptionShared(): Promise<PushConnectionStatus> {
   if (syncInFlight) return syncInFlight
 
@@ -135,7 +152,6 @@ export async function repairPushSubscription(): Promise<PushConnectionStatus> {
     }
   }
 
-  const subscription = await createPushSubscription(registration)
-  await persistPushSubscription(subscription, previousEndpoint)
+  await createAndPersistReplacement(registration, previousEndpoint)
   return 'connected'
 }

--- a/src/lib/push.ts
+++ b/src/lib/push.ts
@@ -1,5 +1,13 @@
 import { postJsonWithAuth } from '@/lib/api-client'
 
+export type PushConnectionStatus =
+  | 'unsupported'
+  | 'permission-required'
+  | 'blocked'
+  | 'connected'
+
+let syncInFlight: Promise<PushConnectionStatus> | null = null
+
 function urlBase64ToUint8Array(base64String: string): ArrayBuffer {
   const padding = '='.repeat((4 - (base64String.length % 4)) % 4)
   const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/')
@@ -12,38 +20,122 @@ function urlBase64ToUint8Array(base64String: string): ArrayBuffer {
   return buffer
 }
 
-export async function registerPushSubscription(): Promise<void> {
-  if (typeof window === 'undefined') return
-  if (!('serviceWorker' in navigator) || !('PushManager' in window) || !('Notification' in window)) return
+function getUnsupportedStatus(): PushConnectionStatus | null {
+  if (typeof window === 'undefined') return 'unsupported'
+  if (!('serviceWorker' in navigator) || !('PushManager' in window) || !('Notification' in window)) {
+    return 'unsupported'
+  }
+  return null
+}
 
-  const registration = await navigator.serviceWorker.register('/sw.js')
-  await navigator.serviceWorker.ready
+async function getReadyRegistration(): Promise<ServiceWorkerRegistration> {
+  await navigator.serviceWorker.register('/sw.js')
+  return await navigator.serviceWorker.ready
+}
 
-  const permission =
-    Notification.permission === 'default'
-      ? await Notification.requestPermission()
-      : Notification.permission
+async function createPushSubscription(
+  registration: ServiceWorkerRegistration
+): Promise<PushSubscription> {
+  return await registration.pushManager.subscribe({
+    userVisibleOnly: true,
+    applicationServerKey: urlBase64ToUint8Array(
+      process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY!
+    ),
+  })
+}
 
-  if (permission !== 'granted') return
-
-  const existing = await registration.pushManager.getSubscription()
-  const subscription =
-    existing ??
-    (await registration.pushManager.subscribe({
-      userVisibleOnly: true,
-      applicationServerKey: urlBase64ToUint8Array(
-        process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY!
-      ),
-    }))
-
+async function persistPushSubscription(
+  subscription: PushSubscription,
+  previousEndpoint?: string
+): Promise<void> {
   const json = subscription.toJSON() as {
-    endpoint: string
-    keys: { p256dh: string; auth: string }
+    endpoint?: string
+    keys?: { p256dh?: string; auth?: string }
+  }
+
+  if (!json.endpoint || !json.keys?.p256dh || !json.keys.auth) {
+    throw new Error('Push subscription is missing required fields')
   }
 
   await postJsonWithAuth('/api/push/subscribe', {
     endpoint: json.endpoint,
     p256dh: json.keys.p256dh,
     auth: json.keys.auth,
+    ...(previousEndpoint && previousEndpoint !== json.endpoint ? { previousEndpoint } : {}),
   })
+}
+
+async function ensurePushSubscription(): Promise<PushConnectionStatus> {
+  const registration = await getReadyRegistration()
+  const existing = await registration.pushManager.getSubscription()
+  const subscription = existing ?? await createPushSubscription(registration)
+
+  // Upserting the browser endpoint also rebinds it after a Koko account switch.
+  await persistPushSubscription(subscription)
+  return 'connected'
+}
+
+function ensurePushSubscriptionShared(): Promise<PushConnectionStatus> {
+  if (syncInFlight) return syncInFlight
+
+  syncInFlight = ensurePushSubscription().finally(() => {
+    syncInFlight = null
+  })
+  return syncInFlight
+}
+
+export async function syncPushSubscriptionIfGranted(): Promise<PushConnectionStatus> {
+  const unsupported = getUnsupportedStatus()
+  if (unsupported) return unsupported
+
+  if (Notification.permission === 'default') return 'permission-required'
+  if (Notification.permission === 'denied') return 'blocked'
+
+  return await ensurePushSubscriptionShared()
+}
+
+export async function registerPushSubscription(): Promise<PushConnectionStatus> {
+  const unsupported = getUnsupportedStatus()
+  if (unsupported) return unsupported
+
+  const permission =
+    Notification.permission === 'default'
+      ? await Notification.requestPermission()
+      : Notification.permission
+
+  if (permission === 'denied') return 'blocked'
+  if (permission !== 'granted') return 'permission-required'
+
+  return await ensurePushSubscriptionShared()
+}
+
+export async function repairPushSubscription(): Promise<PushConnectionStatus> {
+  const unsupported = getUnsupportedStatus()
+  if (unsupported) return unsupported
+
+  if (Notification.permission === 'default') return 'permission-required'
+  if (Notification.permission === 'denied') return 'blocked'
+
+  if (syncInFlight) {
+    try {
+      await syncInFlight
+    } catch {
+      // A user-requested repair should still get its own clean attempt.
+    }
+  }
+
+  const registration = await getReadyRegistration()
+  const existing = await registration.pushManager.getSubscription()
+  const previousEndpoint = existing?.endpoint
+
+  if (existing) {
+    const unsubscribed = await existing.unsubscribe()
+    if (!unsubscribed) {
+      throw new Error('Failed to unsubscribe stale push subscription')
+    }
+  }
+
+  const subscription = await createPushSubscription(registration)
+  await persistPushSubscription(subscription, previousEndpoint)
+  return 'connected'
 }


### PR DESCRIPTION
## Summary

- 알림 권한이 이미 허용된 기기는 첫 화면 이후 idle 시점에 서비스 워커와 푸시 구독을 조용히 동기화합니다.
- 기존 endpoint를 현재 로그인 계정으로 다시 연결하고, 구독이 없으면 새로 생성합니다.
- 설정의 앱 화면에서 실제 알림 연결 상태를 표시하고 오래된 구독을 강제로 다시 연결할 수 있게 했습니다.
- 수동 복구는 기존 구독 해제 성공 후 새 구독을 만들며, 새 endpoint 저장 후 현재 사용자 소유의 이전 endpoint만 정리합니다.
- 새 구독 생성 또는 서버 저장이 일시적으로 실패하면 현재 구독 상태를 다시 확인하고 딱 한 번만 복구를 재시도합니다.
- 서비스 워커 업데이트를 즉시 활성화하고, 명시적 tag가 없는 일정/리마인더 알림이 서로 조용히 덮어쓰지 않도록 했습니다.
- 동시 동기화, 계정 재연결, 복구·재시도 실패, endpoint 정리 실패, 서비스 워커 표시 정책을 테스트로 고정했습니다.

## Testing

- `npm run test -- --runInBand` (75 suites, 760 tests passed)
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build` (컴파일 및 TypeScript 통과, 로컬에 `NEXT_PUBLIC_SUPABASE_URL`이 없어 page data 수집 단계에서 중단)
- [ ] Vercel Preview에서 설정 > 앱 > 알림 다시 연결 동작 확인
- [ ] iPhone PWA와 Android Chrome에서 가족 간 일정 추가 알림 양방향 확인
