### PR TITLE
perf: improve reminder item entry feedback

### DIFF
--- a/src/__tests__/reminders/AddItemInput.test.tsx
+++ b/src/__tests__/reminders/AddItemInput.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { AddItemInput } from '@/components/reminders/AddItemInput'
 
@@ -37,6 +37,36 @@ describe('AddItemInput', () => {
       expect(input).toHaveValue('')
       expect(input).toHaveFocus()
     })
+  })
+
+  it('저장 응답 전에도 입력값을 즉시 비우고 중복 제출을 막는다', async () => {
+    let resolveAdd: ((created: boolean) => void) | null = null
+    const addPromise = new Promise<boolean>((resolve) => {
+      resolveAdd = resolve
+    })
+    const onAdd = jest.fn().mockReturnValue(addPromise)
+    const user = userEvent.setup()
+    render(<AddItemInput onAdd={onAdd} />)
+
+    const input = screen.getByPlaceholderText('아이템 추가...')
+    await user.type(input, '우유')
+    await user.keyboard('{Enter}')
+
+    expect(onAdd).toHaveBeenCalledWith('우유')
+    expect(input).toHaveValue('')
+    expect(input).toHaveAttribute('aria-busy', 'true')
+    expect(input).toHaveAttribute('readonly')
+
+    await user.keyboard('{Enter}')
+    expect(onAdd).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      resolveAdd?.(true)
+      await addPromise
+    })
+
+    expect(input).not.toHaveAttribute('readonly')
+    expect(input).toHaveFocus()
   })
 
   it('onAdd 실패 시 입력값을 유지하고 다시 제출 가능하다', async () => {

--- a/src/__tests__/reminders/ReminderDetailView.test.tsx
+++ b/src/__tests__/reminders/ReminderDetailView.test.tsx
@@ -812,6 +812,120 @@ describe('ReminderDetailView', () => {
     )
   })
 
+  it('floating 추가는 저장 응답 전에 낙관적 항목을 표시하고 입력값을 비운다', async () => {
+    let resolveAdd: ((item: Awaited<ReturnType<typeof addReminderItem>>) => void) | null = null
+    const addPromise = new Promise<Awaited<ReturnType<typeof addReminderItem>>>((resolve) => {
+      resolveAdd = resolve
+    })
+    mockAddReminderItem.mockReturnValueOnce(addPromise)
+    const user = userEvent.setup()
+
+    render(
+      <ReminderDetailView
+        listId="list-1"
+        user={mockUser}
+        onClose={onClose}
+        onPreviewItemsChange={onPreviewItemsChange}
+      />
+    )
+
+    await user.click(await screen.findByTestId('floating-add-item-button'))
+    const input = within(await screen.findByTestId('bottom-add-item-input'))
+      .getByPlaceholderText('아이템 추가...')
+    await user.type(input, '버터')
+    await user.keyboard('{Enter}')
+
+    expect(screen.getByText('버터')).toBeInTheDocument()
+    expect(input).toHaveValue('')
+    expect(input).toHaveAttribute('readonly')
+    expect(mockBroadcast).not.toHaveBeenCalled()
+
+    await user.click(screen.getByTestId('reminder-detail-scroll'))
+    expect(screen.getByTestId('bottom-add-item-input')).toBeInTheDocument()
+
+    await act(async () => {
+      resolveAdd?.({
+        id: 'item-new',
+        list_id: 'list-1',
+        created_by: 'user-1',
+        name: '버터',
+        is_checked: false,
+        checked_by: null,
+        checked_at: null,
+        sort_order: 0,
+        created_at: '2026-01-01T00:00:01Z',
+      })
+      await addPromise
+    })
+
+    expect(screen.getByText('버터')).toBeInTheDocument()
+    expect(input).not.toHaveAttribute('readonly')
+    expect(mockBroadcast).toHaveBeenCalled()
+  })
+
+  it('추가 실패 롤백은 저장 중 수신한 다른 항목을 보존하고 입력 원문을 복원한다', async () => {
+    const existingItem = {
+      id: 'item-1',
+      list_id: 'list-1',
+      created_by: 'user-1',
+      name: '우유',
+      is_checked: false,
+      checked_by: null,
+      checked_at: null,
+      sort_order: 0,
+      created_at: '2026-01-01T00:00:00Z',
+    }
+    const remoteItem = {
+      ...existingItem,
+      id: 'item-remote',
+      name: '가족이 추가한 항목',
+      sort_order: 1,
+      created_at: '2026-01-01T00:00:01Z',
+    }
+    let rejectAdd: ((error: Error) => void) | null = null
+    const addPromise = new Promise<Awaited<ReturnType<typeof addReminderItem>>>((_, reject) => {
+      rejectAdd = reject
+    })
+    mockGetReminderItems.mockResolvedValueOnce([existingItem] as never)
+    mockAddReminderItem.mockReturnValueOnce(addPromise)
+    const user = userEvent.setup()
+
+    render(
+      <ReminderDetailView
+        listId="list-1"
+        user={mockUser}
+        onClose={onClose}
+        onPreviewItemsChange={onPreviewItemsChange}
+      />
+    )
+
+    await user.click(await screen.findByTestId('floating-add-item-button'))
+    const input = within(await screen.findByTestId('bottom-add-item-input'))
+      .getByPlaceholderText('아이템 추가...')
+    await user.type(input, '버터')
+    await user.keyboard('{Enter}')
+    expect(screen.getByText('버터')).toBeInTheDocument()
+
+    mockGetReminderItems.mockResolvedValueOnce([existingItem, remoteItem] as never)
+    const refreshItems = mockUseRealtimeSync.mock.calls.find(
+      ([channelName]) => channelName === 'list_items_list-1'
+    )?.[1] as (() => void) | undefined
+    act(() => refreshItems?.())
+    expect(await screen.findByText('가족이 추가한 항목')).toBeInTheDocument()
+
+    await act(async () => {
+      rejectAdd?.(new Error('save failed'))
+      await addPromise.catch(() => {})
+    })
+
+    expect(screen.queryByText('버터')).not.toBeInTheDocument()
+    expect(screen.getByText('우유')).toBeInTheDocument()
+    expect(screen.getByText('가족이 추가한 항목')).toBeInTheDocument()
+    expect(input).toHaveValue('버터')
+    expect(input).not.toHaveAttribute('readonly')
+    expect(screen.getByText('아이템을 저장하지 못했어요')).toBeInTheDocument()
+  })
+
   it('floating 추가 입력창 바깥 빈 공간을 누르면 연속 추가를 종료한다', async () => {
     const user = userEvent.setup()
     mockGetReminderItems.mockResolvedValueOnce([

--- a/src/components/reminders/AddItemInput.tsx
+++ b/src/components/reminders/AddItemInput.tsx
@@ -31,15 +31,19 @@ export const AddItemInput = forwardRef<HTMLInputElement, Props>(function AddItem
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     if (!value.trim() || loading) return
+    const submittedValue = value.trim()
+
+    ignoreNextEmptyBlurRef.current = true
+    setValue('')
     setLoading(true)
     try {
-      const created = await onAdd(value.trim())
+      const created = await onAdd(submittedValue)
       if (created) {
-        ignoreNextEmptyBlurRef.current = true
-        setValue('')
         requestAnimationFrame(() => {
           inputRef.current?.focus()
         })
+      } else {
+        setValue((currentValue) => currentValue || submittedValue)
       }
     } finally {
       setLoading(false)
@@ -60,6 +64,8 @@ export const AddItemInput = forwardRef<HTMLInputElement, Props>(function AddItem
         type="text"
         value={value}
         onChange={(e) => setValue(e.target.value)}
+        aria-busy={loading}
+        readOnly={loading}
         onBlur={() => {
           if (ignoreNextEmptyBlurRef.current) {
             ignoreNextEmptyBlurRef.current = false

--- a/src/components/reminders/ReminderDetailView.tsx
+++ b/src/components/reminders/ReminderDetailView.tsx
@@ -101,6 +101,7 @@ export function ReminderDetailView({
 
   const closeAddSessionIfDraftEmpty = useCallback(() => {
     const input = addInputRef.current
+    if (input?.readOnly) return
     if (input?.value.trim()) return
     setAddSession(null)
   }, [])
@@ -253,30 +254,41 @@ export function ReminderDetailView({
       is_checked: false,
       checked_by: null,
       checked_at: null,
-      sort_order: items.length,
+      sort_order: 0,
       created_at: new Date().toISOString(),
     }
-    const previousItems = items
-    const optimisticItems = withInsertedReminderItem(items, optimisticItem, afterItemId)
-    setItemsWithPreview(optimisticItems)
+    setItemsWithPreview((currentItems) => (
+      withInsertedReminderItem(currentItems, optimisticItem, afterItemId)
+    ))
 
     try {
       const realItem = await addReminderItem(listId, user.id, name, afterItemId ?? null)
-      const nextItems = optimisticItems.map((item) =>
-        item.id === optimisticItem.id
-          ? { ...realItem, sort_order: item.sort_order }
-          : item
-      )
-      setItemsWithPreview(nextItems)
+      setItemsWithPreview((currentItems) => {
+        const itemsWithoutExistingReal = currentItems.filter((item) => item.id !== realItem.id)
+        const optimisticIndex = itemsWithoutExistingReal.findIndex(
+          (item) => item.id === optimisticItem.id
+        )
+        if (optimisticIndex < 0) {
+          return withInsertedReminderItem(itemsWithoutExistingReal, realItem, afterItemId)
+        }
+
+        return itemsWithoutExistingReal.map((item) =>
+          item.id === optimisticItem.id
+            ? { ...realItem, sort_order: item.sort_order }
+            : item
+        )
+      })
       broadcast()
-      return nextItems.find((item) => item.id === realItem.id) ?? realItem
+      return realItem
     } catch (e) {
       console.error('[ReminderDetailView] addReminderItem failed:', e)
-      setItemsWithPreview(previousItems)
+      setItemsWithPreview((currentItems) => (
+        currentItems.filter((item) => item.id !== optimisticItem.id)
+      ))
       setMutationError('아이템을 저장하지 못했어요')
       return null
     }
-  }, [broadcast, items, listId, setItemsWithPreview, user.id])
+  }, [broadcast, listId, setItemsWithPreview, user.id])
 
   const handleBottomAdd = useCallback(
     async (name: string): Promise<boolean> => {


### PR DESCRIPTION
## Summary
- 리마인더 아이템 제출 즉시 입력값을 비우고 낙관적 항목이 바로 보이도록 합니다.
- 저장 중에는 입력창 포커스와 키보드를 유지하되 읽기 전용으로 두어 중복 제출과 인라인 순서 충돌을 막습니다.
- 저장 실패 시 낙관적 항목만 제거하고 입력 원문을 복원합니다.
- 저장 도중 실시간 갱신으로 받은 다른 항목을 성공 확정 또는 실패 롤백이 덮어쓰지 않도록 임시 ID 기준 함수형 갱신을 적용합니다.
- 저장 중 바깥 탭으로 빈 입력 세션이 닫혀 실패 원문을 잃지 않도록 방어합니다.
- 운영 DB 데이터, 스키마, RPC는 변경하지 않습니다.

## Testing
- [x] `npm run test -- --runInBand` (75 suites, 763 tests)
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `git diff --check`
- [x] 저장 응답 전 입력 초기화, 낙관적 항목 표시, 중복 제출 차단 테스트
- [x] 저장 성공 후 확정 항목 교체와 포커스 복원 테스트
- [x] 저장 실패 시 입력 원문 복원과 낙관적 항목 롤백 테스트
- [x] 저장 도중 실시간 수신 항목 보존 및 바깥 탭 방어 테스트
- [ ] Vercel Preview에서 인증 후 리마인더 아이템 추가 수동 확인 (운영 DB 임의 변경 방침에 따라 PR 작성 단계에서는 미수행)