### PR TITLE
perf: align functions with database region

### DIFF
--- a/src/__tests__/deployment-config.test.ts
+++ b/src/__tests__/deployment-config.test.ts
@@ -1,0 +1,14 @@
+import vercelConfig from '../../vercel.json'
+
+describe('Vercel deployment config', () => {
+  it('runs functions in Tokyo next to the Supabase project', () => {
+    expect(vercelConfig.regions).toEqual(['hnd1'])
+  })
+
+  it('keeps the daily digest cron schedule', () => {
+    expect(vercelConfig.crons).toContainEqual({
+      path: '/api/cron/daily-digest',
+      schedule: '0 23 * * *',
+    })
+  })
+})

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,6 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "regions": ["hnd1"],
   "crons": [
     { "path": "/api/cron/daily-digest", "schedule": "0 23 * * *" }
   ]


### PR DESCRIPTION
## Summary\n- Vercel Functions 실행 지역을 Supabase가 위치한 도쿄와 가까운 hnd1로 고정합니다.\n- 기존 일일 요약 알림 cron 설정을 그대로 유지합니다.\n- 지역 설정과 cron 보존을 검증하는 배포 설정 테스트를 추가합니다.\n- 운영 DB 데이터와 스키마는 변경하지 않습니다.\n\n## Testing\n- [x] npm run test -- --runInBand (76 suites, 762 tests)\n- [x] npx tsc --noEmit\n- [x] npm run lint\n- [x] git diff --check\n- [x] Vercel Preview 배포 성공\n- [x] Vercel 배포 메타데이터에서 Function 지역 hnd1 확인\n- 로컬 npm run build는 컴파일과 TypeScript 검사를 통과했지만, 로컬 환경에 NEXT_PUBLIC_SUPABASE_URL이 없어 페이지 데이터 수집 단계에서 중단됐습니다. 배포 환경 빌드는 Vercel Preview에서 통과했습니다.